### PR TITLE
Backend/ add controllers

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/advice/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/advice/ApiExceptionHandler.java
@@ -1,0 +1,97 @@
+package com.atoook.otsukailist.api.advice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.atoook.otsukailist.api.dto.ApiError;
+import com.atoook.otsukailist.api.dto.ApiErrorCode;
+import com.atoook.otsukailist.exception.ResourceNotFoundException;
+
+@RestControllerAdvice(basePackages = "com.atoook.otsukailist.api.controller")
+public class ApiExceptionHandler {
+
+    /**
+     * Handle resource-not-found errors for API requests.
+     *
+     * @param e thrown exception
+     * @return 404 response body
+     */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiError.of(ApiErrorCode.NOT_FOUND, e.getMessage()));
+    }
+
+    /**
+     * Handle generic bad request scenarios such as invalid arguments.
+     *
+     * @param e thrown exception
+     * @return 400 response body
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiError.of(ApiErrorCode.BAD_REQUEST, e.getMessage()));
+    }
+
+    /**
+     * Handle validation errors from bean validation.
+     *
+     * @param e binding exception
+     * @return 400 response body with field errors
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException e) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().forEach(err -> {
+            // 同じフィールドで複数エラーが来たら先勝ち（好みで変えてOK）
+            fieldErrors.putIfAbsent(err.getField(), err.getDefaultMessage());
+        });
+
+        Map<String, Object> details = Map.of("fieldErrors", fieldErrors);
+
+        String msg = fieldErrors.isEmpty()
+                ? ApiErrorCode.VALIDATION_ERROR.defaultMessage()
+                : "入力内容に誤りがあります";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiError.of(ApiErrorCode.VALIDATION_ERROR, msg, details));
+    }
+
+    /**
+     * Handle constraint violations raised by the database.
+     *
+     * @param e data integrity violation
+     * @return 409 response body
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiError> handleConflict(DataIntegrityViolationException e) {
+        // ここは “とりあえず実務的に” 分かりやすいメッセージに寄せる
+        // member の UNIQUE(list_id, display_name) が最頻出想定
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiError.of(
+                        ApiErrorCode.CONFLICT,
+                        "制約違反が発生しました（同一リスト内で重複がないか確認してください）"));
+    }
+
+    /**
+     * Handle unexpected exceptions and respond with a generic error.
+     *
+     * @param e unexpected exception
+     * @return 500 response with generic error
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleInternal(Exception e) {
+        // ログは別途（ここではレスポンスだけ）
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiError.of(ApiErrorCode.INTERNAL_ERROR));
+    }
+
+}

--- a/backend/src/main/java/com/atoook/otsukailist/api/advice/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/advice/ApiExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.atoook.otsukailist.api.dto.ApiError;
 import com.atoook.otsukailist.api.dto.ApiErrorCode;
+import com.atoook.otsukailist.exception.BadRequestException;
 import com.atoook.otsukailist.exception.ResourceNotFoundException;
 
 @RestControllerAdvice(basePackages = "com.atoook.otsukailist.api.controller")
@@ -30,13 +31,13 @@ public class ApiExceptionHandler {
     }
 
     /**
-     * Handle generic bad request scenarios such as invalid arguments.
+     * Handle application-defined bad request scenarios.
      *
      * @param e thrown exception
      * @return 400 response body
      */
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiError> handleBadRequest(IllegalArgumentException e) {
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ApiError> handleBadRequest(BadRequestException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiError.of(ApiErrorCode.BAD_REQUEST, e.getMessage()));
     }

--- a/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiError.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiError.java
@@ -1,0 +1,61 @@
+package com.atoook.otsukailist.api.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiError {
+    private final String error; // 例: "not_found", "validation_error"
+    private final String message; // 人向け
+    private final Instant timestamp; // サーバ時刻
+    private final Map<String, Object> details; // 任意（フィールドエラーなど）
+
+    /**
+     * Build an error payload based on a predefined error code and its default message.
+     *
+     * @param code error code enum
+     * @return error response
+     */
+    public static ApiError of(ApiErrorCode code) {
+        return new ApiError(
+                code.code(),
+                code.defaultMessage(),
+                Instant.now(),
+                Map.of());
+    }
+
+    /**
+     * Build an error payload with a custom message while keeping the error code.
+     *
+     * @param code error code enum
+     * @param message user-friendly message
+     * @return error response
+     */
+    public static ApiError of(ApiErrorCode code, String message) {
+        return new ApiError(
+                code.code(),
+                message,
+                Instant.now(),
+                Map.of());
+    }
+
+    /**
+     * Build an error payload with additional details.
+     *
+     * @param code error code enum
+     * @param message user-friendly message
+     * @param details additional error details map
+     * @return error response
+     */
+    public static ApiError of(ApiErrorCode code, String message, Map<String, Object> details) {
+        return new ApiError(
+                code.code(),
+                message,
+                Instant.now(),
+                details);
+    }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiErrorCode.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiErrorCode.java
@@ -1,0 +1,35 @@
+package com.atoook.otsukailist.api.dto;
+
+public enum ApiErrorCode {
+    NOT_FOUND("not_found", "resource not found"),
+    BAD_REQUEST("bad_request", "bad request"),
+    VALIDATION_ERROR("validation_error", "validation error"),
+    CONFLICT("conflict", "conflict"),
+    INTERNAL_ERROR("internal_error", "internal server error");
+
+    private final String code;
+    private final String defaultMessage;
+
+    ApiErrorCode(String code, String defaultMessage) {
+        this.code = code;
+        this.defaultMessage = defaultMessage;
+    }
+
+    /**
+     * 取得したエラーコード値を返します。
+     *
+     * @return API で利用するエラーコード
+     */
+    public String code() {
+        return code;
+    }
+
+    /**
+     * エラーコードに紐づくデフォルトメッセージを返します。
+     *
+     * @return デフォルトメッセージ
+     */
+    public String defaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/exception/BadRequestException.java
+++ b/backend/src/main/java/com/atoook/otsukailist/exception/BadRequestException.java
@@ -1,0 +1,28 @@
+package com.atoook.otsukailist.exception;
+
+/**
+ * Signals that the client sent a syntactically correct request whose content is
+ * invalid.
+ */
+public class BadRequestException extends RuntimeException {
+
+    /**
+     * Create exception with message.
+     *
+     * @param message detail text
+     */
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create exception with message and cause.
+     *
+     * @param message detail text
+     * @param cause   root cause
+     */
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemListRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemListRepository.java
@@ -7,11 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.atoook.otsukailist.model.ItemList;
 
-@Repository
 public interface ItemListRepository extends JpaRepository<ItemList, UUID> {
     // 基本的なCRUD操作は JpaRepository が自動提供
     // - findById(UUID id)

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
@@ -5,11 +5,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.atoook.otsukailist.model.Item;
 
-@Repository
 public interface ItemRepository extends JpaRepository<Item, UUID> {
     // 基本的なCRUD操作は JpaRepository が自動提供
     // ※ findAll() や条件なし検索は使用禁止（設計思想に反する）

--- a/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
@@ -18,6 +18,7 @@ import com.atoook.otsukailist.dto.DeleteItemResponse;
 import com.atoook.otsukailist.model.ItemList;
 import com.atoook.otsukailist.mapper.ItemMapper;
 import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.exception.BadRequestException;
 import com.atoook.otsukailist.service.message.ErrorMessages;
 
 import lombok.RequiredArgsConstructor;
@@ -79,11 +80,11 @@ public class ItemCommandService {
         if (req.getCompleted() != null) {
             if (req.getCompleted()) {
                 if (req.getCompletedByMemberId() == null) {
-                    throw new IllegalArgumentException(MSG_COMPLETED_BY_NOT_SPECIFIED);
+                    throw new BadRequestException(MSG_COMPLETED_BY_NOT_SPECIFIED);
                 }
                 boolean exists = memberRepo.existsByIdAndItemListId(req.getCompletedByMemberId(), listId);
                 if (!exists) {
-                    throw new IllegalArgumentException(MSG_MEMBER_NOT_IN_LIST);
+                    throw new BadRequestException(MSG_MEMBER_NOT_IN_LIST);
                 }
                 item.setCompleted(true);
                 item.setCompletedByMemberId(req.getCompletedByMemberId());

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
@@ -17,6 +17,7 @@ import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.dto.ItemListResponse;
 import com.atoook.otsukailist.mapper.ItemListMapper;
 import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.exception.BadRequestException;
 import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
 import com.atoook.otsukailist.dto.CreateItemListWithMembersResponse;
 import com.atoook.otsukailist.dto.MutationResponse;
@@ -57,7 +58,7 @@ public class ListCommandService {
         Set<String> seen = new HashSet<>();
         for (String n : names) {
             if (!seen.add(n)) {
-                throw new IllegalArgumentException(String.format(ErrorMessages.MEMBER_DUPLICATED, n));
+                throw new BadRequestException(String.format(ErrorMessages.MEMBER_DUPLICATED, n));
             }
         }
 


### PR DESCRIPTION
This pull request introduces a centralized API error handling mechanism and improves error reporting throughout the backend. The main changes include adding a global exception handler for API controllers, introducing standardized API error response classes, and refactoring services to use a custom `BadRequestException` for client errors instead of generic exceptions. Additionally, the unnecessary `@Repository` annotations were removed from repository interfaces.

**Centralized API Error Handling:**

- Added a new `ApiExceptionHandler` class to globally handle exceptions from API controllers, converting them into standardized HTTP error responses with consistent payloads. This covers not found, bad request, validation, conflict, and internal errors.
- Introduced `ApiError` and `ApiErrorCode` classes to define the structure and standard codes/messages for API error responses. [[1]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68R1-R61) [[2]](diffhunk://#diff-7560539c63505d7704f47564f660ed3636c1288d3f7242d1e70211e21b2f45e3R1-R35)

**Service Layer Improvements:**

- Added a custom `BadRequestException` for signaling client-side errors, and updated service classes (`ItemCommandService`, `ListCommandService`) to throw this exception instead of `IllegalArgumentException` for bad requests. [[1]](diffhunk://#diff-f00116f616b61600800e037dc6dba5f542be904bb1c4e2749c780df23d05dcfdR1-R28) [[2]](diffhunk://#diff-abe0caa3cb9b2b9132e71c2aae0257752277219a6fc3a50ceb95d3c012377642R21) [[3]](diffhunk://#diff-abe0caa3cb9b2b9132e71c2aae0257752277219a6fc3a50ceb95d3c012377642L82-R87) [[4]](diffhunk://#diff-10462c0544b48b6962be5ceb8dc9474e21216132dadae3b168a75efad5027e32R20) [[5]](diffhunk://#diff-10462c0544b48b6962be5ceb8dc9474e21216132dadae3b168a75efad5027e32L60-R61)

**Repository Annotation Cleanup:**

- Removed redundant `@Repository` annotations from `ItemRepository` and `ItemListRepository` interfaces, as Spring Data JPA already handles these automatically. [[1]](diffhunk://#diff-f573f7fcd8d43e3f0ead3bc1c8ea2408c4f7a9c4331e72b7a859b7470ab54a0fL10-L14) [[2]](diffhunk://#diff-4660237e44ab5271c063d9db0958deaebeaa8d0246ad9f73e1ea82aa29561e3eL8-L12)