### PR TITLE
Implement userCache for member selection and history management

### DIFF
--- a/frontend/src/lib/userCache.test.ts
+++ b/frontend/src/lib/userCache.test.ts
@@ -84,28 +84,24 @@ describe('userCache', () => {
     it('新しいエントリを追加できる', () => {
       addOrUpdateListHistory({
         listId: LIST_ID_A,
-        name: 'リストA',
-        url: 'https://example.com/lists/a'
+        name: 'リストA'
       });
       const history = getListHistory();
       expect(history).toHaveLength(1);
       const [first] = history;
       expect(first?.listId).toBe(LIST_ID_A);
       expect(first?.name).toBe('リストA');
-      expect(first?.url).toBe('https://example.com/lists/a');
       expect(typeof first?.lastAccessedAt).toBe('string');
     });
 
     it('同じlistIdの既存エントリをnameとlastAccessedAtを更新する', () => {
       addOrUpdateListHistory({
         listId: LIST_ID_A,
-        name: '旧名前',
-        url: 'https://example.com/lists/a'
+        name: '旧名前'
       });
       addOrUpdateListHistory({
         listId: LIST_ID_A,
-        name: '新名前',
-        url: 'https://example.com/lists/a'
+        name: '新名前'
       });
       const history = getListHistory();
       expect(history).toHaveLength(1);
@@ -114,8 +110,8 @@ describe('userCache', () => {
     });
 
     it('最新アクセスが先頭に来るようにソートされる', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
-      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB' });
       const history = getListHistory();
       const [first, second] = history;
       expect(first?.listId).toBe(LIST_ID_B);
@@ -126,17 +122,16 @@ describe('userCache', () => {
       for (let i = 0; i < 15; i++) {
         addOrUpdateListHistory({
           listId: `list-${i}`,
-          name: `リスト${i}`,
-          url: `https://example.com/lists/${i}`
+          name: `リスト${i}`
         });
       }
       expect(getListHistory()).toHaveLength(10);
     });
 
     it('再アクセスでエントリが先頭に移動する', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
-      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
       const history = getListHistory();
       const [first, second] = history;
       expect(first?.listId).toBe(LIST_ID_A);
@@ -146,7 +141,7 @@ describe('userCache', () => {
 
   describe('updateListHistoryName', () => {
     it('存在するエントリのnameを更新できる', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: '旧名前', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: '旧名前' });
       updateListHistoryName(LIST_ID_A, '新名前');
       const history = getListHistory();
       const [first] = history;
@@ -154,8 +149,8 @@ describe('userCache', () => {
     });
 
     it('nameを更新してもソート順は変わらない', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
-      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB' });
       updateListHistoryName(LIST_ID_A, 'リストA改');
       const history = getListHistory();
       const [first, second] = history;
@@ -164,7 +159,7 @@ describe('userCache', () => {
     });
 
     it('存在しないlistIdは何もしない（他のエントリに影響しない）', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
       updateListHistoryName('non-existent', '更新');
       const history = getListHistory();
       expect(history).toHaveLength(1);
@@ -175,8 +170,8 @@ describe('userCache', () => {
 
   describe('clearListHistory', () => {
     it('全履歴を削除できる', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
-      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB' });
       clearListHistory();
       expect(getListHistory()).toEqual([]);
     });
@@ -188,8 +183,8 @@ describe('userCache', () => {
 
   describe('removeListHistoryEntry', () => {
     it('指定したlistIdのエントリを削除できる', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
-      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB' });
       removeListHistoryEntry(LIST_ID_A);
       const history = getListHistory();
       expect(history).toHaveLength(1);
@@ -198,13 +193,13 @@ describe('userCache', () => {
     });
 
     it('存在しないlistIdを指定しても他のエントリに影響しない', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
       removeListHistoryEntry('non-existent');
       expect(getListHistory()).toHaveLength(1);
     });
 
     it('最後の1件を削除すると履歴が空になる', () => {
-      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA' });
       removeListHistoryEntry(LIST_ID_A);
       expect(getListHistory()).toEqual([]);
     });

--- a/frontend/src/lib/userCache.test.ts
+++ b/frontend/src/lib/userCache.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getSelectedMemberId,
+  setSelectedMemberId,
+  getListHistory,
+  addOrUpdateListHistory,
+  updateListHistoryName,
+  clearListHistory,
+  removeListHistoryEntry
+} from './userCache';
+
+const LIST_ID_A = 'list-uuid-a';
+const LIST_ID_B = 'list-uuid-b';
+const MEMBER_ID_1 = 'member-uuid-1';
+const MEMBER_ID_2 = 'member-uuid-2';
+
+describe('userCache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('getSelectedMemberId / setSelectedMemberId', () => {
+    it('存在しないlistIdはnullを返す', () => {
+      expect(getSelectedMemberId(LIST_ID_A)).toBeNull();
+    });
+
+    it('保存したmemberIdを復元できる', () => {
+      setSelectedMemberId(LIST_ID_A, MEMBER_ID_1);
+      expect(getSelectedMemberId(LIST_ID_A)).toBe(MEMBER_ID_1);
+    });
+
+    it('listIdごとに独立して保存される', () => {
+      setSelectedMemberId(LIST_ID_A, MEMBER_ID_1);
+      setSelectedMemberId(LIST_ID_B, MEMBER_ID_2);
+      expect(getSelectedMemberId(LIST_ID_A)).toBe(MEMBER_ID_1);
+      expect(getSelectedMemberId(LIST_ID_B)).toBe(MEMBER_ID_2);
+    });
+
+    it('上書き保存ができる', () => {
+      setSelectedMemberId(LIST_ID_A, MEMBER_ID_1);
+      setSelectedMemberId(LIST_ID_A, MEMBER_ID_2);
+      expect(getSelectedMemberId(LIST_ID_A)).toBe(MEMBER_ID_2);
+    });
+  });
+
+  describe('getListHistory', () => {
+    it('履歴がない場合は空配列を返す', () => {
+      expect(getListHistory()).toEqual([]);
+    });
+
+    it('破損したJSONは空配列を返す', () => {
+      localStorage.setItem('otsukailist:history', '{invalid json');
+      expect(getListHistory()).toEqual([]);
+    });
+
+    it('配列でない値は空配列を返す', () => {
+      localStorage.setItem('otsukailist:history', JSON.stringify({ listId: LIST_ID_A }));
+      expect(getListHistory()).toEqual([]);
+    });
+
+    it('不正な構造のエントリを除外して有効なエントリのみ返す', () => {
+      localStorage.setItem(
+        'otsukailist:history',
+        JSON.stringify([
+          {
+            listId: LIST_ID_A,
+            name: 'リストA',
+            url: 'https://example.com/lists/a',
+            lastAccessedAt: '2026-01-01T00:00:00.000Z'
+          },
+          { listId: 123, name: 'bad', url: 'x', lastAccessedAt: 'y' }, // listId is not string
+          null,
+          'string entry'
+        ])
+      );
+      const history = getListHistory();
+      expect(history).toHaveLength(1);
+      const [first] = history;
+      expect(first?.listId).toBe(LIST_ID_A);
+    });
+  });
+
+  describe('addOrUpdateListHistory', () => {
+    it('新しいエントリを追加できる', () => {
+      addOrUpdateListHistory({
+        listId: LIST_ID_A,
+        name: 'リストA',
+        url: 'https://example.com/lists/a'
+      });
+      const history = getListHistory();
+      expect(history).toHaveLength(1);
+      const [first] = history;
+      expect(first?.listId).toBe(LIST_ID_A);
+      expect(first?.name).toBe('リストA');
+      expect(first?.url).toBe('https://example.com/lists/a');
+      expect(typeof first?.lastAccessedAt).toBe('string');
+    });
+
+    it('同じlistIdの既存エントリをnameとlastAccessedAtを更新する', () => {
+      addOrUpdateListHistory({
+        listId: LIST_ID_A,
+        name: '旧名前',
+        url: 'https://example.com/lists/a'
+      });
+      addOrUpdateListHistory({
+        listId: LIST_ID_A,
+        name: '新名前',
+        url: 'https://example.com/lists/a'
+      });
+      const history = getListHistory();
+      expect(history).toHaveLength(1);
+      const [first] = history;
+      expect(first?.name).toBe('新名前');
+    });
+
+    it('最新アクセスが先頭に来るようにソートされる', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      const history = getListHistory();
+      const [first, second] = history;
+      expect(first?.listId).toBe(LIST_ID_B);
+      expect(second?.listId).toBe(LIST_ID_A);
+    });
+
+    it('最大10件に切り詰められる', () => {
+      for (let i = 0; i < 15; i++) {
+        addOrUpdateListHistory({
+          listId: `list-${i}`,
+          name: `リスト${i}`,
+          url: `https://example.com/lists/${i}`
+        });
+      }
+      expect(getListHistory()).toHaveLength(10);
+    });
+
+    it('再アクセスでエントリが先頭に移動する', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      const history = getListHistory();
+      const [first, second] = history;
+      expect(first?.listId).toBe(LIST_ID_A);
+      expect(second?.listId).toBe(LIST_ID_B);
+    });
+  });
+
+  describe('updateListHistoryName', () => {
+    it('存在するエントリのnameを更新できる', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: '旧名前', url: 'url-a' });
+      updateListHistoryName(LIST_ID_A, '新名前');
+      const history = getListHistory();
+      const [first] = history;
+      expect(first?.name).toBe('新名前');
+    });
+
+    it('nameを更新してもソート順は変わらない', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      updateListHistoryName(LIST_ID_A, 'リストA改');
+      const history = getListHistory();
+      const [first, second] = history;
+      expect(first?.listId).toBe(LIST_ID_B); // ソート順は変わらない
+      expect(second?.name).toBe('リストA改');
+    });
+
+    it('存在しないlistIdは何もしない（他のエントリに影響しない）', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      updateListHistoryName('non-existent', '更新');
+      const history = getListHistory();
+      expect(history).toHaveLength(1);
+      const [first] = history;
+      expect(first?.name).toBe('リストA');
+    });
+  });
+
+  describe('clearListHistory', () => {
+    it('全履歴を削除できる', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      clearListHistory();
+      expect(getListHistory()).toEqual([]);
+    });
+
+    it('履歴が空の状態でclearしてもエラーにならない', () => {
+      expect(() => clearListHistory()).not.toThrow();
+    });
+  });
+
+  describe('removeListHistoryEntry', () => {
+    it('指定したlistIdのエントリを削除できる', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      addOrUpdateListHistory({ listId: LIST_ID_B, name: 'リストB', url: 'url-b' });
+      removeListHistoryEntry(LIST_ID_A);
+      const history = getListHistory();
+      expect(history).toHaveLength(1);
+      const [first] = history;
+      expect(first?.listId).toBe(LIST_ID_B);
+    });
+
+    it('存在しないlistIdを指定しても他のエントリに影響しない', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      removeListHistoryEntry('non-existent');
+      expect(getListHistory()).toHaveLength(1);
+    });
+
+    it('最後の1件を削除すると履歴が空になる', () => {
+      addOrUpdateListHistory({ listId: LIST_ID_A, name: 'リストA', url: 'url-a' });
+      removeListHistoryEntry(LIST_ID_A);
+      expect(getListHistory()).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/lib/userCache.ts
+++ b/frontend/src/lib/userCache.ts
@@ -1,0 +1,102 @@
+import type { UUID } from '@/types/api';
+
+const MEMBER_KEY_PREFIX = 'otsukailist:settings:member:';
+const HISTORY_KEY = 'otsukailist:history';
+const MAX_HISTORY_ENTRIES = 10;
+
+export type ListHistoryEntry = {
+  listId: UUID;
+  name: string;
+  url: string;
+  lastAccessedAt: string;
+};
+
+// --- selectedMemberId ---
+
+export function getSelectedMemberId(listId: string): string | null {
+  try {
+    return localStorage.getItem(`${MEMBER_KEY_PREFIX}${listId}`);
+  } catch {
+    return null;
+  }
+}
+
+export function setSelectedMemberId(listId: string, memberId: string): void {
+  try {
+    localStorage.setItem(`${MEMBER_KEY_PREFIX}${listId}`, memberId);
+  } catch {
+    // ignore (e.g. storage quota exceeded or private-browsing restriction)
+  }
+}
+
+// --- list history ---
+
+function isValidHistoryEntry(entry: unknown): entry is ListHistoryEntry {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const e = entry as Record<string, unknown>;
+  return (
+    typeof e.listId === 'string' &&
+    typeof e.name === 'string' &&
+    typeof e.url === 'string' &&
+    typeof e.lastAccessedAt === 'string'
+  );
+}
+
+export function getListHistory(): ListHistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidHistoryEntry);
+  } catch {
+    return [];
+  }
+}
+
+export function addOrUpdateListHistory(entry: { listId: string; name: string; url: string }): void {
+  try {
+    const history = getListHistory();
+    const now = new Date().toISOString();
+    const newEntry: ListHistoryEntry = { ...entry, lastAccessedAt: now };
+    // 既存エントリを除去してから先頭に挿入することで、同一ミリ秒の場合も
+    // 安定ソート（ES2019+ 保証）により最新アクセスが先頭を保つ
+    const filtered = history.filter((h) => h.listId !== entry.listId);
+    filtered.unshift(newEntry);
+    const sorted = filtered
+      .sort((a, b) => b.lastAccessedAt.localeCompare(a.lastAccessedAt))
+      .slice(0, MAX_HISTORY_ENTRIES);
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(sorted));
+  } catch {
+    // ignore
+  }
+}
+
+export function updateListHistoryName(listId: string, name: string): void {
+  try {
+    const history = getListHistory();
+    const idx = history.findIndex((h) => h.listId === listId);
+    if (idx < 0) return;
+    history[idx] = { ...history[idx]!, name };
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearListHistory(): void {
+  try {
+    localStorage.removeItem(HISTORY_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function removeListHistoryEntry(listId: string): void {
+  try {
+    const history = getListHistory().filter((h) => h.listId !== listId);
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/src/lib/userCache.ts
+++ b/frontend/src/lib/userCache.ts
@@ -7,7 +7,6 @@ const MAX_HISTORY_ENTRIES = 10;
 export type ListHistoryEntry = {
   listId: UUID;
   name: string;
-  url: string;
   lastAccessedAt: string;
 };
 
@@ -34,12 +33,7 @@ export function setSelectedMemberId(listId: string, memberId: string): void {
 function isValidHistoryEntry(entry: unknown): entry is ListHistoryEntry {
   if (typeof entry !== 'object' || entry === null) return false;
   const e = entry as Record<string, unknown>;
-  return (
-    typeof e.listId === 'string' &&
-    typeof e.name === 'string' &&
-    typeof e.url === 'string' &&
-    typeof e.lastAccessedAt === 'string'
-  );
+  return typeof e.listId === 'string' && typeof e.name === 'string' && typeof e.lastAccessedAt === 'string';
 }
 
 export function getListHistory(): ListHistoryEntry[] {
@@ -48,13 +42,16 @@ export function getListHistory(): ListHistoryEntry[] {
     if (!raw) return [];
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidHistoryEntry);
+    return parsed
+      .filter(isValidHistoryEntry)
+      .sort((a, b) => b.lastAccessedAt.localeCompare(a.lastAccessedAt))
+      .slice(0, MAX_HISTORY_ENTRIES);
   } catch {
     return [];
   }
 }
 
-export function addOrUpdateListHistory(entry: { listId: string; name: string; url: string }): void {
+export function addOrUpdateListHistory(entry: { listId: string; name: string }): void {
   try {
     const history = getListHistory();
     const now = new Date().toISOString();

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -132,11 +132,7 @@ export default defineComponent({
         }
 
         // リスト履歴に追加/更新
-        addOrUpdateListHistory({
-          listId,
-          name: snapshot.name,
-          url: window.location.href
-        });
+        addOrUpdateListHistory({ listId, name: snapshot.name });
       } catch (err: unknown) {
         console.error('Failed to load snapshot', err);
         this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -13,6 +13,7 @@ import type { Member, MemberId } from '@/types/member';
 import { fetchSnapshot } from '@/api/list';
 import { useListStore } from '@/stores/list';
 import { getErrorMessage } from '@/lib/http';
+import { getSelectedMemberId, setSelectedMemberId, addOrUpdateListHistory } from '@/lib/userCache';
 
 export default defineComponent({
   name: 'ItemListPage',
@@ -120,9 +121,22 @@ export default defineComponent({
       try {
         const snapshot = await fetchSnapshot(listId);
         this.listStore.applySnapshot(snapshot);
-        if (!this.selectedMemberId && snapshot.members.length > 0) {
+
+        // キャッシュから selectedMemberId を復元し、メンバー一覧で検証する
+        const cachedMemberId = getSelectedMemberId(listId);
+        const memberIds = snapshot.members.map((m) => m.id);
+        if (cachedMemberId && memberIds.includes(cachedMemberId)) {
+          this.selectedMemberId = cachedMemberId;
+        } else if (snapshot.members.length > 0) {
           this.selectedMemberId = snapshot.members[0]?.id ?? null;
         }
+
+        // リスト履歴に追加/更新
+        addOrUpdateListHistory({
+          listId,
+          name: snapshot.name,
+          url: window.location.href
+        });
       } catch (err: unknown) {
         console.error('Failed to load snapshot', err);
         this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';
@@ -132,6 +146,9 @@ export default defineComponent({
     },
     handleMemberSelect(selectedId: string) {
       this.selectedMemberId = selectedId;
+      if (this.currentListId) {
+        setSelectedMemberId(this.currentListId, selectedId);
+      }
     },
     onSearchInput(value: string): void {
       this.searchQuery = normalizeInput(value);

--- a/frontend/src/pages/ListEditPage.vue
+++ b/frontend/src/pages/ListEditPage.vue
@@ -12,6 +12,7 @@ import { useMutation } from '@/composables/useMutation';
 import { createMember, deleteMember } from '@/api/member';
 import { renameList } from '@/api/list';
 import { getErrorMessage } from '@/lib/http';
+import { updateListHistoryName, getSelectedMemberId } from '@/lib/userCache';
 
 export default defineComponent({
   name: 'ListEditPage',
@@ -51,7 +52,10 @@ export default defineComponent({
     if (listId && this.listStore.listId === listId) {
       this.listName = this.listStore.name;
       this.refreshMembersFromStore();
-      this.selectedMemberId = this.listStore.members[0]?.id ?? null;
+      const cachedMemberId = getSelectedMemberId(listId);
+      const memberIds = this.listStore.members.map((m) => m.id);
+      this.selectedMemberId =
+        cachedMemberId && memberIds.includes(cachedMemberId) ? cachedMemberId : (this.listStore.members[0]?.id ?? null);
       return;
     }
 
@@ -143,6 +147,7 @@ export default defineComponent({
             this.errorMessage = 'リスト名の更新が反映されませんでした。時間をおいて再試行してください。';
             return;
           }
+          updateListHistoryName(this.currentListId!, normalizedListName);
         } catch (err: unknown) {
           console.error('Failed to rename list', err);
           this.errorMessage = getErrorMessage(err) ?? 'リスト名の更新に失敗しました。';

--- a/frontend/src/pages/WelcomePage.vue
+++ b/frontend/src/pages/WelcomePage.vue
@@ -3,7 +3,7 @@ import ContentArea from '../components/ContentArea.vue';
 import MainButton from '../components/MainButton.vue';
 import SwipeContainer from '../components/SwipeContainer.vue';
 import BadgeTag from '../components/BadgeTag.vue';
-import { getListHistory, removeListHistoryEntry } from '../lib/userCache';
+import { getListHistory, removeListHistoryEntry } from '@/lib/userCache';
 
 export default {
   name: 'WelcomePage',
@@ -63,8 +63,6 @@ export default {
                 type="button"
                 @click="removeHistoryEntry(entry.listId)"
                 :aria-label="`${entry.name}を履歴からクリア`"
-                tabindex="-1"
-                role="button"
               >
                 <BadgeTag text="履歴からクリア" size="small" class="bg-ember-400 border-ember-600 text-white" />
               </button>

--- a/frontend/src/pages/WelcomePage.vue
+++ b/frontend/src/pages/WelcomePage.vue
@@ -1,16 +1,33 @@
 <script>
 import ContentArea from '../components/ContentArea.vue';
 import MainButton from '../components/MainButton.vue';
+import SwipeContainer from '../components/SwipeContainer.vue';
+import BadgeTag from '../components/BadgeTag.vue';
+import { getListHistory, removeListHistoryEntry } from '../lib/userCache';
 
 export default {
   name: 'WelcomePage',
   components: {
     ContentArea,
-    MainButton
+    MainButton,
+    SwipeContainer,
+    BadgeTag
+  },
+  data() {
+    return {
+      listHistory: []
+    };
+  },
+  created() {
+    this.listHistory = getListHistory();
   },
   methods: {
     navigateToCreateList() {
       this.$router.push('/create-list');
+    },
+    removeHistoryEntry(listId) {
+      removeListHistoryEntry(listId);
+      this.listHistory = this.listHistory.filter((e) => e.listId !== listId);
     }
   }
 };
@@ -23,6 +40,38 @@ export default {
       <h2 class="text-3xl font-bold font-serif text-charcoal-800 mb-4">ようこそ！</h2>
       <p class="text-charcoal-600 mb-8 leading-relaxed">あなたの買い物を<br />🍖 スマートに管理しましょう</p>
       <MainButton @click="navigateToCreateList">はじめる</MainButton>
+    </div>
+
+    <!-- 最近見たリスト -->
+    <div v-if="listHistory.length > 0" class="mt-10">
+      <div class="flex items-center mb-3">
+        <h3 class="text-sm font-semibold text-charcoal-600">最近見たリスト</h3>
+      </div>
+      <ul class="space-y-2">
+        <li v-for="entry in listHistory" :key="entry.listId" class="rounded-lg overflow-hidden">
+          <SwipeContainer hidden-bg-color="#fef7f0">
+            <router-link
+              :to="`/lists/${entry.listId}`"
+              class="flex items-center px-4 py-3 bg-white border border-charcoal-200 rounded-lg hover:bg-charcoal-50 transition-colors"
+            >
+              <span class="text-charcoal-400 mr-3 text-base" aria-hidden="true">📋</span>
+              <span class="text-sm text-charcoal-700 font-medium truncate flex-1">{{ entry.name }}</span>
+              <span class="text-charcoal-300 text-xs ml-2" aria-hidden="true">›</span>
+            </router-link>
+            <template #hiddenActions>
+              <button
+                type="button"
+                @click="removeHistoryEntry(entry.listId)"
+                :aria-label="`${entry.name}を履歴からクリア`"
+                tabindex="-1"
+                role="button"
+              >
+                <BadgeTag text="履歴からクリア" size="small" class="bg-ember-400 border-ember-600 text-white" />
+              </button>
+            </template>
+          </SwipeContainer>
+        </li>
+      </ul>
     </div>
   </ContentArea>
 </template>


### PR DESCRIPTION
This pull request introduces a comprehensive localStorage-based user cache system for tracking user preferences and recently viewed lists. It adds a new utility module (`userCache.ts`) with robust test coverage, and integrates recent list history and member selection persistence across several pages. The Welcome page now features a "Recently Viewed Lists" section, allowing users to quickly access and manage their list history.

**User cache utility and test coverage:**

- Implemented `userCache.ts`, which provides functions to persist and retrieve the selected member per list, as well as maintain a history of recently viewed lists (up to 10 entries), including add, update, remove, and clear operations. The module ensures data integrity and handles edge cases gracefully.
- Added a comprehensive test suite (`userCache.test.ts`) covering all user cache behaviors, including error handling and edge cases.

**Integration with list and member selection:**

- Updated `ItemListPage.vue` and `ListEditPage.vue` to utilize the user cache for restoring and persisting the selected member per list, and for updating list history and names as appropriate. This ensures user preferences are retained across sessions and page reloads. [[1]](diffhunk://#diff-3f5818ec33d23995f71d69557331222dbef5378c72bcae26f63c25605e8b2ef3R16) [[2]](diffhunk://#diff-3f5818ec33d23995f71d69557331222dbef5378c72bcae26f63c25605e8b2ef3L123-R139) [[3]](diffhunk://#diff-3f5818ec33d23995f71d69557331222dbef5378c72bcae26f63c25605e8b2ef3R149-R151) [[4]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7R15) [[5]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7L54-R58) [[6]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7R150)

**Welcome page enhancements:**

- Enhanced `WelcomePage.vue` to display a "Recently Viewed Lists" section, listing up to 10 recent lists from the user cache. Each entry can be removed individually via a swipe action, improving user experience and discoverability. [[1]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408R4-R30) [[2]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408R44-R75)…selection and list history management