### PR TITLE
Fontend/ Add link share page

### DIFF
--- a/frontend/src/components/BadgeTag.vue
+++ b/frontend/src/components/BadgeTag.vue
@@ -18,7 +18,7 @@
 import { twMerge } from 'tailwind-merge';
 
 export default {
-  name: 'Badge',
+  name: 'BadgeTag',
   emits: ['remove'],
   props: {
     text: {

--- a/frontend/src/components/ContentArea.vue
+++ b/frontend/src/components/ContentArea.vue
@@ -25,9 +25,9 @@ export default {
 
       switch (this.layout) {
         case 'center':
-          return `${baseClass} flex items-center justify-center`;
+          return `${baseClass} flex flex-col items-center justify-center`;
         case 'center-vertical':
-          return `${baseClass} flex items-center`;
+          return `${baseClass} flex flex-col items-center`;
         default:
           return baseClass;
       }

--- a/frontend/src/pages/CreateListPage.vue
+++ b/frontend/src/pages/CreateListPage.vue
@@ -3,7 +3,7 @@ import ContentArea from '../components/ContentArea.vue';
 import MainButton from '../components/MainButton.vue';
 import TextInputWithLabel from '../components/TextInputWithLabel.vue';
 import TextInput from '../components/TextInput.vue';
-import Badge from '../components/Badge.vue';
+import BadgeTag from '../components/BadgeTag.vue';
 
 export default {
   name: 'CreateListPage',
@@ -12,7 +12,7 @@ export default {
     MainButton,
     TextInputWithLabel,
     TextInput,
-    Badge
+    BadgeTag
   },
   data() {
     return {
@@ -32,8 +32,15 @@ export default {
         console.log('リストID:', listId);
 
         // アイテムリスト画面に遷移
+        // this.$router.push({
+        //   name: 'ItemList',
+        //   params: { id: listId },
+        //   query: { name: this.listName }
+        // });
+
+        // リスト共有画面に遷移
         this.$router.push({
-          name: 'ItemList',
+          name: 'ShareList',
           params: { id: listId },
           query: { name: this.listName }
         });
@@ -89,7 +96,7 @@ export default {
       <!-- メンバーバッジ表示 -->
       <div v-if="members.length > 0" class="mt-3">
         <div class="flex flex-wrap gap-2">
-          <Badge
+          <BadgeTag
             v-for="member in members"
             :key="member.id"
             :text="member.name"

--- a/frontend/src/pages/CreateListPage.vue
+++ b/frontend/src/pages/CreateListPage.vue
@@ -31,13 +31,6 @@ export default {
         console.log('リスト名:', this.listName);
         console.log('リストID:', listId);
 
-        // アイテムリスト画面に遷移
-        // this.$router.push({
-        //   name: 'ItemList',
-        //   params: { id: listId },
-        //   query: { name: this.listName }
-        // });
-
         // リスト共有画面に遷移
         this.$router.push({
           name: 'ShareList',

--- a/frontend/src/pages/ShareListPage.vue
+++ b/frontend/src/pages/ShareListPage.vue
@@ -82,9 +82,7 @@ export default {
   <ContentArea layout="center">
     <h1 class="text-2xl font-bold font-sans">共有リンク</h1>
     <div class="mt-6 flex gap-2 px-2 py-1 border border-charcoal-200 bg-charcoal-100 rounded-md w-full">
-      <span
-        class="flex-1 min-w-0 text-charcoal-800 whitespace-nowrap overflow-hidden text-clip overflow-x-scroll scrollbar-hidden"
-      >
+      <span class="flex-1 min-w-0 text-charcoal-800 whitespace-nowrap overflow-hidden overflow-x-auto scrollbar-hidden">
         {{ listURL }}
       </span>
       <MainButton @click="copyUrl" :disabled="!listURL" size="small"> コピー </MainButton>

--- a/frontend/src/pages/ShareListPage.vue
+++ b/frontend/src/pages/ShareListPage.vue
@@ -85,7 +85,7 @@ export default {
       <span class="flex-1 min-w-0 text-charcoal-800 whitespace-nowrap overflow-hidden overflow-x-auto scrollbar-hidden">
         {{ listURL }}
       </span>
-      <MainButton @click="copyUrl" :disabled="!listURL" size="small"> コピー </MainButton>
+      <MainButton @click="copyUrl" size="small"> コピー </MainButton>
     </div>
     <div class="mt-6">
       <MainButton variant="secondary" @click="navigateToItemList"> アイテムリストへ移動 </MainButton>

--- a/frontend/src/pages/ShareListPage.vue
+++ b/frontend/src/pages/ShareListPage.vue
@@ -1,0 +1,61 @@
+<script>
+import ContentArea from '../components/ContentArea.vue';
+import MainButton from '../components/MainButton.vue';
+
+export default {
+  name: 'ShareListPage',
+  components: {
+    ContentArea,
+    MainButton
+  },
+  data() {
+    return {
+      listName: '',
+      listId: '',
+      listURL: ''
+    };
+  },
+  created() {
+    this.listName = this.$route.query.name;
+    this.listId = this.$route.params.id;
+    // ルートパラメータからリストIDを取得
+    this.listURL = `http://example.com/lists/${this.listId}?name=${encodeURIComponent(this.listName)}`;
+  },
+  methods: {
+    copyUrl() {
+      navigator.clipboard
+        .writeText(this.listURL)
+        .then(() => {
+          alert('リンクがコピーされました！');
+        })
+        .catch(() => {
+          alert('コピーに失敗しました。手動でコピーしてください。');
+        });
+    },
+    navigateToItemList() {
+      this.$router.push({
+        name: 'ItemList',
+        params: { id: this.listId },
+        query: { name: this.listName }
+      });
+    }
+  }
+};
+</script>
+
+<template>
+  <ContentArea layout="center">
+    <h1 class="text-2xl font-bold font-sans">共有リンク</h1>
+    <div class="mt-6 flex gap-2 px-2 py-1 border border-charcoal-200 bg-charcoal-100 rounded-md w-full">
+      <span
+        class="flex-1 min-w-0 text-charcoal-800 whitespace-nowrap overflow-hidden text-clip overflow-x-scroll scrollbar-hidden"
+      >
+        {{ listURL }}
+      </span>
+      <MainButton @click="copyUrl" :disabled="!listURL" size="small"> コピー </MainButton>
+    </div>
+    <div class="mt-6">
+      <MainButton variant="secondary" @click="navigateToItemList"> アイテムリストへ移動 </MainButton>
+    </div>
+  </ContentArea>
+</template>

--- a/frontend/src/pages/ShareListPage.vue
+++ b/frontend/src/pages/ShareListPage.vue
@@ -16,12 +16,47 @@ export default {
     };
   },
   created() {
-    this.listName = this.$route.query.name;
-    this.listId = this.$route.params.id;
-    // ルートパラメータからリストIDを取得
-    this.listURL = `http://example.com/lists/${this.listId}?name=${encodeURIComponent(this.listName)}`;
+    this.initializeFromRoute();
   },
   methods: {
+    initializeFromRoute() {
+      const { isValid, listId, listName } = this.validateRouteParams();
+
+      if (!isValid) {
+        console.error('Invalid route parameters');
+        this.$router.push({ name: 'Welcome' });
+        return;
+      }
+
+      this.listId = listId;
+      this.listName = listName;
+      this.generateShareUrl();
+    },
+
+    validateRouteParams() {
+      const routeId = this.$route.params.id;
+      const routeName = this.$route.query.name;
+
+      // IDの検証
+      if (!routeId || typeof routeId !== 'string' || !routeId.trim()) {
+        return { isValid: false };
+      }
+
+      // 名前の検証とデフォルト値設定
+      const validatedName =
+        routeName && typeof routeName === 'string' && routeName.trim() ? routeName.trim() : 'リスト';
+
+      return {
+        isValid: true,
+        listId: routeId.trim(),
+        listName: validatedName
+      };
+    },
+
+    generateShareUrl() {
+      const baseUrl = import.meta.env.VITE_BASE_URL || window.location.origin;
+      this.listURL = `${baseUrl}/lists/${this.listId}?name=${encodeURIComponent(this.listName)}`;
+    },
     copyUrl() {
       navigator.clipboard
         .writeText(this.listURL)

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 // Lazy loading for better performance
 const WelcomePage = () => import('../pages/WelcomePage.vue');
 const CreateListPage = () => import('../pages/CreateListPage.vue');
+const ShareListPage = () => import('../pages/ShareListPage.vue');
 const ItemListPage = () => import('../pages/ItemListPage.vue');
 
 const routes: RouteRecordRaw[] = [
@@ -15,6 +16,11 @@ const routes: RouteRecordRaw[] = [
     path: '/create-list',
     name: 'CreateList',
     component: CreateListPage
+  },
+  {
+    path: '/share-list/:id',
+    name: 'ShareList',
+    component: ShareListPage
   },
   {
     path: '/list/:id',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -23,7 +23,7 @@ const routes: RouteRecordRaw[] = [
     component: ShareListPage
   },
   {
-    path: '/list/:id',
+    path: '/lists/:id',
     name: 'ItemList',
     component: ItemListPage
   }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -39,7 +39,10 @@
 }
 
 @utility scrollbar-hidden {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+
   &::-webkit-scrollbar {
-    display: none;
+    display: none; /* WebKit browsers */
   }
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -37,3 +37,9 @@
   --color-error-500: #ef4444;
   --color-error-600: #dc2626;
 }
+
+@utility scrollbar-hidden {
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new share list feature and refactors the badge component. The main updates include the addition of a `ShareListPage`, routing changes to support sharing, and a rename of the `Badge` component to `BadgeTag`. There are also improvements to layout handling and a new utility style for hiding scrollbars.

**Share List Feature:**
* Added new `ShareListPage.vue` component, which generates and displays a shareable URL for a list, handles validation of route parameters, and allows users to copy the link or navigate to the item list.
* Updated routing in `router/index.ts` to include the `/share-list/:id` path and corresponding `ShareList` route for the new share page. [[1]](diffhunk://#diff-fac443ccc131cf97270d3ee45346b5b00c67e25e055a748a0fb66715c3718342R6) [[2]](diffhunk://#diff-fac443ccc131cf97270d3ee45346b5b00c67e25e055a748a0fb66715c3718342R20-R24)
* Modified `CreateListPage.vue` to redirect users to the new `ShareList` page upon list creation, instead of directly to the item list.

**Component Refactoring:**
* Renamed the `Badge` component to `BadgeTag` and updated all relevant imports and usage in `CreateListPage.vue` and the component file itself. [[1]](diffhunk://#diff-26b4d7eff95019de6103476bf1dc1a9d5b0b20d693f7fe45176ca0e0413b19adL21-R21) [[2]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fL6-R6) [[3]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fL15-R15) [[4]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fL92-R99)

**Styling and Layout Improvements:**
* Added a `scrollbar-hidden` utility class to `style.css` for hiding scrollbars in supported browsers.
* Improved layout handling in `ContentArea.vue` by ensuring vertical stacking with `flex-col` for center and center-vertical layouts.