### PR TITLE
fontend/improve text input semantics

### DIFF
--- a/frontend/src/components/TextInput.vue
+++ b/frontend/src/components/TextInput.vue
@@ -97,8 +97,6 @@ export default {
           'focus:ring-2 focus:ring-wood-500 focus:border-wood-500'
         ].join(' '),
         inline: [
-          // Full inline-width input
-          'w-full',
           // Flexible inline input (no padding - container provides it)
           'flex-1',
           // Minimal styling for inline use

--- a/frontend/src/components/TextInput.vue
+++ b/frontend/src/components/TextInput.vue
@@ -1,11 +1,11 @@
 <template>
   <input
+    :type="type"
     :id="inputId || undefined"
     :name="inputName || inputId"
     :value="modelValue"
     @input="$emit('update:modelValue', $event.target.value)"
     @keydown="handleKeyDown"
-    type="text"
     :placeholder="placeholder"
     :aria-label="ariaLabel || undefined"
     :disabled="disabled"
@@ -22,6 +22,11 @@ export default {
   name: 'TextInput',
   emits: ['update:modelValue', 'enter'],
   props: {
+    type: {
+      type: String,
+      default: 'text',
+      validator: (value) => ['text', 'search'].includes(value)
+    },
     inputId: {
       type: String,
       default: ''
@@ -92,6 +97,8 @@ export default {
           'focus:ring-2 focus:ring-wood-500 focus:border-wood-500'
         ].join(' '),
         inline: [
+          // Full inline-width input
+          'w-full',
           // Flexible inline input (no padding - container provides it)
           'flex-1',
           // Minimal styling for inline use

--- a/frontend/src/components/TextInput.vue
+++ b/frontend/src/components/TextInput.vue
@@ -47,6 +47,8 @@ export default {
       type: String,
       default: 'default',
       validator: (value) => ['default', 'inline'].includes(value)
+      // 'default': Standalone input with full styling
+      // 'inline': Lightweight input for use inside flex containers (requires parent to have 'flex' class)
     },
     ariaLabel: {
       type: String,

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -114,6 +114,7 @@ export default {
       <div v-if="items.length > 0" class="mb-4">
         <div class="px-2 py-2 border border-charcoal-200 bg-charcoal-100 rounded-md">
           <TextInput
+            :type="'search'"
             :model-value="searchQuery"
             @update:model-value="onSearchInput"
             input-name="search"

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -112,7 +112,7 @@ export default {
 
       <!-- 検索ボックス -->
       <div v-if="items.length > 0" class="mb-4">
-        <div class="px-2 py-2 border border-charcoal-200 bg-charcoal-100 rounded-md">
+        <div class="flex px-2 py-2 border border-charcoal-200 bg-charcoal-100 rounded-md">
           <TextInput
             :type="'search'"
             :model-value="searchQuery"


### PR DESCRIPTION
This pull request enhances the `TextInput` component to support different input types, specifically adding support for a `search` type, and updates its usage in the item list page to improve accessibility and UX for search fields.

Component enhancements:

* Added a `type` prop to the `TextInput` component, allowing it to be rendered as either a `text` or `search` input, with validation and a default value of `text` [[1]](diffhunk://#diff-72a3fb97e51717a372bfd317e7c7acdd29dcaa0ed128b315b7d00ca3f8debe19R3-L8) [[2]](diffhunk://#diff-72a3fb97e51717a372bfd317e7c7acdd29dcaa0ed128b315b7d00ca3f8debe19R25-R29).
* Updated the `variant` prop in `TextInput` with inline documentation to clarify usage for styling contexts.

Usage updates:

* Modified the search box in `ItemListPage.vue` to use the new `type="search"` feature and updated the container to use a flex layout for improved alignment.