### PR TITLE
Improve text color for readability and fix spelling in AppFooter

### DIFF
--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -8,6 +8,6 @@ const year = new Date().getFullYear();
 
 <template>
   <div class="bg-gray-100 px-6 py-3">
-    <p class="text-xs text-gray-500 text-center">© {{ year }} OTUKAI リスト</p>
+    <p class="text-xs text-gray-500 text-center">© {{ year }} OTSUKAI リスト</p>
   </div>
 </template>

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -191,9 +191,9 @@ export default defineComponent({
         class="w-full flex items-center gap-2 mt-1 py-1 text-left focus:outline-none focus:ring-2 focus:ring-charcoal-400 rounded"
       >
         <div class="flex-1 h-px bg-charcoal-200"></div>
-        <span class="text-xs text-charcoal-400 whitespace-nowrap">{{ group.label }} {{ group.items.length }}件</span>
+        <span class="text-xs text-charcoal-500 whitespace-nowrap">{{ group.label }} {{ group.items.length }}件</span>
         <span
-          class="text-charcoal-400 text-xs transition-transform duration-200"
+          class="text-charcoal-500 text-xs transition-transform duration-200"
           :class="{ '-rotate-90': isGroupCollapsed(group.key) }"
           aria-hidden="true"
           >▼</span
@@ -201,7 +201,7 @@ export default defineComponent({
       </button>
       <div v-else-if="group.showHeader" class="flex items-center gap-2 mt-1 py-1">
         <div class="flex-1 h-px bg-charcoal-200"></div>
-        <span class="text-xs text-charcoal-400 whitespace-nowrap">{{ group.label }} {{ group.items.length }}件</span>
+        <span class="text-xs text-charcoal-500 whitespace-nowrap">{{ group.label }} {{ group.items.length }}件</span>
       </div>
 
       <!-- グループ内アイテム -->

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -100,7 +100,7 @@ export default defineComponent({
       if (incomplete === 0) {
         return '全て完了 🎉';
       }
-      return `あと ${incomplete} 件 / 完了 ${completed} 件`;
+      return `あと ${incomplete} 件 ・ 完了 ${completed} 件`;
     },
     formattedLastItemActivityAt(): string | null {
       return formatActivityAt(this.listStore.lastItemActivityAt);
@@ -208,15 +208,15 @@ export default defineComponent({
       <!-- チェック時に記録する購入者選択 + サマリー -->
       <div v-if="filteredItems.length > 0" class="w-full flex justify-between items-center mb-2">
         <div class="flex flex-col gap-0.5">
-          <span class="text-xs text-charcoal-400">{{ itemSummary }}</span>
-          <span v-if="formattedLastItemActivityAt" class="text-xs text-charcoal-300 flex items-center gap-1">
+          <span class="text-xs text-charcoal-600">{{ itemSummary }}</span>
+          <span v-if="formattedLastItemActivityAt" class="text-xs text-charcoal-500 flex items-center gap-1">
             最終更新: {{ formattedLastItemActivityAt }}
             <button
               type="button"
               @click="currentListId && loadSnapshot(currentListId)"
               :disabled="snapshotLoading"
               aria-label="リストを再読み込み"
-              class="text-charcoal-300 hover:text-charcoal-500 disabled:opacity-40 transition-colors"
+              class="text-charcoal-400 hover:text-charcoal-600 disabled:opacity-40 transition-colors"
             >
               <span :class="{ 'animate-spin': snapshotLoading }" style="display: inline-block">🔁</span>
             </button>


### PR DESCRIPTION
This pull request mainly focuses on improving the visual consistency and clarity of the UI by updating color schemes for text elements and making minor adjustments to displayed text in the item list. The changes enhance readability and ensure a more cohesive look across the application.

**UI color and text consistency improvements:**

* Updated text color classes from `text-charcoal-400` to `text-charcoal-500` for group headers and expand/collapse icons in `ItemGroupList.vue` to improve visibility and consistency.
* Changed summary and activity text colors in `ItemListPage.vue` to darker shades (`text-charcoal-600` and `text-charcoal-500`) for better readability, and updated the reload button color for improved contrast.

**Text and label adjustments:**

* Modified the item summary separator from `/` to `・` in `ItemListPage.vue` for clearer separation between incomplete and completed item counts.
* Fixed a typo in the footer by changing "OTUKAI" to "OTSUKAI" in `AppFooter.vue`.