### PR TITLE
Backend/ add query controller

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListQueryController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListQueryController.java
@@ -1,0 +1,34 @@
+package com.atoook.otsukailist.api.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.atoook.otsukailist.dto.ItemListSnapshotResponse;
+import com.atoook.otsukailist.service.ListQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lists")
+public class ItemListQueryController {
+    private final ListQueryService listQueryService;
+
+    /**
+     * Get the latest snapshot of the specified item list.
+     *
+     * @param listId the ID of the item list
+     * @return 200 snapshot of the item list
+     */
+    @GetMapping("/{listId}/snapshot")
+    public ResponseEntity<ItemListSnapshotResponse> snapshot(
+            @PathVariable("listId") UUID listId) {
+        return ResponseEntity.ok(listQueryService.snapshot(listId));
+    }
+
+}

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
@@ -1,15 +1,19 @@
 package com.atoook.otsukailist.service;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.atoook.otsukailist.dto.ItemListSnapshotResponse;
+import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MemberResponse;
 import com.atoook.otsukailist.exception.ResourceNotFoundException;
 import com.atoook.otsukailist.mapper.ItemMapper;
 import com.atoook.otsukailist.mapper.MemberMapper;
+import com.atoook.otsukailist.model.Item;
 import com.atoook.otsukailist.model.ItemList;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.ItemRepository;
@@ -22,38 +26,37 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ListQueryService {
 
-  private final ItemListRepository itemListRepo;
-  private final MemberRepository memberRepo;
-  private final ItemRepository itemRepo;
+    private final ItemListRepository itemListRepo;
+    private final MemberRepository memberRepo;
+    private final ItemRepository itemRepo;
 
-  /**
-   * Retrieve the latest snapshot of a list including members and items.
-   *
-   * @param listId target list ID
-   * @return aggregated snapshot response
-   */
-  @Transactional(readOnly = true)
-  public ItemListSnapshotResponse snapshot(UUID listId) {
-    ItemList list =
-        itemListRepo
-            .findById(listId)
-            .orElseThrow(
-                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+    /**
+     * Retrieve the latest snapshot of a list including members and items.
+     *
+     * @param listId target list ID
+     * @return aggregated snapshot response
+     */
+    @Transactional(readOnly = true)
+    public ItemListSnapshotResponse snapshot(UUID listId) {
+        ItemList list = itemListRepo
+                .findById(listId)
+                .orElseThrow(
+                        () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
 
-    var members =
-        memberRepo.findByItemListId(listId).stream().map(MemberMapper::toResponse).toList();
+        List<MemberResponse> members = memberRepo.findByItemListId(listId).stream().map(MemberMapper::toResponse)
+                .toList();
 
-    var itemEntities = itemRepo.findByItemListId(listId);
-    var items = itemEntities.stream().map(ItemMapper::toResponse).toList();
+        List<Item> itemEntities = itemRepo.findByItemListId(listId);
+        List<ItemResponse> items = itemEntities.stream().map(ItemMapper::toResponse).toList();
 
-    return ItemListSnapshotResponse.builder()
-        .listId(list.getId())
-        .name(list.getName())
-        .revision(list.getRevision())
-        .itemCount(itemEntities.size())
-        .serverTime(Instant.now())
-        .members(members)
-        .items(items)
-        .build();
-  }
+        return ItemListSnapshotResponse.builder()
+                .listId(list.getId())
+                .name(list.getName())
+                .revision(list.getRevision())
+                .itemCount(itemEntities.size())
+                .serverTime(Instant.now())
+                .members(members)
+                .items(items)
+                .build();
+    }
 }


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve the latest snapshot of an item list and refactors the related service logic for improved clarity and maintainability. The main changes include the addition of a new controller, updates to the service layer to support the new endpoint, and minor code cleanups.

### API Enhancements

* Added a new REST controller `ItemListQueryController` with a `GET /api/lists/{listId}/snapshot` endpoint to retrieve the latest snapshot of a specified item list.

### Service Layer Improvements

* Refactored the `ListQueryService.snapshot` method to use explicit type declarations (`List<MemberResponse>`, `List<Item>`, and `List<ItemResponse>`) for better readability and maintainability.
* Updated imports in `ListQueryService.java` to include the necessary DTOs and models for the new and refactored logic.