### PR TITLE
fix: template error and tabindex

### DIFF
--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -1,8 +1,8 @@
+<template>
   <SwipeContainer :hiddenBgColor="'#fef7f0'">
     <div
       :id="`item-${item.id}`"
-      class="flex items-center gap-3 p-3 bg-wood-100 border border-wood-200 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-wood-300 focus:ring-opacity-60"
-      tabindex="0"
+      class="flex items-center gap-3 p-3 bg-wood-100 border border-wood-200 rounded-lg shadow-sm focus:outline-none focus-within:ring-2 focus-within:ring-wood-300 focus-within:ring-opacity-60"
       role="listitem"
       :aria-label="`アイテム: ${item.name}. ${isCompleted ? '完了済み' : '未完了'}`"
     >


### PR DESCRIPTION
This pull request makes a small accessibility improvement to the `ItemBox.vue` component. The focus ring is now shown when any child element inside the item box is focused, not just the item box itself.

* Changed the CSS class from `focus:ring-...` to `focus-within:ring-...` on the main container in `ItemBox.vue` to improve accessibility by displaying a focus ring when any child element is focused.