### PR TITLE
Frontend/Extend main button feature

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,9 @@
       "name": "otsukailist-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "tailwind-merge": "^3.4.0",
         "vue": "^3.5.21",
-        "vue-router": "^4.5.1"
+        "vue-router": "^4.6.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -3652,6 +3653,16 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
@@ -3930,9 +3941,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
-      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
@@ -3941,7 +3952,7 @@
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "vue": "^3.2.0"
+        "vue": "^3.5.0"
       }
     },
     "node_modules/vue-tsc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,9 @@
     "format": "prettier -w src/*.{ts,vue} && prettier -w src/**/*.{ts,vue}"
   },
   "dependencies": {
+    "tailwind-merge": "^3.4.0",
     "vue": "^3.5.21",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.6.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend/src/components/MainButton.vue
+++ b/frontend/src/components/MainButton.vue
@@ -1,20 +1,40 @@
 <template>
   <button
     type="button"
+    :class="buttonClass"
     :disabled="disabled"
-    class="bg-wood-500 text-wood-50 px-6 py-3 rounded-lg hover:bg-wood-600 active:bg-wood-700 transition-all duration-200 transform hover:scale-105 shadow-md hover:shadow-lg border border-wood-600 font-medium disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
   >
     <slot />
   </button>
 </template>
 
 <script>
+import { twMerge } from 'tailwind-merge';
+
 export default {
   name: 'MainButton',
   props: {
+    variant: {
+      type: String,
+      default: 'primary',
+      validator: (value) => ['primary', 'secondary', 'cancel'].includes(value)
+    },
     disabled: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    buttonClass() {
+      const baseClass = 'px-6 py-3 rounded-lg font-medium transition-[background-color,transform,box-shadow] duration-200 transform hover:scale-105 shadow-md hover:shadow-lg border disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none';
+      
+      const variantClasses = {
+        primary: 'bg-wood-500 text-wood-50 border-wood-600 hover:bg-wood-600 active:bg-wood-700',
+        secondary: 'bg-transparent text-wood-700 border-wood-300 hover:bg-wood-50 active:bg-wood-100',
+        cancel: 'bg-transparent text-charcoal-500 border-charcoal-300 hover:bg-charcoal-50 active:bg-charcoal-100'
+      };
+      
+      return twMerge(baseClass, variantClasses[this.variant]);
     }
   }
 };

--- a/frontend/src/components/MainButton.vue
+++ b/frontend/src/components/MainButton.vue
@@ -1,9 +1,5 @@
 <template>
-  <button
-    type="button"
-    :class="buttonClass"
-    :disabled="disabled"
-  >
+  <button type="button" :class="buttonClass" :disabled="disabled">
     <slot />
   </button>
 </template>
@@ -26,14 +22,29 @@ export default {
   },
   computed: {
     buttonClass() {
-      const baseClass = 'px-6 py-3 rounded-lg font-medium transition-[background-color,transform,box-shadow] duration-200 transform hover:scale-105 shadow-md hover:shadow-lg border disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none';
-      
+      const baseClass = [
+        // Layout & spacing
+        'px-6 py-3 rounded-lg',
+        // Typography
+        'font-medium',
+        // Transitions
+        'transition-[background-color,transform,box-shadow] duration-200',
+        // Transform & hover effects
+        'transform hover:scale-105',
+        // Shadows
+        'shadow-md hover:shadow-lg',
+        // Border
+        'border',
+        // Disabled states
+        'disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none'
+      ].join(' ');
+
       const variantClasses = {
         primary: 'bg-wood-500 text-wood-50 border-wood-600 hover:bg-wood-600 active:bg-wood-700',
         secondary: 'bg-transparent text-wood-700 border-wood-300 hover:bg-wood-50 active:bg-wood-100',
         cancel: 'bg-transparent text-charcoal-500 border-charcoal-300 hover:bg-charcoal-50 active:bg-charcoal-100'
       };
-      
+
       return twMerge(baseClass, variantClasses[this.variant]);
     }
   }


### PR DESCRIPTION
This pull request updates dependencies and improves the `MainButton` component in the frontend project. The most significant changes include adding the `tailwind-merge` package, updating `vue-router` to the latest version, and refactoring the `MainButton` component to support multiple button variants and cleaner class management.

**Dependency updates:**
- Upgraded `vue-router` from version 4.5.1 to 4.6.4, ensuring compatibility with newer versions of Vue and bringing in bug fixes and improvements. (`frontend/package.json`, `frontend/package-lock.json`) [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR11-R13) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3933-R3946) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3944-R3955) [[4]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R15-R17)
- Added the `tailwind-merge` package (version 3.4.0) to help manage and merge Tailwind CSS classes more effectively. (`frontend/package.json`, `frontend/package-lock.json`) [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR11-R13) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR3656-R3665) [[3]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R15-R17)

**Component improvements:**
- Refactored the `MainButton` component to use `tailwind-merge` for merging Tailwind classes, and introduced a `variant` prop that allows the button to have `primary`, `secondary`, or `cancel` styles, improving reusability and maintainability. (`frontend/src/components/MainButton.vue`)