### PR TITLE
Frontend/ display all members below list title

### DIFF
--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -77,7 +77,7 @@ export default {
         { id: '3', name: 'けんたろう' },
         { id: '4', name: 'Mike' },
         { id: '5', name: 'トミージャッカーソン' },
-        { id: '6', name: 'SomeoneWhoHasLoooooongName' },
+        { id: '6', name: 'ハリーポッターストレンジャーシングス' },
         { id: '7', name: 'Ellen' },
         { id: '8', name: 'Daisy' },
         { id: '9', name: 'Lily' },
@@ -153,9 +153,9 @@ export default {
   <ContentArea>
     <div class="w-full">
       <!-- リストタイトル -->
-      <div class="mb-6">
-        <h2 class="text-2xl font-bold text-charcoal-800 text-center mb-2">{{ listName }}</h2>
-        <p class="text-sm text-charcoal-600 text-center">🍖 買い物リスト</p>
+      <div class="mb-8">
+        <h2 class="text-2xl font-black text-charcoal-800 text-center mb-2">{{ listName }}</h2>
+        <p class="text-sm text-charcoal-600 text-center">{{ members.map((member) => member.name).join(' ・ ') }}</p>
       </div>
 
       <!-- 新しいアイテム追加 -->

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -67,6 +67,9 @@ export default {
         const normalizedItemName = normalizeForSearch(item.name);
         return normalizedItemName.includes(normalizedQuery);
       });
+    },
+    memberNames(): string {
+      return this.members.map((member) => member.name).join(' ・ ');
     }
   },
   methods: {
@@ -155,7 +158,7 @@ export default {
       <!-- リストタイトル -->
       <div class="mb-8">
         <h2 class="text-2xl font-black text-charcoal-800 text-center mb-2">{{ listName }}</h2>
-        <p class="text-sm text-charcoal-600 text-center">{{ members.map((member) => member.name).join(' ・ ') }}</p>
+        <p class="text-sm text-charcoal-600 text-center">{{ memberNames }}</p>
       </div>
 
       <!-- 新しいアイテム追加 -->


### PR DESCRIPTION
This pull request updates the display of the item list page to improve the list title section and member display. The most important changes are:

UI improvements to the list title section:

* Increased the bottom margin of the list title container and changed the font weight of the list name to bolder for better visual hierarchy.
* Updated the subtitle below the list name to display the names of all members joined by "・" instead of the fixed text "🍖 買い物リスト", making the member list more visible.

Member data update:

* Changed the name of the member with `id: '6'` from "SomeoneWhoHasLoooooongName" to "ハリーポッターストレンジャーシングス" in the `members` array.