### PR TITLE
Backend/ add command controllers

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -5,6 +5,7 @@ plugins {
 	id 'checkstyle'
 	id 'pmd'
 	id 'com.github.spotbugs' version '6.0.26'
+	id 'com.diffplug.spotless' version '6.25.0'
 }
 
 // テスト環境管理タスクをインポート
@@ -138,4 +139,16 @@ task fixCodeStyle {
 // テスト前に軽い静的解析を実行
 check {
 	dependsOn 'checkstyleMain', 'pmdMain'
+}
+
+// Spotless (コードフォーマッタ)
+spotless {
+	java {
+		target 'src/**/*.java'
+		googleJavaFormat('1.17.0')
+		importOrder 'java', 'jakarta', 'org.springframework', 'com.atoook', ''
+		removeUnusedImports()
+		trimTrailingWhitespace()
+		endWithNewline()
+	}
 }

--- a/backend/src/main/java/com/atoook/otsukailist/OtsukaiListApplication.java
+++ b/backend/src/main/java/com/atoook/otsukailist/OtsukaiListApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class OtsukaiListApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(OtsukaiListApplication.class, args);
-    }
-
+  public static void main(String[] args) {
+    SpringApplication.run(OtsukaiListApplication.class, args);
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/advice/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/advice/ApiExceptionHandler.java
@@ -18,81 +18,80 @@ import com.atoook.otsukailist.exception.ResourceNotFoundException;
 @RestControllerAdvice(basePackages = "com.atoook.otsukailist.api.controller")
 public class ApiExceptionHandler {
 
-    /**
-     * Handle resource-not-found errors for API requests.
-     *
-     * @param e thrown exception
-     * @return 404 response body
-     */
-    @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiError.of(ApiErrorCode.NOT_FOUND, e.getMessage()));
-    }
+  /**
+   * Handle resource-not-found errors for API requests.
+   *
+   * @param e thrown exception
+   * @return 404 response body
+   */
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<ApiError> handleNotFound(ResourceNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(ApiError.of(ApiErrorCode.NOT_FOUND, e.getMessage()));
+  }
 
-    /**
-     * Handle application-defined bad request scenarios.
-     *
-     * @param e thrown exception
-     * @return 400 response body
-     */
-    @ExceptionHandler(BadRequestException.class)
-    public ResponseEntity<ApiError> handleBadRequest(BadRequestException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiError.of(ApiErrorCode.BAD_REQUEST, e.getMessage()));
-    }
+  /**
+   * Handle application-defined bad request scenarios.
+   *
+   * @param e thrown exception
+   * @return 400 response body
+   */
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<ApiError> handleBadRequest(BadRequestException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiError.of(ApiErrorCode.BAD_REQUEST, e.getMessage()));
+  }
 
-    /**
-     * Handle validation errors from bean validation.
-     *
-     * @param e binding exception
-     * @return 400 response body with field errors
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException e) {
-        Map<String, String> fieldErrors = new LinkedHashMap<>();
+  /**
+   * Handle validation errors from bean validation.
+   *
+   * @param e binding exception
+   * @return 400 response body with field errors
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException e) {
+    Map<String, String> fieldErrors = new LinkedHashMap<>();
 
-        e.getBindingResult().getFieldErrors().forEach(err -> {
-            // 同じフィールドで複数エラーが来たら先勝ち（好みで変えてOK）
-            fieldErrors.putIfAbsent(err.getField(), err.getDefaultMessage());
-        });
+    e.getBindingResult()
+        .getFieldErrors()
+        .forEach(
+            err -> {
+              // 同じフィールドで複数エラーが来たら先勝ち（好みで変えてOK）
+              fieldErrors.putIfAbsent(err.getField(), err.getDefaultMessage());
+            });
 
-        Map<String, Object> details = Map.of("fieldErrors", fieldErrors);
+    Map<String, Object> details = Map.of("fieldErrors", fieldErrors);
 
-        String msg = fieldErrors.isEmpty()
-                ? ApiErrorCode.VALIDATION_ERROR.defaultMessage()
-                : "入力内容に誤りがあります";
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiError.of(ApiErrorCode.VALIDATION_ERROR, msg, details));
-    }
+    String msg =
+        fieldErrors.isEmpty() ? ApiErrorCode.VALIDATION_ERROR.defaultMessage() : "入力内容に誤りがあります";
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(ApiError.of(ApiErrorCode.VALIDATION_ERROR, msg, details));
+  }
 
-    /**
-     * Handle constraint violations raised by the database.
-     *
-     * @param e data integrity violation
-     * @return 409 response body
-     */
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ApiError> handleConflict(DataIntegrityViolationException e) {
-        // ここは “とりあえず実務的に” 分かりやすいメッセージに寄せる
-        // member の UNIQUE(list_id, display_name) が最頻出想定
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ApiError.of(
-                        ApiErrorCode.CONFLICT,
-                        "制約違反が発生しました（同一リスト内で重複がないか確認してください）"));
-    }
+  /**
+   * Handle constraint violations raised by the database.
+   *
+   * @param e data integrity violation
+   * @return 409 response body
+   */
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<ApiError> handleConflict(DataIntegrityViolationException e) {
+    // ここは “とりあえず実務的に” 分かりやすいメッセージに寄せる
+    // member の UNIQUE(list_id, display_name) が最頻出想定
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(ApiError.of(ApiErrorCode.CONFLICT, "制約違反が発生しました（同一リスト内で重複がないか確認してください）"));
+  }
 
-    /**
-     * Handle unexpected exceptions and respond with a generic error.
-     *
-     * @param e unexpected exception
-     * @return 500 response with generic error
-     */
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiError> handleInternal(Exception e) {
-        // ログは別途（ここではレスポンスだけ）
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiError.of(ApiErrorCode.INTERNAL_ERROR));
-    }
-
+  /**
+   * Handle unexpected exceptions and respond with a generic error.
+   *
+   * @param e unexpected exception
+   * @return 500 response with generic error
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiError> handleInternal(Exception e) {
+    // ログは別途（ここではレスポンスだけ）
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(ApiError.of(ApiErrorCode.INTERNAL_ERROR));
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -27,6 +27,13 @@ public class ItemCommandController {
 
     private final ItemCommandService itemCommandService;
 
+    /**
+     * Creates a new item under the given list.
+     *
+     * @param listId list identifier
+     * @param req creation payload
+     * @return created item response
+     */
     @PostMapping
     public MutationResponse<ItemResponse> create(
             @PathVariable("listId") UUID listId,
@@ -34,6 +41,14 @@ public class ItemCommandController {
         return itemCommandService.createItem(listId, req);
     }
 
+    /**
+     * Updates an existing item.
+     *
+     * @param listId parent list identifier
+     * @param itemId item identifier
+     * @param req update payload
+     * @return updated item response
+     */
     @PatchMapping("/{itemId}")
     public MutationResponse<ItemResponse> update(
             @PathVariable("listId") UUID listId,
@@ -42,6 +57,13 @@ public class ItemCommandController {
         return itemCommandService.updateItem(listId, itemId, req);
     }
 
+    /**
+     * Deletes the specified item.
+     *
+     * @param listId parent list identifier
+     * @param itemId item identifier
+     * @return deletion response
+     */
     @DeleteMapping("/{itemId}")
     public MutationResponse<DeleteItemResponse> delete(
             @PathVariable("listId") UUID listId,

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -1,5 +1,6 @@
 package com.atoook.otsukailist.api.controller;
 
+import java.net.URI;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.atoook.otsukailist.dto.CreateItemRequest;
 import com.atoook.otsukailist.dto.ItemResponse;
@@ -38,7 +40,12 @@ public class ItemCommandController {
     public ResponseEntity<MutationResponse<ItemResponse>> create(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody CreateItemRequest req) {
-        return ResponseEntity.created(null).body(itemCommandService.createItem(listId, req));
+        MutationResponse<ItemResponse> payload = itemCommandService.createItem(listId, req);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{itemId}")
+                .buildAndExpand(payload.getData().getId())
+                .toUri();
+        return ResponseEntity.created(location).body(payload);
     }
 
     /**

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -2,7 +2,6 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -39,7 +38,7 @@ public class ItemCommandController {
     public ResponseEntity<MutationResponse<ItemResponse>> create(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody CreateItemRequest req) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(itemCommandService.createItem(listId, req));
+        return ResponseEntity.created(null).body(itemCommandService.createItem(listId, req));
     }
 
     /**
@@ -55,7 +54,7 @@ public class ItemCommandController {
             @PathVariable("listId") UUID listId,
             @PathVariable("itemId") UUID itemId,
             @Valid @RequestBody UpdateItemRequest req) {
-        return ResponseEntity.status(HttpStatus.OK).body(itemCommandService.updateItem(listId, itemId, req));
+        return ResponseEntity.ok(itemCommandService.updateItem(listId, itemId, req));
     }
 
     /**
@@ -70,6 +69,6 @@ public class ItemCommandController {
             @PathVariable("listId") UUID listId,
             @PathVariable("itemId") UUID itemId) {
         itemCommandService.deleteItem(listId, itemId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -1,0 +1,51 @@
+package com.atoook.otsukailist.api.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.atoook.otsukailist.dto.CreateItemRequest;
+import com.atoook.otsukailist.dto.DeleteItemResponse;
+import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.UpdateItemRequest;
+import com.atoook.otsukailist.service.ItemCommandService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lists/{listId}/items")
+public class ItemCommandController {
+
+    private final ItemCommandService itemCommandService;
+
+    @PostMapping
+    public MutationResponse<ItemResponse> create(
+            @PathVariable("listId") UUID listId,
+            @Valid @RequestBody CreateItemRequest req) {
+        return itemCommandService.createItem(listId, req);
+    }
+
+    @PatchMapping("/{itemId}")
+    public MutationResponse<ItemResponse> update(
+            @PathVariable("listId") UUID listId,
+            @PathVariable("itemId") UUID itemId,
+            @Valid @RequestBody UpdateItemRequest req) {
+        return itemCommandService.updateItem(listId, itemId, req);
+    }
+
+    @DeleteMapping("/{itemId}")
+    public MutationResponse<DeleteItemResponse> delete(
+            @PathVariable("listId") UUID listId,
+            @PathVariable("itemId") UUID itemId) {
+        return itemCommandService.deleteItem(listId, itemId);
+    }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -2,6 +2,8 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.atoook.otsukailist.dto.CreateItemRequest;
-import com.atoook.otsukailist.dto.DeleteItemResponse;
 import com.atoook.otsukailist.dto.ItemResponse;
 import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.UpdateItemRequest;
@@ -31,14 +32,14 @@ public class ItemCommandController {
      * Creates a new item under the given list.
      *
      * @param listId list identifier
-     * @param req creation payload
-     * @return created item response
+     * @param req    creation payload
+     * @return 201 created item response
      */
     @PostMapping
-    public MutationResponse<ItemResponse> create(
+    public ResponseEntity<MutationResponse<ItemResponse>> create(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody CreateItemRequest req) {
-        return itemCommandService.createItem(listId, req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(itemCommandService.createItem(listId, req));
     }
 
     /**
@@ -46,15 +47,15 @@ public class ItemCommandController {
      *
      * @param listId parent list identifier
      * @param itemId item identifier
-     * @param req update payload
-     * @return updated item response
+     * @param req    update payload
+     * @return 200 updated item response
      */
     @PatchMapping("/{itemId}")
-    public MutationResponse<ItemResponse> update(
+    public ResponseEntity<MutationResponse<ItemResponse>> update(
             @PathVariable("listId") UUID listId,
             @PathVariable("itemId") UUID itemId,
             @Valid @RequestBody UpdateItemRequest req) {
-        return itemCommandService.updateItem(listId, itemId, req);
+        return ResponseEntity.status(HttpStatus.OK).body(itemCommandService.updateItem(listId, itemId, req));
     }
 
     /**
@@ -62,12 +63,13 @@ public class ItemCommandController {
      *
      * @param listId parent list identifier
      * @param itemId item identifier
-     * @return deletion response
+     * @return 204 deletion response
      */
     @DeleteMapping("/{itemId}")
-    public MutationResponse<DeleteItemResponse> delete(
+    public ResponseEntity<Void> delete(
             @PathVariable("listId") UUID listId,
             @PathVariable("itemId") UUID itemId) {
-        return itemCommandService.deleteItem(listId, itemId);
+        itemCommandService.deleteItem(listId, itemId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -2,6 +2,12 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,30 +18,23 @@ import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.UpdateItemListRequest;
 import com.atoook.otsukailist.service.ListCommandService;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/lists")
 public class ItemListCommandController {
-    private final ListCommandService listCommandService;
+  private final ListCommandService listCommandService;
 
-    @PostMapping
-    public MutationResponse<CreateItemListWithMembersResponse> createItemList(
-            @Valid @RequestBody CreateItemListWithMembersRequest req) {
-        return listCommandService.createListWithMembers(req);
-    }
+  @PostMapping
+  public MutationResponse<CreateItemListWithMembersResponse> createItemList(
+      @Valid @RequestBody CreateItemListWithMembersRequest req) {
+    return listCommandService.createListWithMembers(req);
+  }
 
-    @PatchMapping("/{listId}")
-    public MutationResponse<ItemListResponse> rename(
-            @PathVariable("listId") UUID listId,
-            @Valid @RequestBody UpdateItemListRequest req) {
-        return listCommandService.renameList(listId, req);
-    }
-
+  @PatchMapping("/{listId}")
+  public MutationResponse<ItemListResponse> rename(
+      @PathVariable("listId") UUID listId, @Valid @RequestBody UpdateItemListRequest req) {
+    return listCommandService.renameList(listId, req);
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -1,0 +1,40 @@
+package com.atoook.otsukailist.api.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
+import com.atoook.otsukailist.dto.CreateItemListWithMembersResponse;
+import com.atoook.otsukailist.dto.ItemListResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.UpdateItemListRequest;
+import com.atoook.otsukailist.service.ListCommandService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/list")
+public class ItemListCommandController {
+    private final ListCommandService listCommandService;
+
+    @PostMapping
+    public MutationResponse<CreateItemListWithMembersResponse> createItemList(
+            @RequestBody CreateItemListWithMembersRequest req) {
+        return listCommandService.createListWithMembers(req);
+    }
+
+    @PostMapping("/{listId}")
+    public MutationResponse<ItemListResponse> rename(
+            @PathVariable UUID listId,
+            @Valid @RequestBody UpdateItemListRequest req) {
+        return listCommandService.renameList(listId, req);
+    }
+
+}

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -2,8 +2,8 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
-import jakarta.validation.Valid;
-
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +18,7 @@ import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.UpdateItemListRequest;
 import com.atoook.otsukailist.service.ListCommandService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -30,24 +31,24 @@ public class ItemListCommandController {
    * Creates a list together with its initial members.
    *
    * @param req list and member creation payload
-   * @return created list information
+   * @return 201 created list response
    */
   @PostMapping
-  public MutationResponse<CreateItemListWithMembersResponse> createItemList(
+  public ResponseEntity<MutationResponse<CreateItemListWithMembersResponse>> createItemList(
       @Valid @RequestBody CreateItemListWithMembersRequest req) {
-    return listCommandService.createListWithMembers(req);
+    return ResponseEntity.status(HttpStatus.CREATED).body(listCommandService.createListWithMembers(req));
   }
 
   /**
    * Renames the specified list.
    *
    * @param listId target list identifier
-   * @param req rename payload
-   * @return updated list response
+   * @param req    rename payload
+   * @return 200 updated list response
    */
   @PatchMapping("/{listId}")
-  public MutationResponse<ItemListResponse> rename(
+  public ResponseEntity<MutationResponse<ItemListResponse>> rename(
       @PathVariable("listId") UUID listId, @Valid @RequestBody UpdateItemListRequest req) {
-    return listCommandService.renameList(listId, req);
+    return ResponseEntity.status(HttpStatus.OK).body(listCommandService.renameList(listId, req));
   }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -20,19 +20,19 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/list")
+@RequestMapping("/api/lists")
 public class ItemListCommandController {
     private final ListCommandService listCommandService;
 
     @PostMapping
     public MutationResponse<CreateItemListWithMembersResponse> createItemList(
-            @RequestBody CreateItemListWithMembersRequest req) {
+            @Valid @RequestBody CreateItemListWithMembersRequest req) {
         return listCommandService.createListWithMembers(req);
     }
 
     @PostMapping("/{listId}")
     public MutationResponse<ItemListResponse> rename(
-            @PathVariable UUID listId,
+            @PathVariable("listId") UUID listId,
             @Valid @RequestBody UpdateItemListRequest req) {
         return listCommandService.renameList(listId, req);
     }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -1,8 +1,8 @@
 package com.atoook.otsukailist.api.controller;
 
+import java.net.URI;
 import java.util.UUID;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
 import com.atoook.otsukailist.dto.CreateItemListWithMembersResponse;
@@ -36,7 +37,12 @@ public class ItemListCommandController {
   @PostMapping
   public ResponseEntity<MutationResponse<CreateItemListWithMembersResponse>> createItemList(
       @Valid @RequestBody CreateItemListWithMembersRequest req) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(listCommandService.createListWithMembers(req));
+    MutationResponse<CreateItemListWithMembersResponse> payload = listCommandService.createListWithMembers(req);
+    URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+        .path("/{listId}")
+        .buildAndExpand(payload.getData().getListId())
+        .toUri();
+    return ResponseEntity.created(location).body(payload);
   }
 
   /**
@@ -49,6 +55,6 @@ public class ItemListCommandController {
   @PatchMapping("/{listId}")
   public ResponseEntity<MutationResponse<ItemListResponse>> rename(
       @PathVariable("listId") UUID listId, @Valid @RequestBody UpdateItemListRequest req) {
-    return ResponseEntity.status(HttpStatus.OK).body(listCommandService.renameList(listId, req));
+    return ResponseEntity.ok(listCommandService.renameList(listId, req));
   }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -26,12 +26,25 @@ import lombok.RequiredArgsConstructor;
 public class ItemListCommandController {
   private final ListCommandService listCommandService;
 
+  /**
+   * Creates a list together with its initial members.
+   *
+   * @param req list and member creation payload
+   * @return created list information
+   */
   @PostMapping
   public MutationResponse<CreateItemListWithMembersResponse> createItemList(
       @Valid @RequestBody CreateItemListWithMembersRequest req) {
     return listCommandService.createListWithMembers(req);
   }
 
+  /**
+   * Renames the specified list.
+   *
+   * @param listId target list identifier
+   * @param req rename payload
+   * @return updated list response
+   */
   @PatchMapping("/{listId}")
   public MutationResponse<ItemListResponse> rename(
       @PathVariable("listId") UUID listId, @Valid @RequestBody UpdateItemListRequest req) {

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @RestController
@@ -30,7 +31,7 @@ public class ItemListCommandController {
         return listCommandService.createListWithMembers(req);
     }
 
-    @PostMapping("/{listId}")
+    @PatchMapping("/{listId}")
     public MutationResponse<ItemListResponse> rename(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody UpdateItemListRequest req) {

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -1,5 +1,6 @@
 package com.atoook.otsukailist.api.controller;
 
+import java.net.URI;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.atoook.otsukailist.dto.CreateMemberRequest;
 import com.atoook.otsukailist.dto.MemberResponse;
@@ -37,7 +39,12 @@ public class MemberCommandController {
     public ResponseEntity<MutationResponse<MemberResponse>> add(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody CreateMemberRequest req) {
-        return ResponseEntity.created(null).body(memberCommandService.addMember(listId, req));
+        MutationResponse<MemberResponse> payload = memberCommandService.addMember(listId, req);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{memberId}")
+                .buildAndExpand(payload.getData().getId())
+                .toUri();
+        return ResponseEntity.created(location).body(payload);
     }
 
     /**

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -2,6 +2,8 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.atoook.otsukailist.dto.CreateMemberRequest;
-import com.atoook.otsukailist.dto.DeleteMemberResponse;
 import com.atoook.otsukailist.dto.MemberResponse;
 import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.service.MemberCommandService;
@@ -30,42 +31,43 @@ public class MemberCommandController {
      * Adds a new member to the specified list.
      *
      * @param listId target list identifier
-     * @param req creation request payload
-     * @return created member details wrapped in a mutation response
+     * @param req    creation request payload
+     * @return 201 created member details wrapped in a mutation response
      */
     @PostMapping
-    public MutationResponse<MemberResponse> add(
+    public ResponseEntity<MutationResponse<MemberResponse>> add(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody CreateMemberRequest req) {
-        return memberCommandService.addMember(listId, req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(memberCommandService.addMember(listId, req));
     }
 
     /**
      * Renames an existing member.
      *
-     * @param listId parent list identifier
+     * @param listId   parent list identifier
      * @param memberId member identifier
-     * @param req rename request payload
-     * @return updated member information
+     * @param req      rename request payload
+     * @return 200 updated member information
      */
     @PatchMapping("/{memberId}")
-    public MutationResponse<MemberResponse> rename(
+    public ResponseEntity<MutationResponse<MemberResponse>> rename(
             @PathVariable("listId") UUID listId,
             @PathVariable("memberId") UUID memberId,
             @Valid @RequestBody CreateMemberRequest req) {
-        return memberCommandService.renameMember(listId, memberId, req);
+        return ResponseEntity.status(HttpStatus.OK).body(memberCommandService.renameMember(listId, memberId, req));
     }
 
     /**
      * Deletes a member from the list.
      *
-     * @param listId parent list identifier
+     * @param listId   parent list identifier
      * @param memberId member identifier
-     * @return deletion result
+     * @return 204 deletion result
      */
     @DeleteMapping("/{memberId}")
-    public MutationResponse<DeleteMemberResponse> delete(
+    public ResponseEntity<Void> delete(
             @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {
-        return memberCommandService.deleteMember(listId, memberId);
+        memberCommandService.deleteMember(listId, memberId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -2,7 +2,6 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -38,7 +37,7 @@ public class MemberCommandController {
     public ResponseEntity<MutationResponse<MemberResponse>> add(
             @PathVariable("listId") UUID listId,
             @Valid @RequestBody CreateMemberRequest req) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(memberCommandService.addMember(listId, req));
+        return ResponseEntity.created(null).body(memberCommandService.addMember(listId, req));
     }
 
     /**
@@ -54,7 +53,7 @@ public class MemberCommandController {
             @PathVariable("listId") UUID listId,
             @PathVariable("memberId") UUID memberId,
             @Valid @RequestBody CreateMemberRequest req) {
-        return ResponseEntity.status(HttpStatus.OK).body(memberCommandService.renameMember(listId, memberId, req));
+        return ResponseEntity.ok(memberCommandService.renameMember(listId, memberId, req));
     }
 
     /**
@@ -68,6 +67,6 @@ public class MemberCommandController {
     public ResponseEntity<Void> delete(
             @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {
         memberCommandService.deleteMember(listId, memberId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -26,6 +26,13 @@ public class MemberCommandController {
 
     private final MemberCommandService memberCommandService;
 
+    /**
+     * Adds a new member to the specified list.
+     *
+     * @param listId target list identifier
+     * @param req creation request payload
+     * @return created member details wrapped in a mutation response
+     */
     @PostMapping
     public MutationResponse<MemberResponse> add(
             @PathVariable("listId") UUID listId,
@@ -33,6 +40,14 @@ public class MemberCommandController {
         return memberCommandService.addMember(listId, req);
     }
 
+    /**
+     * Renames an existing member.
+     *
+     * @param listId parent list identifier
+     * @param memberId member identifier
+     * @param req rename request payload
+     * @return updated member information
+     */
     @PatchMapping("/{memberId}")
     public MutationResponse<MemberResponse> rename(
             @PathVariable("listId") UUID listId,
@@ -41,6 +56,13 @@ public class MemberCommandController {
         return memberCommandService.renameMember(listId, memberId, req);
     }
 
+    /**
+     * Deletes a member from the list.
+     *
+     * @param listId parent list identifier
+     * @param memberId member identifier
+     * @return deletion result
+     */
     @DeleteMapping("/{memberId}")
     public MutationResponse<DeleteMemberResponse> delete(
             @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -1,22 +1,22 @@
 package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
+
 import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
 
-import com.atoook.otsukailist.dto.MemberResponse;
 import com.atoook.otsukailist.dto.CreateMemberRequest;
-import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.DeleteMemberResponse;
-
+import com.atoook.otsukailist.dto.MemberResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.service.MemberCommandService;
-
-import org.springframework.web.bind.annotation.PostMapping;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,27 +25,25 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/lists/{listId}/members/")
 public class MemberCommandController {
 
-    private final MemberCommandService memberCommandService;
+  private final MemberCommandService memberCommandService;
 
-    @PostMapping("/create")
-    public MutationResponse<MemberResponse> add(
-            @PathVariable("listId") UUID listId,
-            @Valid @RequestBody CreateMemberRequest req) {
-        return memberCommandService.addMember(listId, req);
-    }
+  @PostMapping("/create")
+  public MutationResponse<MemberResponse> add(
+      @PathVariable("listId") UUID listId, @Valid @RequestBody CreateMemberRequest req) {
+    return memberCommandService.addMember(listId, req);
+  }
 
-    @PatchMapping("/{memberId}")
-    public MutationResponse<MemberResponse> rename(
-            @PathVariable("listId") UUID listId,
-            @PathVariable("memberId") UUID memberId,
-            @Valid @RequestBody CreateMemberRequest req) {
-        return memberCommandService.renameMember(listId, memberId, req);
-    }
+  @PatchMapping("/{memberId}")
+  public MutationResponse<MemberResponse> rename(
+      @PathVariable("listId") UUID listId,
+      @PathVariable("memberId") UUID memberId,
+      @Valid @RequestBody CreateMemberRequest req) {
+    return memberCommandService.renameMember(listId, memberId, req);
+  }
 
-    @DeleteMapping("/{memberId}")
-    public MutationResponse<DeleteMemberResponse> delete(
-            @PathVariable("listId") UUID listId,
-            @PathVariable("memberId") UUID memberId) {
-        return memberCommandService.deleteMember(listId, memberId);
-    }
+  @DeleteMapping("/{memberId}")
+  public MutationResponse<DeleteMemberResponse> delete(
+      @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {
+    return memberCommandService.deleteMember(listId, memberId);
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -2,8 +2,6 @@ package com.atoook.otsukailist.api.controller;
 
 import java.util.UUID;
 
-import jakarta.validation.Valid;
-
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,32 +16,34 @@ import com.atoook.otsukailist.dto.MemberResponse;
 import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.service.MemberCommandService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/lists/{listId}/members/")
+@RequestMapping("/api/lists/{listId}/members")
 public class MemberCommandController {
 
-  private final MemberCommandService memberCommandService;
+    private final MemberCommandService memberCommandService;
 
-  @PostMapping("/create")
-  public MutationResponse<MemberResponse> add(
-      @PathVariable("listId") UUID listId, @Valid @RequestBody CreateMemberRequest req) {
-    return memberCommandService.addMember(listId, req);
-  }
+    @PostMapping
+    public MutationResponse<MemberResponse> add(
+            @PathVariable("listId") UUID listId,
+            @Valid @RequestBody CreateMemberRequest req) {
+        return memberCommandService.addMember(listId, req);
+    }
 
-  @PatchMapping("/{memberId}")
-  public MutationResponse<MemberResponse> rename(
-      @PathVariable("listId") UUID listId,
-      @PathVariable("memberId") UUID memberId,
-      @Valid @RequestBody CreateMemberRequest req) {
-    return memberCommandService.renameMember(listId, memberId, req);
-  }
+    @PatchMapping("/{memberId}")
+    public MutationResponse<MemberResponse> rename(
+            @PathVariable("listId") UUID listId,
+            @PathVariable("memberId") UUID memberId,
+            @Valid @RequestBody CreateMemberRequest req) {
+        return memberCommandService.renameMember(listId, memberId, req);
+    }
 
-  @DeleteMapping("/{memberId}")
-  public MutationResponse<DeleteMemberResponse> delete(
-      @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {
-    return memberCommandService.deleteMember(listId, memberId);
-  }
+    @DeleteMapping("/{memberId}")
+    public MutationResponse<DeleteMemberResponse> delete(
+            @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {
+        return memberCommandService.deleteMember(listId, memberId);
+    }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -1,0 +1,51 @@
+package com.atoook.otsukailist.api.controller;
+
+import java.util.UUID;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import com.atoook.otsukailist.dto.MemberResponse;
+import com.atoook.otsukailist.dto.CreateMemberRequest;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.DeleteMemberResponse;
+
+import com.atoook.otsukailist.service.MemberCommandService;
+
+import org.springframework.web.bind.annotation.PostMapping;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lists/{listId}/members/")
+public class MemberCommandController {
+
+    private final MemberCommandService memberCommandService;
+
+    @PostMapping("/create")
+    public MutationResponse<MemberResponse> add(
+            @PathVariable("listId") UUID listId,
+            @Valid @RequestBody CreateMemberRequest req) {
+        return memberCommandService.addMember(listId, req);
+    }
+
+    @PatchMapping("/{memberId}")
+    public MutationResponse<MemberResponse> rename(
+            @PathVariable("listId") UUID listId,
+            @PathVariable("memberId") UUID memberId,
+            @Valid @RequestBody CreateMemberRequest req) {
+        return memberCommandService.renameMember(listId, memberId, req);
+    }
+
+    @DeleteMapping("/{memberId}")
+    public MutationResponse<DeleteMemberResponse> delete(
+            @PathVariable("listId") UUID listId,
+            @PathVariable("memberId") UUID memberId) {
+        return memberCommandService.deleteMember(listId, memberId);
+    }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiError.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiError.java
@@ -9,53 +9,41 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class ApiError {
-    private final String error; // 例: "not_found", "validation_error"
-    private final String message; // 人向け
-    private final Instant timestamp; // サーバ時刻
-    private final Map<String, Object> details; // 任意（フィールドエラーなど）
+  private final String error; // 例: "not_found", "validation_error"
+  private final String message; // 人向け
+  private final Instant timestamp; // サーバ時刻
+  private final Map<String, Object> details; // 任意（フィールドエラーなど）
 
-    /**
-     * Build an error payload based on a predefined error code and its default message.
-     *
-     * @param code error code enum
-     * @return error response
-     */
-    public static ApiError of(ApiErrorCode code) {
-        return new ApiError(
-                code.code(),
-                code.defaultMessage(),
-                Instant.now(),
-                Map.of());
-    }
+  /**
+   * Build an error payload based on a predefined error code and its default message.
+   *
+   * @param code error code enum
+   * @return error response
+   */
+  public static ApiError of(ApiErrorCode code) {
+    return new ApiError(code.code(), code.defaultMessage(), Instant.now(), Map.of());
+  }
 
-    /**
-     * Build an error payload with a custom message while keeping the error code.
-     *
-     * @param code error code enum
-     * @param message user-friendly message
-     * @return error response
-     */
-    public static ApiError of(ApiErrorCode code, String message) {
-        return new ApiError(
-                code.code(),
-                message,
-                Instant.now(),
-                Map.of());
-    }
+  /**
+   * Build an error payload with a custom message while keeping the error code.
+   *
+   * @param code error code enum
+   * @param message user-friendly message
+   * @return error response
+   */
+  public static ApiError of(ApiErrorCode code, String message) {
+    return new ApiError(code.code(), message, Instant.now(), Map.of());
+  }
 
-    /**
-     * Build an error payload with additional details.
-     *
-     * @param code error code enum
-     * @param message user-friendly message
-     * @param details additional error details map
-     * @return error response
-     */
-    public static ApiError of(ApiErrorCode code, String message, Map<String, Object> details) {
-        return new ApiError(
-                code.code(),
-                message,
-                Instant.now(),
-                details);
-    }
+  /**
+   * Build an error payload with additional details.
+   *
+   * @param code error code enum
+   * @param message user-friendly message
+   * @param details additional error details map
+   * @return error response
+   */
+  public static ApiError of(ApiErrorCode code, String message, Map<String, Object> details) {
+    return new ApiError(code.code(), message, Instant.now(), details);
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiErrorCode.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/dto/ApiErrorCode.java
@@ -1,35 +1,35 @@
 package com.atoook.otsukailist.api.dto;
 
 public enum ApiErrorCode {
-    NOT_FOUND("not_found", "resource not found"),
-    BAD_REQUEST("bad_request", "bad request"),
-    VALIDATION_ERROR("validation_error", "validation error"),
-    CONFLICT("conflict", "conflict"),
-    INTERNAL_ERROR("internal_error", "internal server error");
+  NOT_FOUND("not_found", "resource not found"),
+  BAD_REQUEST("bad_request", "bad request"),
+  VALIDATION_ERROR("validation_error", "validation error"),
+  CONFLICT("conflict", "conflict"),
+  INTERNAL_ERROR("internal_error", "internal server error");
 
-    private final String code;
-    private final String defaultMessage;
+  private final String code;
+  private final String defaultMessage;
 
-    ApiErrorCode(String code, String defaultMessage) {
-        this.code = code;
-        this.defaultMessage = defaultMessage;
-    }
+  ApiErrorCode(String code, String defaultMessage) {
+    this.code = code;
+    this.defaultMessage = defaultMessage;
+  }
 
-    /**
-     * 取得したエラーコード値を返します。
-     *
-     * @return API で利用するエラーコード
-     */
-    public String code() {
-        return code;
-    }
+  /**
+   * 取得したエラーコード値を返します。
+   *
+   * @return API で利用するエラーコード
+   */
+  public String code() {
+    return code;
+  }
 
-    /**
-     * エラーコードに紐づくデフォルトメッセージを返します。
-     *
-     * @return デフォルトメッセージ
-     */
-    public String defaultMessage() {
-        return defaultMessage;
-    }
+  /**
+   * エラーコードに紐づくデフォルトメッセージを返します。
+   *
+   * @return デフォルトメッセージ
+   */
+  public String defaultMessage() {
+    return defaultMessage;
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListRequest.java
@@ -2,15 +2,14 @@ package com.atoook.otsukailist.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/**
- * Item List の作成・更新リクエスト用DTO
- */
+/** Item List の作成・更新リクエスト用DTO */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,7 +17,7 @@ import lombok.Setter;
 @Builder
 public class CreateItemListRequest {
 
-    @NotBlank(message = "リスト名は必須です")
-    @Size(max = 100, message = "リスト名は100文字以下にしてください")
-    private String name;
+  @NotBlank(message = "リスト名は必須です")
+  @Size(max = 100, message = "リスト名は100文字以下にしてください")
+  private String name;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListRequest.java
@@ -2,14 +2,13 @@ package com.atoook.otsukailist.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/** Item List の作成・更新リクエスト用DTO */
+/** Item List の作成リクエスト用DTO */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequest.java
@@ -3,8 +3,9 @@ package com.atoook.otsukailist.dto;
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,17 +19,14 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CreateItemListWithMembersRequest {
 
-    @NotBlank(message = "リスト名は必須です")
-    @Size(max = 100, message = "リスト名は100文字以下にしてください")
-    private String name;
+  @NotBlank(message = "リスト名は必須です")
+  @Size(max = 100, message = "リスト名は100文字以下にしてください")
+  private String name;
 
-    /**
-     * 初期メンバー名一覧
-     * - UI側で 1人以上を想定するなら min=1
-     * - 上限は適当（例: 20）
-     */
-    @NotNull(message = "メンバー一覧は必須です")
-    @Size(min = 1, max = 20, message = "メンバーは1〜20名で指定してください")
-    private List<@NotBlank(message = "メンバー名は必須です") @Size(max = 80, message = "メンバー名は80文字以下にしてください") String> memberNames;
-
+  /** 初期メンバー名一覧 - UI側で 1人以上を想定するなら min=1 - 上限は適当（例: 20） */
+  @NotNull(message = "メンバー一覧は必須です")
+  @Size(min = 1, max = 20, message = "メンバーは1〜20名で指定してください")
+  private List<
+          @NotBlank(message = "メンバー名は必須です") @Size(max = 80, message = "メンバー名は80文字以下にしてください") String>
+      memberNames;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersResponse.java
@@ -14,7 +14,6 @@ public class CreateItemListWithMembersResponse {
 
     private UUID listId;
     private String name;
-    private long revision;
 
     private List<MemberResponse> members;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersResponse.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 @Builder
 public class CreateItemListWithMembersResponse {
 
-    private UUID listId;
-    private String name;
+  private UUID listId;
+  private String name;
 
-    private List<MemberResponse> members;
+  private List<MemberResponse> members;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java
@@ -2,15 +2,14 @@ package com.atoook.otsukailist.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/**
- * Item の作成リクエスト用DTO
- */
+/** Item の作成リクエスト用DTO */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,11 +17,10 @@ import lombok.Setter;
 @Builder
 public class CreateItemRequest {
 
-    @NotBlank(message = "アイテム名は必須です")
-    @Size(max = 200, message = "アイテム名は200文字以下にしてください")
-    private String name;
+  @NotBlank(message = "アイテム名は必須です")
+  @Size(max = 200, message = "アイテム名は200文字以下にしてください")
+  private String name;
 
-    // 作成時に完了状態を指定可能（デフォルト: false）
-    @Builder.Default
-    private boolean completed = false;
+  // 作成時に完了状態を指定可能（デフォルト: false）
+  @Builder.Default private boolean completed = false;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java
@@ -2,7 +2,6 @@ package com.atoook.otsukailist.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,9 +17,10 @@ import lombok.Setter;
 public class CreateItemRequest {
 
   @NotBlank(message = "アイテム名は必須です")
-  @Size(max = 200, message = "アイテム名は200文字以下にしてください")
+  @Size(max = 100, message = "アイテム名は100文字以下にしてください")
   private String name;
 
   // 作成時に完了状態を指定可能（デフォルト: false）
-  @Builder.Default private boolean completed = false;
+  @Builder.Default
+  private boolean completed = false;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateMemberRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateMemberRequest.java
@@ -2,6 +2,7 @@ package com.atoook.otsukailist.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import lombok.Setter;
 @Builder
 public class CreateMemberRequest {
 
-    @NotBlank(message = "メンバー名は必須です")
-    @Size(max = 80, message = "メンバー名は80文字以下にしてください")
-    private String displayName;
+  @NotBlank(message = "メンバー名は必須です")
+  @Size(max = 80, message = "メンバー名は80文字以下にしてください")
+  private String displayName;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/DeleteItemResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/DeleteItemResponse.java
@@ -10,5 +10,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class DeleteItemResponse {
-    private UUID deletedItemId;
+  private UUID deletedItemId;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/DeleteMemberResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/DeleteMemberResponse.java
@@ -1,6 +1,7 @@
 package com.atoook.otsukailist.dto;
 
 import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,5 +10,5 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class DeleteMemberResponse {
-    private UUID deletedMemberId;
+  private UUID deletedMemberId;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ItemListResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ItemListResponse.java
@@ -19,8 +19,6 @@ public class ItemListResponse {
 
     private String name;
 
-    private long revision;
-
     private Instant createdAt;
 
     private Instant updatedAt;

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ItemListResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ItemListResponse.java
@@ -7,19 +7,17 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * Item List のレスポンス用DTO
- */
+/** Item List のレスポンス用DTO */
 @Getter
 @AllArgsConstructor
 @Builder
 public class ItemListResponse {
 
-    private UUID id;
+  private UUID id;
 
-    private String name;
+  private String name;
 
-    private Instant createdAt;
+  private Instant createdAt;
 
-    private Instant updatedAt;
+  private Instant updatedAt;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ItemListSnapshotResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ItemListSnapshotResponse.java
@@ -9,34 +9,27 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * Item List のSnapshotレスポンス用DTO
- * * <MEMO>
- * * このDTOは Service で
- * * listRepo.findById
- * * memberRepo.findByItemListId
- * * itemRepo.findByItemListId
- * * で集めて作る（Mapperは個別に ItemMapper/MemberMapper を使う）
- * * → N+1を踏まない。
+ * Item List のSnapshotレスポンス用DTO * <MEMO> * このDTOは Service で * listRepo.findById *
+ * memberRepo.findByItemListId * itemRepo.findByItemListId * で集めて作る（Mapperは個別に
+ * ItemMapper/MemberMapper を使う） * → N+1を踏まない。
  */
 @Getter
 @AllArgsConstructor
 @Builder
 public class ItemListSnapshotResponse {
 
-    private UUID listId;
-    private String name;
+  private UUID listId;
+  private String name;
 
-    /** Socket差分の基準（リスト単位） */
-    private long revision;
+  /** Socket差分の基準（リスト単位） */
+  private long revision;
 
-    /** UI表示用 */
-    private int itemCount;
+  /** UI表示用 */
+  private int itemCount;
 
-    /** 任意：クライアントの基準時刻 */
-    private Instant serverTime;
+  /** 任意：クライアントの基準時刻 */
+  private Instant serverTime;
 
-    @Builder.Default
-    private List<MemberResponse> members = List.of();
-    @Builder.Default
-    private List<ItemResponse> items = List.of();
+  @Builder.Default private List<MemberResponse> members = List.of();
+  @Builder.Default private List<ItemResponse> items = List.of();
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ItemResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ItemResponse.java
@@ -8,26 +8,24 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * Item のレスポンス用DTO
- */
+/** Item のレスポンス用DTO */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ItemResponse {
 
-    private UUID id;
+  private UUID id;
 
-    private String name;
+  private String name;
 
-    private boolean completed;
+  private boolean completed;
 
-    private UUID completedByMemberId;
+  private UUID completedByMemberId;
 
-    private Instant completedAt;
+  private Instant completedAt;
 
-    private Instant createdAt;
+  private Instant createdAt;
 
-    private Instant updatedAt;
+  private Instant updatedAt;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/MemberResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/MemberResponse.java
@@ -12,11 +12,11 @@ import lombok.Getter;
 @Builder
 public class MemberResponse {
 
-    private UUID id;
+  private UUID id;
 
-    private String displayName;
+  private String displayName;
 
-    private Instant createdAt;
+  private Instant createdAt;
 
-    private Instant updatedAt;
+  private Instant updatedAt;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/MutationResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/MutationResponse.java
@@ -1,13 +1,13 @@
 package com.atoook.otsukailist.dto;
 
-import lombok.Getter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class MutationResponse<T> {
-    private long revision;
-    private T data;
+  private long revision;
+  private T data;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemListRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemListRequest.java
@@ -1,17 +1,15 @@
 package com.atoook.otsukailist.dto;
 
-import jakarta.validation.constraints.Size;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/**
- * ItemList の更新リクエスト用DTO
- * - 名前の変更
- */
+/** ItemList の更新リクエスト用DTO - 名前の変更 */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -19,7 +17,7 @@ import lombok.Setter;
 @Builder
 public class UpdateItemListRequest {
 
-    @NotBlank
-    @Size(max = 100, message = "リスト名は100文字以下にしてください")
-    private String name;
+  @NotBlank
+  @Size(max = 100, message = "リスト名は100文字以下にしてください")
+  private String name;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java
@@ -2,6 +2,7 @@ package com.atoook.otsukailist.dto;
 
 import java.util.UUID;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,7 @@ import lombok.Setter;
 public class UpdateItemRequest {
 
   // 名前は任意更新（nullの場合は更新しない）
+  @Size(max = 100, message = "アイテム名は100文字以下にしてください")
   private String name;
 
   // 完了状態（nullの場合は更新しない）

--- a/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java
@@ -8,11 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-/**
- * Item の更新リクエスト用DTO
- * - 完了状態の変更
- * - 名前の変更
- */
+/** Item の更新リクエスト用DTO - 完了状態の変更 - 名前の変更 */
 @Getter
 @Setter
 @NoArgsConstructor
@@ -20,12 +16,12 @@ import lombok.Setter;
 @Builder
 public class UpdateItemRequest {
 
-    // 名前は任意更新（nullの場合は更新しない）
-    private String name;
+  // 名前は任意更新（nullの場合は更新しない）
+  private String name;
 
-    // 完了状態（nullの場合は更新しない）
-    private Boolean completed;
+  // 完了状態（nullの場合は更新しない）
+  private Boolean completed;
 
-    // completed=true のとき必須（未完了に戻すときは不要）
-    private UUID completedByMemberId;
+  // completed=true のとき必須（未完了に戻すときは不要）
+  private UUID completedByMemberId;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/exception/BadRequestException.java
+++ b/backend/src/main/java/com/atoook/otsukailist/exception/BadRequestException.java
@@ -1,28 +1,24 @@
 package com.atoook.otsukailist.exception;
 
-/**
- * Signals that the client sent a syntactically correct request whose content is
- * invalid.
- */
+/** Signals that the client sent a syntactically correct request whose content is invalid. */
 public class BadRequestException extends RuntimeException {
 
-    /**
-     * Create exception with message.
-     *
-     * @param message detail text
-     */
-    public BadRequestException(String message) {
-        super(message);
-    }
+  /**
+   * Create exception with message.
+   *
+   * @param message detail text
+   */
+  public BadRequestException(String message) {
+    super(message);
+  }
 
-    /**
-     * Create exception with message and cause.
-     *
-     * @param message detail text
-     * @param cause   root cause
-     */
-    public BadRequestException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
+  /**
+   * Create exception with message and cause.
+   *
+   * @param message detail text
+   * @param cause root cause
+   */
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/atoook/otsukailist/exception/ResourceNotFoundException.java
@@ -1,26 +1,24 @@
 package com.atoook.otsukailist.exception;
 
-/**
- * サービス層でリソース未発見を表す例外。
- */
+/** サービス層でリソース未発見を表す例外。 */
 public class ResourceNotFoundException extends RuntimeException {
 
-    /**
-     * Create exception with message.
-     *
-     * @param message detail text
-     */
-    public ResourceNotFoundException(String message) {
-        super(message);
-    }
+  /**
+   * Create exception with message.
+   *
+   * @param message detail text
+   */
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
 
-    /**
-     * Create exception with message and cause.
-     *
-     * @param message detail text
-     * @param cause root cause
-     */
-    public ResourceNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  /**
+   * Create exception with message and cause.
+   *
+   * @param message detail text
+   * @param cause root cause
+   */
+  public ResourceNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/mapper/ItemListMapper.java
+++ b/backend/src/main/java/com/atoook/otsukailist/mapper/ItemListMapper.java
@@ -6,52 +6,44 @@ import com.atoook.otsukailist.model.ItemList;
 
 import lombok.experimental.UtilityClass;
 
-/**
- * ItemList Entity ↔ DTO 変換用マッパー
- */
+/** ItemList Entity ↔ DTO 変換用マッパー */
 @UtilityClass
 public class ItemListMapper {
 
-    /**
-     * Entity → Response DTO 変換
-     */
-    public static ItemListResponse toResponse(ItemList entity) {
-        if (entity == null) {
-            return null;
-        }
-
-        return ItemListResponse.builder()
-                .id(entity.getId())
-                .name(entity.getName().trim())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
+  /** Entity → Response DTO 変換 */
+  public static ItemListResponse toResponse(ItemList entity) {
+    if (entity == null) {
+      return null;
     }
 
-    /**
-     * Request DTO → Entity 変換（新規作成時）
-     */
-    public static ItemList toEntity(CreateItemListRequest request) {
-        if (request == null) {
-            return null;
-        }
+    return ItemListResponse.builder()
+        .id(entity.getId())
+        .name(entity.getName().trim())
+        .createdAt(entity.getCreatedAt())
+        .updatedAt(entity.getUpdatedAt())
+        .build();
+  }
 
-        ItemList entity = new ItemList();
-        entity.setName(request.getName().trim());
-        // revision は DB default(0) / entity の初期値(0L) に任せる
-        return entity;
+  /** Request DTO → Entity 変換（新規作成時） */
+  public static ItemList toEntity(CreateItemListRequest request) {
+    if (request == null) {
+      return null;
     }
 
-    /**
-     * Request DTO で既存 Entity を更新
-     */
-    public static void updateEntity(ItemList entity, CreateItemListRequest request) {
-        if (entity == null || request == null) {
-            return;
-        }
+    ItemList entity = new ItemList();
+    entity.setName(request.getName().trim());
+    // revision は DB default(0) / entity の初期値(0L) に任せる
+    return entity;
+  }
 
-        if (request.getName() != null) {
-            entity.setName(request.getName().trim());
-        }
+  /** Request DTO で既存 Entity を更新 */
+  public static void updateEntity(ItemList entity, CreateItemListRequest request) {
+    if (entity == null || request == null) {
+      return;
     }
+
+    if (request.getName() != null) {
+      entity.setName(request.getName().trim());
+    }
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/mapper/ItemListMapper.java
+++ b/backend/src/main/java/com/atoook/otsukailist/mapper/ItemListMapper.java
@@ -23,7 +23,6 @@ public class ItemListMapper {
         return ItemListResponse.builder()
                 .id(entity.getId())
                 .name(entity.getName().trim())
-                .revision(entity.getRevision())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();

--- a/backend/src/main/java/com/atoook/otsukailist/mapper/ItemMapper.java
+++ b/backend/src/main/java/com/atoook/otsukailist/mapper/ItemMapper.java
@@ -8,66 +8,54 @@ import com.atoook.otsukailist.model.ItemList;
 
 import lombok.experimental.UtilityClass;
 
-/**
- * Item Entity ↔ DTO 変換用マッパー
- */
+/** Item Entity ↔ DTO 変換用マッパー */
 @UtilityClass
 public class ItemMapper {
 
-    /**
-     * Entity → Response DTO 変換
-     */
-    public static ItemResponse toResponse(Item entity) {
-        if (entity == null) {
-            return null;
-        }
-
-        return ItemResponse.builder()
-                .id(entity.getId())
-                .name(entity.getName().trim())
-                .completed(entity.isCompleted())
-                .completedByMemberId(entity.getCompletedByMemberId())
-                .completedAt(entity.getCompletedAt())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
+  /** Entity → Response DTO 変換 */
+  public static ItemResponse toResponse(Item entity) {
+    if (entity == null) {
+      return null;
     }
 
-    /**
-     * Request DTO → Entity 変換（新規作成時）
-     */
-    public static Item toEntity(CreateItemRequest request, ItemList itemList) {
-        if (request == null) {
-            return null;
-        }
+    return ItemResponse.builder()
+        .id(entity.getId())
+        .name(entity.getName().trim())
+        .completed(entity.isCompleted())
+        .completedByMemberId(entity.getCompletedByMemberId())
+        .completedAt(entity.getCompletedAt())
+        .createdAt(entity.getCreatedAt())
+        .updatedAt(entity.getUpdatedAt())
+        .build();
+  }
 
-        Item entity = new Item();
-        entity.setName(request.getName().trim());
-        entity.setCompleted(request.isCompleted());
-        entity.setItemList(itemList);
-
-        return entity;
+  /** Request DTO → Entity 変換（新規作成時） */
+  public static Item toEntity(CreateItemRequest request, ItemList itemList) {
+    if (request == null) {
+      return null;
     }
 
-    /**
-     * Update Request DTO で既存 Entity を更新（名前のみ）
-     * 完了/未完了の更新は Service の責務とするためここでは行わない
-     * なぜこの分離が重要か（設計的理由）
-     * - Mapper：純粋変換
-     * - Service：業務ルールと整合性
-     * この分離をしておくと：
-     * - 後で status に拡張しても Mapper を触らずに済む
-     * - Socket対応（完了イベント）も Service に閉じ込められる
-     * - テストが書きやすい（Mapperは単純、Serviceは業務テスト）
-     */
-    public static void updateEntity(Item entity, UpdateItemRequest request) {
-        if (entity == null || request == null) {
-            return;
-        }
+    Item entity = new Item();
+    entity.setName(request.getName().trim());
+    entity.setCompleted(request.isCompleted());
+    entity.setItemList(itemList);
 
-        // 名前の更新（nullでない場合のみ）
-        if (request.getName() != null) {
-            entity.setName(request.getName().trim());
-        }
+    return entity;
+  }
+
+  /**
+   * Update Request DTO で既存 Entity を更新（名前のみ） 完了/未完了の更新は Service の責務とするためここでは行わない なぜこの分離が重要か（設計的理由） -
+   * Mapper：純粋変換 - Service：業務ルールと整合性 この分離をしておくと： - 後で status に拡張しても Mapper を触らずに済む -
+   * Socket対応（完了イベント）も Service に閉じ込められる - テストが書きやすい（Mapperは単純、Serviceは業務テスト）
+   */
+  public static void updateEntity(Item entity, UpdateItemRequest request) {
+    if (entity == null || request == null) {
+      return;
     }
+
+    // 名前の更新（nullでない場合のみ）
+    if (request.getName() != null) {
+      entity.setName(request.getName().trim());
+    }
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/atoook/otsukailist/mapper/MemberMapper.java
@@ -7,49 +7,43 @@ import com.atoook.otsukailist.model.Member;
 
 import lombok.experimental.UtilityClass;
 
-/**
- * Member Entity ↔ DTO 変換用マッパー
- */
+/** Member Entity ↔ DTO 変換用マッパー */
 @UtilityClass
 public class MemberMapper {
 
-    public static MemberResponse toResponse(Member entity) {
-        if (entity == null) {
-            return null;
-        }
-
-        return MemberResponse.builder()
-                .id(entity.getId())
-                .displayName(entity.getDisplayName().trim())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
+  public static MemberResponse toResponse(Member entity) {
+    if (entity == null) {
+      return null;
     }
 
-    /**
-     * 新規作成時：list は Service が確定させて渡す（N+1回避＆存在確認）
-     */
-    public static Member toEntity(CreateMemberRequest request, ItemList itemList) {
-        if (request == null) {
-            return null;
-        }
+    return MemberResponse.builder()
+        .id(entity.getId())
+        .displayName(entity.getDisplayName().trim())
+        .createdAt(entity.getCreatedAt())
+        .updatedAt(entity.getUpdatedAt())
+        .build();
+  }
 
-        Member entity = new Member();
-        entity.setDisplayName(request.getDisplayName().trim());
-        entity.setItemList(itemList);
-        return entity;
+  /** 新規作成時：list は Service が確定させて渡す（N+1回避＆存在確認） */
+  public static Member toEntity(CreateMemberRequest request, ItemList itemList) {
+    if (request == null) {
+      return null;
     }
 
-    /**
-     * 既存更新: displayName のみ
-     */
-    public static void updateEntity(Member entity, CreateMemberRequest request) {
-        if (entity == null || request == null) {
-            return;
-        }
+    Member entity = new Member();
+    entity.setDisplayName(request.getDisplayName().trim());
+    entity.setItemList(itemList);
+    return entity;
+  }
 
-        if (request.getDisplayName() != null) {
-            entity.setDisplayName(request.getDisplayName().trim());
-        }
+  /** 既存更新: displayName のみ */
+  public static void updateEntity(Member entity, CreateMemberRequest request) {
+    if (entity == null || request == null) {
+      return;
     }
+
+    if (request.getDisplayName() != null) {
+      entity.setDisplayName(request.getDisplayName().trim());
+    }
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/atoook/otsukailist/mapper/MemberMapper.java
@@ -11,39 +11,37 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class MemberMapper {
 
-  public static MemberResponse toResponse(Member entity) {
-    if (entity == null) {
-      return null;
+    public static MemberResponse toResponse(Member entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        return MemberResponse.builder()
+                .id(entity.getId())
+                .displayName(entity.getDisplayName().trim())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
     }
 
-    return MemberResponse.builder()
-        .id(entity.getId())
-        .displayName(entity.getDisplayName().trim())
-        .createdAt(entity.getCreatedAt())
-        .updatedAt(entity.getUpdatedAt())
-        .build();
-  }
+    /** 新規作成時：list は Service が確定させて渡す（N+1回避＆存在確認） */
+    public static Member toEntity(CreateMemberRequest request, ItemList itemList) {
+        if (request == null) {
+            return null;
+        }
 
-  /** 新規作成時：list は Service が確定させて渡す（N+1回避＆存在確認） */
-  public static Member toEntity(CreateMemberRequest request, ItemList itemList) {
-    if (request == null) {
-      return null;
+        Member entity = new Member();
+        entity.setDisplayName(request.getDisplayName().trim());
+        entity.setItemList(itemList);
+        return entity;
     }
 
-    Member entity = new Member();
-    entity.setDisplayName(request.getDisplayName().trim());
-    entity.setItemList(itemList);
-    return entity;
-  }
+    /** 既存更新: displayName のみ */
+    public static void updateEntity(Member entity, CreateMemberRequest request) {
+        if (entity == null || request == null) {
+            return;
+        }
 
-  /** 既存更新: displayName のみ */
-  public static void updateEntity(Member entity, CreateMemberRequest request) {
-    if (entity == null || request == null) {
-      return;
+        entity.setDisplayName(request.getDisplayName().trim());
     }
-
-    if (request.getDisplayName() != null) {
-      entity.setDisplayName(request.getDisplayName().trim());
-    }
-  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/model/Item.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/Item.java
@@ -10,15 +10,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
-
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @Setter
@@ -26,37 +26,37 @@ import lombok.Setter;
 @Entity
 @Table(name = "item")
 public class Item {
-    @Id
-    @UuidGenerator
-    @JdbcTypeCode(SqlTypes.BINARY)
-    @Column(name = "id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
-    private UUID id;
+  @Id
+  @UuidGenerator
+  @JdbcTypeCode(SqlTypes.BINARY)
+  @Column(name = "id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+  private UUID id;
 
-    @Column(name = "name", nullable = false, length = 255)
-    private String name;
+  @Column(name = "name", nullable = false, length = 255)
+  private String name;
 
-    // DB物理名: is_completed（TINYINT(1)）
-    @Column(name = "is_completed", nullable = false)
-    private boolean completed;
+  // DB物理名: is_completed（TINYINT(1)）
+  @Column(name = "is_completed", nullable = false)
+  private boolean completed;
 
-    // 誰が完了させたか（member.id）。未完了のときはNULL。
-    @JdbcTypeCode(SqlTypes.BINARY)
-    @Column(name = "completed_by_member_id", columnDefinition = "BINARY(16)")
-    private UUID completedByMemberId;
+  // 誰が完了させたか（member.id）。未完了のときはNULL。
+  @JdbcTypeCode(SqlTypes.BINARY)
+  @Column(name = "completed_by_member_id", columnDefinition = "BINARY(16)")
+  private UUID completedByMemberId;
 
-    // いつ完了させたか。未完了のときはNULL。
-    @Column(name = "completed_at")
-    private Instant completedAt;
+  // いつ完了させたか。未完了のときはNULL。
+  @Column(name = "completed_at")
+  private Instant completedAt;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt;
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "list_id", nullable = false)
-    private ItemList itemList;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "list_id", nullable = false)
+  private ItemList itemList;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/model/ItemList.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/ItemList.java
@@ -1,13 +1,9 @@
 package com.atoook.otsukailist.model;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
-
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -15,10 +11,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
-import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 @Getter
@@ -27,29 +27,29 @@ import org.hibernate.type.SqlTypes;
 @Entity
 @Table(name = "item_list")
 public class ItemList {
-    @Id
-    @UuidGenerator
-    @JdbcTypeCode(SqlTypes.BINARY) // UUIDをBINARY(16)として扱う
-    @Column(name = "id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
-    private UUID id;
+  @Id
+  @UuidGenerator
+  @JdbcTypeCode(SqlTypes.BINARY) // UUIDをBINARY(16)として扱う
+  @Column(name = "id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+  private UUID id;
 
-    @Column(name = "name", nullable = false, length = 100)
-    private String name;
+  @Column(name = "name", nullable = false, length = 100)
+  private String name;
 
-    @Column(name = "revision", nullable = false)
-    private long revision = 0L;
+  @Column(name = "revision", nullable = false)
+  private long revision = 0L;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt;
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
 
-    @OneToMany(mappedBy = "itemList", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Item> items = new ArrayList<>();
+  @OneToMany(mappedBy = "itemList", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Item> items = new ArrayList<>();
 
-    @OneToMany(mappedBy = "itemList", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Member> members = new ArrayList<>();
+  @OneToMany(mappedBy = "itemList", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Member> members = new ArrayList<>();
 }

--- a/backend/src/main/java/com/atoook/otsukailist/model/Member.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/Member.java
@@ -6,51 +6,54 @@ import java.util.UUID;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import jakarta.persistence.Id;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.type.SqlTypes;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 @Getter
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "member", uniqueConstraints = {
-        @UniqueConstraint(name = "uq_member_list_name", columnNames = { "list_id", "display_name" })
-}, indexes = {
-        @Index(name = "idx_member_list_id", columnList = "list_id")
-})
+@Table(
+    name = "member",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uq_member_list_name",
+          columnNames = {"list_id", "display_name"})
+    },
+    indexes = {@Index(name = "idx_member_list_id", columnList = "list_id")})
 public class Member {
 
-    @Id
-    @UuidGenerator
-    @JdbcTypeCode(SqlTypes.BINARY)
-    @Column(name = "id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
-    private UUID id;
+  @Id
+  @UuidGenerator
+  @JdbcTypeCode(SqlTypes.BINARY)
+  @Column(name = "id", columnDefinition = "BINARY(16)", nullable = false, updatable = false)
+  private UUID id;
 
-    @Column(name = "display_name", nullable = false, length = 80)
-    private String displayName;
+  @Column(name = "display_name", nullable = false, length = 80)
+  private String displayName;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
 
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt;
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "list_id", nullable = false)
-    private ItemList itemList;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "list_id", nullable = false)
+  private ItemList itemList;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemListRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemListRepository.java
@@ -1,7 +1,7 @@
 package com.atoook.otsukailist.repository;
 
-import java.util.UUID;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,18 +11,18 @@ import org.springframework.data.repository.query.Param;
 import com.atoook.otsukailist.model.ItemList;
 
 public interface ItemListRepository extends JpaRepository<ItemList, UUID> {
-    // 基本的なCRUD操作は JpaRepository が自動提供
-    // - findById(UUID id)
-    // - findAll()
-    // - save(ItemList entity)
-    // - deleteById(UUID id)
-    // - count()
-    // - existsById(UUID id)
+  // 基本的なCRUD操作は JpaRepository が自動提供
+  // - findById(UUID id)
+  // - findAll()
+  // - save(ItemList entity)
+  // - deleteById(UUID id)
+  // - count()
+  // - existsById(UUID id)
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update ItemList l set l.revision = l.revision + 1 where l.id = :listId")
-    int incrementRevision(@Param("listId") UUID listId);
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("update ItemList l set l.revision = l.revision + 1 where l.id = :listId")
+  int incrementRevision(@Param("listId") UUID listId);
 
-    @Query("select l.revision from ItemList l where l.id = :listId")
-    Optional<Long> findRevision(@Param("listId") UUID listId);
+  @Query("select l.revision from ItemList l where l.id = :listId")
+  Optional<Long> findRevision(@Param("listId") UUID listId);
 }

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
@@ -9,15 +9,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.atoook.otsukailist.model.Item;
 
 public interface ItemRepository extends JpaRepository<Item, UUID> {
-    // 基本的なCRUD操作は JpaRepository が自動提供
-    // ※ findAll() や条件なし検索は使用禁止（設計思想に反する）
+  // 基本的なCRUD操作は JpaRepository が自動提供
+  // ※ findAll() や条件なし検索は使用禁止（設計思想に反する）
 
-    // 特定のアイテムリストのアイテムを取得（必須：リストIDでスコープ）
-    List<Item> findByItemListId(UUID itemListId);
+  // 特定のアイテムリストのアイテムを取得（必須：リストIDでスコープ）
+  List<Item> findByItemListId(UUID itemListId);
 
-    // 特定のアイテムを取得
-    Optional<Item> findByIdAndItemListId(UUID itemId, UUID itemListId);
+  // 特定のアイテムを取得
+  Optional<Item> findByIdAndItemListId(UUID itemId, UUID itemListId);
 
-    // リスト内のアイテム存在チェック
-    boolean existsByIdAndItemListId(UUID itemId, UUID itemListId);
+  // リスト内のアイテム存在チェック
+  boolean existsByIdAndItemListId(UUID itemId, UUID itemListId);
 }

--- a/backend/src/main/java/com/atoook/otsukailist/repository/MemberRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/MemberRepository.java
@@ -9,10 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.atoook.otsukailist.model.Member;
 
 public interface MemberRepository extends JpaRepository<Member, UUID> {
-    List<Member> findByItemListId(UUID listId);
+  List<Member> findByItemListId(UUID listId);
 
-    Optional<Member> findByIdAndItemListId(UUID id, UUID listId);
+  Optional<Member> findByIdAndItemListId(UUID id, UUID listId);
 
-    boolean existsByIdAndItemListId(UUID id, UUID listId);
-
+  boolean existsByIdAndItemListId(UUID id, UUID listId);
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
@@ -1,24 +1,24 @@
 package com.atoook.otsukailist.service;
 
-import java.util.UUID;
 import java.time.Instant;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.atoook.otsukailist.model.Item;
-import com.atoook.otsukailist.repository.ItemRepository;
-import com.atoook.otsukailist.repository.ItemListRepository;
-import com.atoook.otsukailist.repository.MemberRepository;
-import com.atoook.otsukailist.dto.UpdateItemRequest;
-import com.atoook.otsukailist.dto.ItemResponse;
 import com.atoook.otsukailist.dto.CreateItemRequest;
-import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.DeleteItemResponse;
-import com.atoook.otsukailist.model.ItemList;
-import com.atoook.otsukailist.mapper.ItemMapper;
-import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.UpdateItemRequest;
 import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.mapper.ItemMapper;
+import com.atoook.otsukailist.model.Item;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ItemRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
 
 import lombok.RequiredArgsConstructor;
@@ -27,102 +27,107 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ItemCommandService {
 
-    private final ItemRepository itemRepo;
-    private final ItemListRepository itemListRepo;
-    private final MemberRepository memberRepo;
+  private final ItemRepository itemRepo;
+  private final ItemListRepository itemListRepo;
+  private final MemberRepository memberRepo;
 
-    private final ListRevisionService listRevisionService;
+  private final ListRevisionService listRevisionService;
 
-    private static final String MSG_MEMBER_NOT_IN_LIST = "指定された完了者はリストのメンバーではありません";
-    private static final String MSG_COMPLETED_BY_NOT_SPECIFIED = "完了者が未指定です";
+  private static final String MSG_MEMBER_NOT_IN_LIST = "指定された完了者はリストのメンバーではありません";
+  private static final String MSG_COMPLETED_BY_NOT_SPECIFIED = "完了者が未指定です";
 
-    /**
-     * Item追加（listIdスコープ）
-     * - 完了状態を作成時に許可するなら completedByMemberId もDTOに追加するのが整合的
-     * - ミニマムなら「作成時は未完了固定」を推奨
-     */
-    @Transactional
-    public MutationResponse<ItemResponse> createItem(UUID listId, CreateItemRequest req) {
-        // list存在確認
-        ItemList list = itemListRepo.findById(listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+  /**
+   * Item追加（listIdスコープ） - 完了状態を作成時に許可するなら completedByMemberId もDTOに追加するのが整合的 - ミニマムなら「作成時は未完了固定」を推奨
+   */
+  @Transactional
+  public MutationResponse<ItemResponse> createItem(UUID listId, CreateItemRequest req) {
+    // list存在確認
+    ItemList list =
+        itemListRepo
+            .findById(listId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
 
-        // Entity作成（ミニマム：作成時は未完了固定）
-        Item item = new Item();
-        item.setName(req.getName().trim());
+    // Entity作成（ミニマム：作成時は未完了固定）
+    Item item = new Item();
+    item.setName(req.getName().trim());
+    item.setCompleted(false);
+    item.setCompletedByMemberId(null);
+    item.setCompletedAt(null);
+    item.setItemList(list);
+
+    Item saved = itemRepo.save(item);
+
+    long revision = listRevisionService.incrementAndGet(listId);
+
+    return MutationResponse.<ItemResponse>builder()
+        .revision(revision)
+        .data(ItemMapper.toResponse(saved))
+        .build();
+  }
+
+  /** Item更新（rename / setCompleted） */
+  @Transactional
+  public MutationResponse<ItemResponse> updateItem(
+      UUID listId, UUID itemId, UpdateItemRequest req) {
+    Item item =
+        itemRepo
+            .findByIdAndItemListId(itemId, listId)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
+
+    // rename（Mapperは name のみ更新）
+    ItemMapper.updateEntity(item, req);
+
+    // completion（業務ロジック）
+    if (req.getCompleted() != null) {
+      if (req.getCompleted()) {
+        if (req.getCompletedByMemberId() == null) {
+          throw new BadRequestException(MSG_COMPLETED_BY_NOT_SPECIFIED);
+        }
+        boolean exists = memberRepo.existsByIdAndItemListId(req.getCompletedByMemberId(), listId);
+        if (!exists) {
+          throw new BadRequestException(MSG_MEMBER_NOT_IN_LIST);
+        }
+        item.setCompleted(true);
+        item.setCompletedByMemberId(req.getCompletedByMemberId());
+        item.setCompletedAt(Instant.now());
+      } else {
         item.setCompleted(false);
         item.setCompletedByMemberId(null);
         item.setCompletedAt(null);
-        item.setItemList(list);
-
-        Item saved = itemRepo.save(item);
-
-        long revision = listRevisionService.incrementAndGet(listId);
-
-        return MutationResponse.<ItemResponse>builder()
-                .revision(revision)
-                .data(ItemMapper.toResponse(saved))
-                .build();
+      }
     }
 
-    /**
-     * Item更新（rename / setCompleted）
-     */
-    @Transactional
-    public MutationResponse<ItemResponse> updateItem(UUID listId, UUID itemId, UpdateItemRequest req) {
-        Item item = itemRepo.findByIdAndItemListId(itemId, listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
+    Item saved = itemRepo.save(item);
 
-        // rename（Mapperは name のみ更新）
-        ItemMapper.updateEntity(item, req);
+    long revision = listRevisionService.incrementAndGet(listId);
 
-        // completion（業務ロジック）
-        if (req.getCompleted() != null) {
-            if (req.getCompleted()) {
-                if (req.getCompletedByMemberId() == null) {
-                    throw new BadRequestException(MSG_COMPLETED_BY_NOT_SPECIFIED);
-                }
-                boolean exists = memberRepo.existsByIdAndItemListId(req.getCompletedByMemberId(), listId);
-                if (!exists) {
-                    throw new BadRequestException(MSG_MEMBER_NOT_IN_LIST);
-                }
-                item.setCompleted(true);
-                item.setCompletedByMemberId(req.getCompletedByMemberId());
-                item.setCompletedAt(Instant.now());
-            } else {
-                item.setCompleted(false);
-                item.setCompletedByMemberId(null);
-                item.setCompletedAt(null);
-            }
-        }
+    return MutationResponse.<ItemResponse>builder()
+        .revision(revision)
+        .data(ItemMapper.toResponse(saved))
+        .build();
+  }
 
-        Item saved = itemRepo.save(item);
+  /** Item削除（listIdスコープ） */
+  @Transactional
+  public MutationResponse<DeleteItemResponse> deleteItem(UUID listId, UUID itemId) {
+    // listIdスコープで存在確認
+    Item item =
+        itemRepo
+            .findByIdAndItemListId(itemId, listId)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
 
-        long revision = listRevisionService.incrementAndGet(listId);
+    itemRepo.delete(item);
 
-        return MutationResponse.<ItemResponse>builder()
-                .revision(revision)
-                .data(ItemMapper.toResponse(saved))
-                .build();
-    }
+    long revision = listRevisionService.incrementAndGet(listId);
 
-    /**
-     * Item削除（listIdスコープ）
-     */
-    @Transactional
-    public MutationResponse<DeleteItemResponse> deleteItem(UUID listId, UUID itemId) {
-        // listIdスコープで存在確認
-        Item item = itemRepo.findByIdAndItemListId(itemId, listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
-
-        itemRepo.delete(item);
-
-        long revision = listRevisionService.incrementAndGet(listId);
-
-        return MutationResponse.<DeleteItemResponse>builder()
-                .revision(revision)
-                .data(DeleteItemResponse.builder().deletedItemId(itemId).build())
-                .build();
-    }
-
+    return MutationResponse.<DeleteItemResponse>builder()
+        .revision(revision)
+        .data(DeleteItemResponse.builder().deletedItemId(itemId).build())
+        .build();
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
@@ -42,7 +42,8 @@ public class ListCommandService {
      * @return response that contains stored entities
      */
     @Transactional
-    public CreateItemListWithMembersResponse createListWithMembers(CreateItemListWithMembersRequest req) {
+    public MutationResponse<CreateItemListWithMembersResponse> createListWithMembers(
+            CreateItemListWithMembersRequest req) {
         String listName = req.getName().trim();
 
         ItemList list = new ItemList();
@@ -71,11 +72,15 @@ public class ListCommandService {
         }
         List<Member> savedMembers = memberRepo.saveAll(members);
 
-        return CreateItemListWithMembersResponse.builder()
+        CreateItemListWithMembersResponse data = CreateItemListWithMembersResponse.builder()
                 .listId(savedList.getId())
                 .name(savedList.getName())
-                .revision(savedList.getRevision())
                 .members(savedMembers.stream().map(MemberMapper::toResponse).toList())
+                .build();
+
+        return MutationResponse.<CreateItemListWithMembersResponse>builder()
+                .revision(savedList.getRevision())
+                .data(data)
                 .build();
     }
 
@@ -83,7 +88,7 @@ public class ListCommandService {
      * Rename an existing list and return the latest revision.
      *
      * @param listId identifier of the target list
-     * @param req rename request payload
+     * @param req    rename request payload
      * @return renamed list payload with the incremented revision
      */
     @Transactional

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
@@ -48,7 +48,7 @@ public class ListCommandService {
 
         ItemList list = new ItemList();
         list.setName(listName);
-        ItemList savedList = itemListRepo.save(list);
+        ItemList savedList = itemListRepo.saveAndFlush(list);
 
         // 正規化 + 重複チェック（アプリ側で早期に分かりやすく）
         List<String> names = req.getMemberNames().stream()
@@ -70,7 +70,7 @@ public class ListCommandService {
             m.setItemList(savedList);
             members.add(m);
         }
-        List<Member> savedMembers = memberRepo.saveAll(members);
+        List<Member> savedMembers = memberRepo.saveAllAndFlush(members);
 
         CreateItemListWithMembersResponse data = CreateItemListWithMembersResponse.builder()
                 .listId(savedList.getId())
@@ -99,7 +99,7 @@ public class ListCommandService {
         list.setName(req.getName().trim());
 
         // list保存（updated_at更新）
-        ItemList saved = itemListRepo.save(list);
+        ItemList saved = itemListRepo.saveAndFlush(list);
 
         long revision = listRevisionService.incrementAndGet(listId);
 

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
@@ -9,19 +9,19 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
+import com.atoook.otsukailist.dto.CreateItemListWithMembersResponse;
+import com.atoook.otsukailist.dto.ItemListResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.UpdateItemListRequest;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.mapper.ItemListMapper;
 import com.atoook.otsukailist.mapper.MemberMapper;
 import com.atoook.otsukailist.model.ItemList;
 import com.atoook.otsukailist.model.Member;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
-import com.atoook.otsukailist.dto.ItemListResponse;
-import com.atoook.otsukailist.mapper.ItemListMapper;
-import com.atoook.otsukailist.exception.ResourceNotFoundException;
-import com.atoook.otsukailist.exception.BadRequestException;
-import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
-import com.atoook.otsukailist.dto.CreateItemListWithMembersResponse;
-import com.atoook.otsukailist.dto.MutationResponse;
-import com.atoook.otsukailist.dto.UpdateItemListRequest;
 import com.atoook.otsukailist.service.message.ErrorMessages;
 
 import lombok.RequiredArgsConstructor;
@@ -30,83 +30,84 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ListCommandService {
 
-    private final ItemListRepository itemListRepo;
-    private final MemberRepository memberRepo;
+  private final ItemListRepository itemListRepo;
+  private final MemberRepository memberRepo;
 
-    private final ListRevisionService listRevisionService;
+  private final ListRevisionService listRevisionService;
 
-    /**
-     * Create a list with its initial member set.
-     *
-     * @param req list and member creation request
-     * @return response that contains stored entities
-     */
-    @Transactional
-    public MutationResponse<CreateItemListWithMembersResponse> createListWithMembers(
-            CreateItemListWithMembersRequest req) {
-        String listName = req.getName().trim();
+  /**
+   * Create a list with its initial member set.
+   *
+   * @param req list and member creation request
+   * @return response that contains stored entities
+   */
+  @Transactional
+  public MutationResponse<CreateItemListWithMembersResponse> createListWithMembers(
+      CreateItemListWithMembersRequest req) {
+    String listName = req.getName().trim();
 
-        ItemList list = new ItemList();
-        list.setName(listName);
-        ItemList savedList = itemListRepo.saveAndFlush(list);
+    ItemList list = new ItemList();
+    list.setName(listName);
+    ItemList savedList = itemListRepo.saveAndFlush(list);
 
-        // 正規化 + 重複チェック（アプリ側で早期に分かりやすく）
-        List<String> names = req.getMemberNames().stream()
-                .map(String::trim)
-                .filter(s -> !s.isBlank())
-                .toList();
+    // 正規化 + 重複チェック（アプリ側で早期に分かりやすく）
+    List<String> names =
+        req.getMemberNames().stream().map(String::trim).filter(s -> !s.isBlank()).toList();
 
-        Set<String> seen = new HashSet<>();
-        for (String n : names) {
-            if (!seen.add(n)) {
-                throw new BadRequestException(String.format(ErrorMessages.MEMBER_DUPLICATED, n));
-            }
-        }
-
-        List<Member> members = new ArrayList<>();
-        for (String n : names) {
-            Member m = new Member();
-            m.setDisplayName(n);
-            m.setItemList(savedList);
-            members.add(m);
-        }
-        List<Member> savedMembers = memberRepo.saveAllAndFlush(members);
-
-        CreateItemListWithMembersResponse data = CreateItemListWithMembersResponse.builder()
-                .listId(savedList.getId())
-                .name(savedList.getName())
-                .members(savedMembers.stream().map(MemberMapper::toResponse).toList())
-                .build();
-
-        return MutationResponse.<CreateItemListWithMembersResponse>builder()
-                .revision(savedList.getRevision())
-                .data(data)
-                .build();
+    Set<String> seen = new HashSet<>();
+    for (String n : names) {
+      if (!seen.add(n)) {
+        throw new BadRequestException(String.format(ErrorMessages.MEMBER_DUPLICATED, n));
+      }
     }
 
-    /**
-     * Rename an existing list and return the latest revision.
-     *
-     * @param listId identifier of the target list
-     * @param req    rename request payload
-     * @return renamed list payload with the incremented revision
-     */
-    @Transactional
-    public MutationResponse<ItemListResponse> renameList(UUID listId, UpdateItemListRequest req) {
-        ItemList list = itemListRepo.findById(listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
-
-        list.setName(req.getName().trim());
-
-        // list保存（updated_at更新）
-        ItemList saved = itemListRepo.saveAndFlush(list);
-
-        long revision = listRevisionService.incrementAndGet(listId);
-
-        return MutationResponse.<ItemListResponse>builder()
-                .revision(revision)
-                .data(ItemListMapper.toResponse(saved)) // list単体mapper想定（items触らない）
-                .build();
+    List<Member> members = new ArrayList<>();
+    for (String n : names) {
+      Member m = new Member();
+      m.setDisplayName(n);
+      m.setItemList(savedList);
+      members.add(m);
     }
+    List<Member> savedMembers = memberRepo.saveAllAndFlush(members);
 
+    CreateItemListWithMembersResponse data =
+        CreateItemListWithMembersResponse.builder()
+            .listId(savedList.getId())
+            .name(savedList.getName())
+            .members(savedMembers.stream().map(MemberMapper::toResponse).toList())
+            .build();
+
+    return MutationResponse.<CreateItemListWithMembersResponse>builder()
+        .revision(savedList.getRevision())
+        .data(data)
+        .build();
+  }
+
+  /**
+   * Rename an existing list and return the latest revision.
+   *
+   * @param listId identifier of the target list
+   * @param req rename request payload
+   * @return renamed list payload with the incremented revision
+   */
+  @Transactional
+  public MutationResponse<ItemListResponse> renameList(UUID listId, UpdateItemListRequest req) {
+    ItemList list =
+        itemListRepo
+            .findById(listId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+
+    list.setName(req.getName().trim());
+
+    // list保存（updated_at更新）
+    ItemList saved = itemListRepo.saveAndFlush(list);
+
+    long revision = listRevisionService.incrementAndGet(listId);
+
+    return MutationResponse.<ItemListResponse>builder()
+        .revision(revision)
+        .data(ItemListMapper.toResponse(saved)) // list単体mapper想定（items触らない）
+        .build();
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
@@ -22,38 +22,38 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ListQueryService {
 
-    private final ItemListRepository itemListRepo;
-    private final MemberRepository memberRepo;
-    private final ItemRepository itemRepo;
+  private final ItemListRepository itemListRepo;
+  private final MemberRepository memberRepo;
+  private final ItemRepository itemRepo;
 
-    /**
-     * Retrieve the latest snapshot of a list including members and items.
-     *
-     * @param listId target list ID
-     * @return aggregated snapshot response
-     */
-    @Transactional(readOnly = true)
-    public ItemListSnapshotResponse snapshot(UUID listId) {
-        ItemList list = itemListRepo.findById(listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+  /**
+   * Retrieve the latest snapshot of a list including members and items.
+   *
+   * @param listId target list ID
+   * @return aggregated snapshot response
+   */
+  @Transactional(readOnly = true)
+  public ItemListSnapshotResponse snapshot(UUID listId) {
+    ItemList list =
+        itemListRepo
+            .findById(listId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
 
-        var members = memberRepo.findByItemListId(listId).stream()
-                .map(MemberMapper::toResponse)
-                .toList();
+    var members =
+        memberRepo.findByItemListId(listId).stream().map(MemberMapper::toResponse).toList();
 
-        var itemEntities = itemRepo.findByItemListId(listId);
-        var items = itemEntities.stream()
-                .map(ItemMapper::toResponse)
-                .toList();
+    var itemEntities = itemRepo.findByItemListId(listId);
+    var items = itemEntities.stream().map(ItemMapper::toResponse).toList();
 
-        return ItemListSnapshotResponse.builder()
-                .listId(list.getId())
-                .name(list.getName())
-                .revision(list.getRevision())
-                .itemCount(itemEntities.size())
-                .serverTime(Instant.now())
-                .members(members)
-                .items(items)
-                .build();
-    }
+    return ItemListSnapshotResponse.builder()
+        .listId(list.getId())
+        .name(list.getName())
+        .revision(list.getRevision())
+        .itemCount(itemEntities.size())
+        .serverTime(Instant.now())
+        .members(members)
+        .items(items)
+        .build();
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListRevisionService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListRevisionService.java
@@ -2,7 +2,6 @@ package com.atoook.otsukailist.service;
 
 import java.util.UUID;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,23 +10,24 @@ import com.atoook.otsukailist.exception.ResourceNotFoundException;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class ListRevisionService {
 
-    private final ItemListRepository itemListRepo;
+  private final ItemListRepository itemListRepo;
 
-    /**
-     * listId の revision を原子的に +1 し、更新後revisionを返す。
-     * 呼び出しは「更新系ServiceのTxの中」で行う想定。
-     */
-    @Transactional(propagation = Propagation.MANDATORY)
-    public long incrementAndGet(UUID listId) {
-        int updated = itemListRepo.incrementRevision(listId);
-        if (updated != 1) {
-            throw new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト"));
-        }
-        return itemListRepo.findRevision(listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+  /** listId の revision を原子的に +1 し、更新後revisionを返す。 呼び出しは「更新系ServiceのTxの中」で行う想定。 */
+  @Transactional(propagation = Propagation.MANDATORY)
+  public long incrementAndGet(UUID listId) {
+    int updated = itemListRepo.incrementRevision(listId);
+    if (updated != 1) {
+      throw new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト"));
     }
+    return itemListRepo
+        .findRevision(listId)
+        .orElseThrow(
+            () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/MemberCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/MemberCommandService.java
@@ -5,16 +5,16 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.atoook.otsukailist.repository.ItemListRepository;
-import com.atoook.otsukailist.repository.MemberRepository;
-import com.atoook.otsukailist.dto.MutationResponse;
-import com.atoook.otsukailist.dto.MemberResponse;
 import com.atoook.otsukailist.dto.CreateMemberRequest;
 import com.atoook.otsukailist.dto.DeleteMemberResponse;
-import com.atoook.otsukailist.model.Member;
-import com.atoook.otsukailist.model.ItemList;
-import com.atoook.otsukailist.mapper.MemberMapper;
+import com.atoook.otsukailist.dto.MemberResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.mapper.MemberMapper;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.Member;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
 
 import lombok.RequiredArgsConstructor;
@@ -23,89 +23,101 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberCommandService {
 
-    private final ItemListRepository itemListRepo;
-    private final MemberRepository memberRepo;
+  private final ItemListRepository itemListRepo;
+  private final MemberRepository memberRepo;
 
-    /**
-     * Add a member to the specified list.
-     *
-     * @param listId target list ID
-     * @param req request body with the display name
-     * @return created member payload with the new revision number
-     */
-    @Transactional
-    public MutationResponse<MemberResponse> addMember(UUID listId, CreateMemberRequest req) {
-        ItemList list = itemListRepo.findById(listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+  /**
+   * Add a member to the specified list.
+   *
+   * @param listId target list ID
+   * @param req request body with the display name
+   * @return created member payload with the new revision number
+   */
+  @Transactional
+  public MutationResponse<MemberResponse> addMember(UUID listId, CreateMemberRequest req) {
+    ItemList list =
+        itemListRepo
+            .findById(listId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
 
-        Member member = new Member();
-        member.setDisplayName(req.getDisplayName().trim());
-        member.setItemList(list);
+    Member member = new Member();
+    member.setDisplayName(req.getDisplayName().trim());
+    member.setItemList(list);
 
-        Member saved = memberRepo.save(member);
+    Member saved = memberRepo.save(member);
 
-        long revision = incrementAndGetRevision(listId);
+    long revision = incrementAndGetRevision(listId);
 
-        return MutationResponse.<MemberResponse>builder()
-                .revision(revision)
-                .data(MemberMapper.toResponse(saved))
-                .build();
+    return MutationResponse.<MemberResponse>builder()
+        .revision(revision)
+        .data(MemberMapper.toResponse(saved))
+        .build();
+  }
+
+  /**
+   * Rename an existing member that belongs to the specified list.
+   *
+   * @param listId target list ID
+   * @param memberId member identifier
+   * @param req request body
+   * @return updated member payload with the new revision number
+   */
+  @Transactional
+  public MutationResponse<MemberResponse> renameMember(
+      UUID listId, UUID memberId, CreateMemberRequest req) {
+    Member member =
+        memberRepo
+            .findByIdAndItemListId(memberId, listId)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "メンバー")));
+
+    // Mapperでtrim含めて更新する想定
+    MemberMapper.updateEntity(member, req);
+
+    Member saved = memberRepo.save(member);
+
+    long revision = incrementAndGetRevision(listId);
+
+    return MutationResponse.<MemberResponse>builder()
+        .revision(revision)
+        .data(MemberMapper.toResponse(saved))
+        .build();
+  }
+
+  /**
+   * Remove a member from the specified list.
+   *
+   * @param listId target list ID
+   * @param memberId member identifier
+   * @return deletion response with the new revision number
+   */
+  @Transactional
+  public MutationResponse<DeleteMemberResponse> deleteMember(UUID listId, UUID memberId) {
+    Member member =
+        memberRepo
+            .findByIdAndItemListId(memberId, listId)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "メンバー")));
+
+    memberRepo.delete(member);
+    // DB側 FK: item.completed_by_member_id ON DELETE SET NULL が効く
+
+    long revision = incrementAndGetRevision(listId);
+
+    return MutationResponse.<DeleteMemberResponse>builder()
+        .revision(revision)
+        .data(DeleteMemberResponse.builder().deletedMemberId(memberId).build())
+        .build();
+  }
+
+  private long incrementAndGetRevision(UUID listId) {
+    int updated = itemListRepo.incrementRevision(listId);
+    if (updated != 1) {
+      throw new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト"));
     }
-
-    /**
-     * Rename an existing member that belongs to the specified list.
-     *
-     * @param listId target list ID
-     * @param memberId member identifier
-     * @param req request body
-     * @return updated member payload with the new revision number
-     */
-    @Transactional
-    public MutationResponse<MemberResponse> renameMember(UUID listId, UUID memberId, CreateMemberRequest req) {
-        Member member = memberRepo.findByIdAndItemListId(memberId, listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "メンバー")));
-
-        // Mapperでtrim含めて更新する想定
-        MemberMapper.updateEntity(member, req);
-
-        Member saved = memberRepo.save(member);
-
-        long revision = incrementAndGetRevision(listId);
-
-        return MutationResponse.<MemberResponse>builder()
-                .revision(revision)
-                .data(MemberMapper.toResponse(saved))
-                .build();
-    }
-
-    /**
-     * Remove a member from the specified list.
-     *
-     * @param listId target list ID
-     * @param memberId member identifier
-     * @return deletion response with the new revision number
-     */
-    @Transactional
-    public MutationResponse<DeleteMemberResponse> deleteMember(UUID listId, UUID memberId) {
-        Member member = memberRepo.findByIdAndItemListId(memberId, listId)
-                .orElseThrow(() -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "メンバー")));
-
-        memberRepo.delete(member);
-        // DB側 FK: item.completed_by_member_id ON DELETE SET NULL が効く
-
-        long revision = incrementAndGetRevision(listId);
-
-        return MutationResponse.<DeleteMemberResponse>builder()
-                .revision(revision)
-                .data(DeleteMemberResponse.builder().deletedMemberId(memberId).build())
-                .build();
-    }
-
-    private long incrementAndGetRevision(UUID listId) {
-        int updated = itemListRepo.incrementRevision(listId);
-        if (updated != 1) {
-            throw new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト"));
-        }
-        return itemListRepo.findRevision(listId).orElseThrow();
-    }
+    return itemListRepo.findRevision(listId).orElseThrow();
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/message/ErrorMessages.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/message/ErrorMessages.java
@@ -2,13 +2,10 @@ package com.atoook.otsukailist.service.message;
 
 import lombok.experimental.UtilityClass;
 
-/**
- * サービス層で共有するエラーメッセージ定数。
- * 将来的に国際化が必要になったら MessageSource 等へ移行する。
- */
+/** サービス層で共有するエラーメッセージ定数。 将来的に国際化が必要になったら MessageSource 等へ移行する。 */
 @UtilityClass
 public class ErrorMessages {
 
-    public static final String NOT_FOUND = "%s が見つかりません";
-    public static final String MEMBER_DUPLICATED = "メンバー名が重複しています: %s";
+  public static final String NOT_FOUND = "%s が見つかりません";
+  public static final String MEMBER_DUPLICATED = "メンバー名が重複しています: %s";
 }

--- a/backend/src/test/java/com/atoook/otsukailist/OtsukaiListApplicationTests.java
+++ b/backend/src/test/java/com/atoook/otsukailist/OtsukaiListApplicationTests.java
@@ -1,15 +1,14 @@
 package com.atoook.otsukailist;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import org.junit.jupiter.api.Test;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class OtsukaiListApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
+  @Test
+  void contextLoads() {}
 }

--- a/backend/src/test/java/com/atoook/otsukailist/OtsukaiListApplicationTests.java
+++ b/backend/src/test/java/com/atoook/otsukailist/OtsukaiListApplicationTests.java
@@ -10,5 +10,5 @@ import org.junit.jupiter.api.Test;
 class OtsukaiListApplicationTests {
 
   @Test
-  void contextLoads() {}
+  void contextLoads() { }
 }

--- a/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
@@ -1,5 +1,10 @@
 package com.atoook.otsukailist.dto;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,88 +13,85 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * JSON シリアライゼーションのテスト
- * boolean フィールドが正しくシリアライズ・デシリアライズされることを確認
- */
+/** JSON シリアライゼーションのテスト boolean フィールドが正しくシリアライズ・デシリアライズされることを確認 */
 class JsonSerializationTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  private final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    @Test
-    @DisplayName("ItemResponse の JSON シリアライゼーション テスト")
-    void testItemResponseSerialization() throws JsonProcessingException {
-        // Given
-        UUID id = UUID.randomUUID();
-        UUID completedByMemberId = UUID.randomUUID();
-        Instant createdAt = Instant.parse("2024-01-01T00:00:00Z");
-        Instant updatedAt = Instant.parse("2024-01-01T01:00:00Z");
-        Instant completedAt = Instant.parse("2024-01-01T00:30:00Z");
+  @Test
+  @DisplayName("ItemResponse の JSON シリアライゼーション テスト")
+  void testItemResponseSerialization() throws JsonProcessingException {
+    // Given
+    UUID id = UUID.randomUUID();
+    UUID completedByMemberId = UUID.randomUUID();
+    Instant createdAt = Instant.parse("2024-01-01T00:00:00Z");
+    Instant updatedAt = Instant.parse("2024-01-01T01:00:00Z");
+    Instant completedAt = Instant.parse("2024-01-01T00:30:00Z");
 
-        ItemResponse response = ItemResponse.builder()
-                .id(id)
-                .name("テストアイテム")
-                .completed(true)
-                .completedByMemberId(completedByMemberId)
-                .completedAt(completedAt)
-                .createdAt(createdAt)
-                .updatedAt(updatedAt)
-                .build();
+    ItemResponse response =
+        ItemResponse.builder()
+            .id(id)
+            .name("テストアイテム")
+            .completed(true)
+            .completedByMemberId(completedByMemberId)
+            .completedAt(completedAt)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
 
-        // When - シリアライゼーション
-        String json = objectMapper.writeValueAsString(response);
+    // When - シリアライゼーション
+    String json = objectMapper.writeValueAsString(response);
 
-        // Then - JSON に "completed" フィールドが含まれることを確認
-        JsonNode jsonNode = objectMapper.readTree(json);
-        assertThat(jsonNode.get("id").asText()).isEqualTo(id.toString());
-        assertThat(jsonNode.get("completed").asBoolean()).isTrue();
-        assertThat(jsonNode.get("completedByMemberId").asText()).isEqualTo(completedByMemberId.toString());
-        assertThat(jsonNode.get("completedAt").asText()).isEqualTo(completedAt.toString());
-        assertThat(jsonNode.get("createdAt").asText()).isEqualTo(createdAt.toString());
-        assertThat(jsonNode.get("updatedAt").asText()).isEqualTo(updatedAt.toString());
+    // Then - JSON に "completed" フィールドが含まれることを確認
+    JsonNode jsonNode = objectMapper.readTree(json);
+    assertThat(jsonNode.get("id").asText()).isEqualTo(id.toString());
+    assertThat(jsonNode.get("completed").asBoolean()).isTrue();
+    assertThat(jsonNode.get("completedByMemberId").asText())
+        .isEqualTo(completedByMemberId.toString());
+    assertThat(jsonNode.get("completedAt").asText()).isEqualTo(completedAt.toString());
+    assertThat(jsonNode.get("createdAt").asText()).isEqualTo(createdAt.toString());
+    assertThat(jsonNode.get("updatedAt").asText()).isEqualTo(updatedAt.toString());
 
-        // デシリアライゼーション
-        ItemResponse deserialized = objectMapper.readValue(json, ItemResponse.class);
-        assertThat(deserialized.getId()).isEqualTo(id);
-        assertThat(deserialized.isCompleted()).isTrue();
-        assertThat(deserialized.getCompletedByMemberId()).isEqualTo(completedByMemberId);
-        assertThat(deserialized.getCompletedAt()).isEqualTo(completedAt);
-        assertThat(deserialized.getCreatedAt()).isEqualTo(createdAt);
-        assertThat(deserialized.getUpdatedAt()).isEqualTo(updatedAt);
-        assertThat(deserialized.getName()).isEqualTo("テストアイテム");
-    }
+    // デシリアライゼーション
+    ItemResponse deserialized = objectMapper.readValue(json, ItemResponse.class);
+    assertThat(deserialized.getId()).isEqualTo(id);
+    assertThat(deserialized.isCompleted()).isTrue();
+    assertThat(deserialized.getCompletedByMemberId()).isEqualTo(completedByMemberId);
+    assertThat(deserialized.getCompletedAt()).isEqualTo(completedAt);
+    assertThat(deserialized.getCreatedAt()).isEqualTo(createdAt);
+    assertThat(deserialized.getUpdatedAt()).isEqualTo(updatedAt);
+    assertThat(deserialized.getName()).isEqualTo("テストアイテム");
+  }
 
-    @Test
-    @DisplayName("CreateItemRequest の JSON デシリアライゼーション テスト")
-    void testCreateItemRequestDeserialization() throws JsonProcessingException {
-        // Given
-        String json = """
+  @Test
+  @DisplayName("CreateItemRequest の JSON デシリアライゼーション テスト")
+  void testCreateItemRequestDeserialization() throws JsonProcessingException {
+    // Given
+    String json =
+        """
                 {
                     "name": "新しいアイテム",
                     "completed": false
                 }
                 """;
 
-        // When
-        CreateItemRequest request = objectMapper.readValue(json, CreateItemRequest.class);
+    // When
+    CreateItemRequest request = objectMapper.readValue(json, CreateItemRequest.class);
 
-        // Then
-        assertThat(request.getName()).isEqualTo("新しいアイテム");
-        assertThat(request.isCompleted()).isFalse();
-    }
+    // Then
+    assertThat(request.getName()).isEqualTo("新しいアイテム");
+    assertThat(request.isCompleted()).isFalse();
+  }
 
-    @Test
-    @DisplayName("UpdateItemRequest の JSON デシリアライゼーション テスト")
-    void testUpdateItemRequestDeserialization() throws JsonProcessingException {
-        // Given
-        String json = """
+  @Test
+  @DisplayName("UpdateItemRequest の JSON デシリアライゼーション テスト")
+  void testUpdateItemRequestDeserialization() throws JsonProcessingException {
+    // Given
+    String json =
+        """
                 {
                     "name": "更新されたアイテム",
                     "completed": true,
@@ -97,12 +99,13 @@ class JsonSerializationTest {
                 }
                 """;
 
-        // When
-        UpdateItemRequest request = objectMapper.readValue(json, UpdateItemRequest.class);
+    // When
+    UpdateItemRequest request = objectMapper.readValue(json, UpdateItemRequest.class);
 
-        // Then
-        assertThat(request.getName()).isEqualTo("更新されたアイテム");
-        assertThat(request.getCompleted()).isTrue();
-        assertThat(request.getCompletedByMemberId()).isEqualTo(UUID.fromString("4aa8c874-708b-4f96-8658-3f4daff9c6ee"));
-    }
+    // Then
+    assertThat(request.getName()).isEqualTo("更新されたアイテム");
+    assertThat(request.getCompleted()).isTrue();
+    assertThat(request.getCompletedByMemberId())
+        .isEqualTo(UUID.fromString("4aa8c874-708b-4f96-8658-3f4daff9c6ee"));
+  }
 }


### PR DESCRIPTION
This pull request introduces several new API controllers for command operations (create, update, delete) on items, item lists, and members, and makes various improvements to code style, formatting, and DTO definitions. It also adds automated code formatting with Spotless and cleans up several DTOs for consistency and clarity.

**Major new features and improvements:**

*API Command Controllers*
- Added `ItemCommandController`, `ItemListCommandController`, and `MemberCommandController` to handle create, update, and delete operations for items, lists, and members, respectively. These controllers provide RESTful endpoints and use appropriate response codes and payloads. [[1]](diffhunk://#diff-388e8a9c30a6c05f524af3285f80222ab5ab396d832b428ce6dbf68a7e6a3372R1-R81) [[2]](diffhunk://#diff-cc556a0d71b0a2d1d5f4764a3460431c568beb8ed310dd833d77b1126e91997dR1-R60) [[3]](diffhunk://#diff-8b0e828588b40d5f2db278fd80fa06ec7fada84e4613383540ce937161813f17R1-R79)

*Build and Code Formatting*
- Integrated the Spotless plugin into the Gradle build for automatic Java code formatting using Google Java Format, import order, and whitespace rules. [[1]](diffhunk://#diff-cd279e89731dcd028c2a5741b1f8ba13cdd851ff187ade540479f55aa89dbeddR8) [[2]](diffhunk://#diff-cd279e89731dcd028c2a5741b1f8ba13cdd851ff187ade540479f55aa89dbeddR143-R154)

*DTO and Validation Updates*
- Updated DTOs for item, list, and member creation requests and responses:
  - Cleaned up class-level and field-level Javadoc/comments for clarity and conciseness. [[1]](diffhunk://#diff-e6d032f192b683520d976e54417ad8ccf35af4854d2f7f9b0830bf91858e5f48L11-R11) [[2]](diffhunk://#diff-2b9e2c1abd28bf58ab8da2190f21c6c7dab846210b516f04cca247c15819b69eL10-R10) [[3]](diffhunk://#diff-870fd9d82c1cf983f4754cd1f100f71189d35013d62e4511916cae8579738032L12-R14) [[4]](diffhunk://#diff-3eb66b3cb676c82662105f83bbe6cbf479e4a729231667cf7a588461ea297678L25-R31)
  - Adjusted validation constraints, such as reducing the maximum item name length from 200 to 100 characters.
  - Removed unused or redundant fields (e.g., `revision` from some responses). [[1]](diffhunk://#diff-b45b4d6c99e71a900ace9297df2063a28f12689e636976520ff3fb80e67849fcL17) [[2]](diffhunk://#diff-2b9e2c1abd28bf58ab8da2190f21c6c7dab846210b516f04cca247c15819b69eL22-L23)

*Error Handling and Formatting*
- Refactored error response creation for consistency and readability in `ApiError` and `ApiExceptionHandler`, improving formatting and simplifying code. [[1]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68L24-R24) [[2]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68L39-R35) [[3]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68L55-R47) [[4]](diffhunk://#diff-b84c7eef8c81ea0c3d2dd270915d527631d0bb36e0bf05291dc3785afda64160L55-R66) [[5]](diffhunk://#diff-b84c7eef8c81ea0c3d2dd270915d527631d0bb36e0bf05291dc3785afda64160L80-R82)

*General Code Clean-up*
- Minor formatting and import order fixes across DTOs and application files for better maintainability. [[1]](diffhunk://#diff-deed26d0bb11efee9d91021c873c6298daeee1309283776152ccf77da9aee433L12) [[2]](diffhunk://#diff-7f9f738458f63b6fc70f6c3a352e65b0e594dd61d0e8e043fbde6764672b66b4R4) [[3]](diffhunk://#diff-5c3849c46cfac33e6f2f39b9c2211f157b9b6f16d85340618c49d91c814b76d0L3-R5) [[4]](diffhunk://#diff-97d31dc075ef182b08f2a8248469c9fea6d88efeda28722768de8b9490bc8172R5)

**References:**  
[[1]](diffhunk://#diff-388e8a9c30a6c05f524af3285f80222ab5ab396d832b428ce6dbf68a7e6a3372R1-R81) [[2]](diffhunk://#diff-cc556a0d71b0a2d1d5f4764a3460431c568beb8ed310dd833d77b1126e91997dR1-R60) [[3]](diffhunk://#diff-8b0e828588b40d5f2db278fd80fa06ec7fada84e4613383540ce937161813f17R1-R79) [[4]](diffhunk://#diff-cd279e89731dcd028c2a5741b1f8ba13cdd851ff187ade540479f55aa89dbeddR8) [[5]](diffhunk://#diff-cd279e89731dcd028c2a5741b1f8ba13cdd851ff187ade540479f55aa89dbeddR143-R154) [[6]](diffhunk://#diff-e6d032f192b683520d976e54417ad8ccf35af4854d2f7f9b0830bf91858e5f48L11-R11) [[7]](diffhunk://#diff-90d5880300472c29951d444629131c427310ca090040db11fc76873162b1d1b5L22-R20) [[8]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68L24-R24) [[9]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68L39-R35) [[10]](diffhunk://#diff-33de1cd8e5559d3a9f2eb583a07e52cc58c8f72799163e94a32af2973aa30b68L55-R47) [[11]](diffhunk://#diff-b84c7eef8c81ea0c3d2dd270915d527631d0bb36e0bf05291dc3785afda64160L55-R66) [[12]](diffhunk://#diff-b84c7eef8c81ea0c3d2dd270915d527631d0bb36e0bf05291dc3785afda64160L80-R82) [[13]](diffhunk://#diff-2b9e2c1abd28bf58ab8da2190f21c6c7dab846210b516f04cca247c15819b69eL22-L23) [[14]](diffhunk://#diff-b45b4d6c99e71a900ace9297df2063a28f12689e636976520ff3fb80e67849fcL17) [[15]](diffhunk://#diff-3eb66b3cb676c82662105f83bbe6cbf479e4a729231667cf7a588461ea297678L25-R31) [[16]](diffhunk://#diff-deed26d0bb11efee9d91021c873c6298daeee1309283776152ccf77da9aee433L12) [[17]](diffhunk://#diff-7f9f738458f63b6fc70f6c3a352e65b0e594dd61d0e8e043fbde6764672b66b4R4) [[18]](diffhunk://#diff-5c3849c46cfac33e6f2f39b9c2211f157b9b6f16d85340618c49d91c814b76d0L3-R5) [[19]](diffhunk://#diff-97d31dc075ef182b08f2a8248469c9fea6d88efeda28722768de8b9490bc8172R5) [[20]](diffhunk://#diff-870fd9d82c1cf983f4754cd1f100f71189d35013d62e4511916cae8579738032L12-R14) [[21]](diffhunk://#diff-870fd9d82c1cf983f4754cd1f100f71189d35013d62e4511916cae8579738032L38-R34)