### PR TITLE
Add endpoint and function to retrieve list metadata

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListQueryController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListQueryController.java
@@ -1,18 +1,26 @@
 package com.atoook.otsukailist.api.controller;
 
+import java.util.List;
 import java.util.UUID;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.atoook.otsukailist.dto.ItemListSnapshotResponse;
+import com.atoook.otsukailist.dto.ListMetaItemResponse;
 import com.atoook.otsukailist.service.ListQueryService;
 
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/lists")
@@ -28,5 +36,19 @@ public class ItemListQueryController {
   @GetMapping("/{listId}/snapshot")
   public ResponseEntity<ItemListSnapshotResponse> snapshot(@PathVariable("listId") UUID listId) {
     return ResponseEntity.ok(listQueryService.snapshot(listId));
+  }
+
+  /**
+   * Get metadata (name, item counts, last activity) for a batch of lists.
+   *
+   * <p>List IDs that no longer exist are silently omitted from the response.
+   *
+   * @param listIds list of listIds to query (max 10)
+   * @return 200 metadata for each existing list
+   */
+  @GetMapping("/meta")
+  public ResponseEntity<List<ListMetaItemResponse>> listsMeta(
+      @RequestParam @NotEmpty @Size(max = 10) List<UUID> listIds) {
+    return ResponseEntity.ok(listQueryService.getListsMeta(listIds));
   }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ListMetaItemResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ListMetaItemResponse.java
@@ -1,0 +1,26 @@
+package com.atoook.otsukailist.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/** 複数リストのメタ情報バッチ取得レスポンスの1件分 */
+@Getter
+@AllArgsConstructor
+@Builder
+public class ListMetaItemResponse {
+
+  private UUID listId;
+
+  private String name;
+
+  private long itemCount;
+
+  private long incompleteCount;
+
+  /** アイテムの最終更新日時。アイテムが0件の場合は null。 */
+  private Instant lastItemActivityAt;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
@@ -1,5 +1,6 @@
 package com.atoook.otsukailist.repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,4 +35,28 @@ public interface ItemRepository extends JpaRepository<Item, UUID> {
 
   // リスト内のアイテム存在チェック
   boolean existsByIdAndItemListId(UUID itemId, UUID itemListId);
+
+  /** 複数リストのアイテム集計をまとめて取得する。 存在しないlistIdは結果に含まれない（削除済み判定に使う）。 */
+  @Query(
+      """
+      SELECT i.itemList.id                                    AS listId,
+             COUNT(i)                                         AS itemCount,
+             SUM(CASE WHEN i.completed = false THEN 1 ELSE 0 END) AS incompleteCount,
+             MAX(i.updatedAt)                                 AS lastItemActivityAt
+      FROM Item i
+      WHERE i.itemList.id IN :listIds
+      GROUP BY i.itemList.id
+      """)
+  List<ItemSummaryProjection> summarizeByListIds(@Param("listIds") List<UUID> listIds);
+
+  /** アイテム集計クエリの結果射影 */
+  interface ItemSummaryProjection {
+    UUID getListId();
+
+    long getItemCount();
+
+    long getIncompleteCount();
+
+    Instant getLastItemActivityAt();
+  }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
@@ -3,13 +3,16 @@ package com.atoook.otsukailist.service;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.atoook.otsukailist.dto.ItemListSnapshotResponse;
 import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.ListMetaItemResponse;
 import com.atoook.otsukailist.dto.MemberResponse;
 import com.atoook.otsukailist.exception.ResourceNotFoundException;
 import com.atoook.otsukailist.mapper.ItemMapper;
@@ -64,5 +67,38 @@ public class ListQueryService {
         .members(members)
         .items(items)
         .build();
+  }
+
+  /**
+   * 複数リストのメタ情報をまとめて取得する。
+   *
+   * <p>存在しないlistId（削除済みなど）は結果に含まれない。 アイテムが0件のリストは itemCount=0, incompleteCount=0,
+   * lastItemActivityAt=null で返す。
+   *
+   * @param listIds 取得対象のリストID一覧（最大10件）
+   * @return 存在するリストのメタ情報一覧
+   */
+  @Transactional(readOnly = true)
+  public List<ListMetaItemResponse> getListsMeta(List<UUID> listIds) {
+    List<ItemList> existingLists = itemListRepo.findAllById(listIds);
+
+    // アイテム集計をバッチ取得し、listId -> projection のマップに変換
+    Map<UUID, ItemRepository.ItemSummaryProjection> summaryMap =
+        itemRepo.summarizeByListIds(listIds).stream()
+            .collect(Collectors.toMap(ItemRepository.ItemSummaryProjection::getListId, p -> p));
+
+    return existingLists.stream()
+        .map(
+            list -> {
+              ItemRepository.ItemSummaryProjection summary = summaryMap.get(list.getId());
+              return ListMetaItemResponse.builder()
+                  .listId(list.getId())
+                  .name(list.getName())
+                  .itemCount(summary != null ? summary.getItemCount() : 0L)
+                  .incompleteCount(summary != null ? summary.getIncompleteCount() : 0L)
+                  .lastItemActivityAt(summary != null ? summary.getLastItemActivityAt() : null)
+                  .build();
+            })
+        .toList();
   }
 }

--- a/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
@@ -161,4 +161,55 @@ class JsonSerializationTest {
     assertThat(jsonNode.has("lastItemActivityAt")).isTrue();
     assertThat(jsonNode.get("lastItemActivityAt").isNull()).isTrue();
   }
+
+  @Test
+  @DisplayName("ListMetaItemResponse の lastItemActivityAt が ISO 8601 文字列でシリアライズされること")
+  void testListMetaItemResponseSerializationWithLastItemActivityAt()
+      throws JsonProcessingException {
+    // Given
+    UUID listId = UUID.randomUUID();
+    Instant lastItemActivityAt = Instant.parse("2024-06-15T10:30:00Z");
+
+    ListMetaItemResponse response =
+        ListMetaItemResponse.builder()
+            .listId(listId)
+            .name("テストリスト")
+            .itemCount(5L)
+            .incompleteCount(2L)
+            .lastItemActivityAt(lastItemActivityAt)
+            .build();
+
+    // When
+    String json = objectMapper.writeValueAsString(response);
+
+    // Then
+    JsonNode jsonNode = objectMapper.readTree(json);
+    assertThat(jsonNode.get("lastItemActivityAt").asText())
+        .isEqualTo(lastItemActivityAt.toString());
+    assertThat(jsonNode.get("itemCount").asLong()).isEqualTo(5L);
+    assertThat(jsonNode.get("incompleteCount").asLong()).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("ListMetaItemResponse の lastItemActivityAt が null のとき JSON null でシリアライズされること")
+  void testListMetaItemResponseSerializationWithNullLastItemActivityAt()
+      throws JsonProcessingException {
+    // Given
+    ListMetaItemResponse response =
+        ListMetaItemResponse.builder()
+            .listId(UUID.randomUUID())
+            .name("空のリスト")
+            .itemCount(0L)
+            .incompleteCount(0L)
+            .lastItemActivityAt(null)
+            .build();
+
+    // When
+    String json = objectMapper.writeValueAsString(response);
+
+    // Then
+    JsonNode jsonNode = objectMapper.readTree(json);
+    assertThat(jsonNode.has("lastItemActivityAt")).isTrue();
+    assertThat(jsonNode.get("lastItemActivityAt").isNull()).isTrue();
+  }
 }

--- a/frontend/src/api/list.ts
+++ b/frontend/src/api/list.ts
@@ -3,6 +3,7 @@ import type {
   CreateItemListWithMembersResponse,
   ItemListResponse,
   ItemListSnapshot,
+  ListMetaItem,
   MutationResponse,
   UUID
 } from '@/types/api';
@@ -19,5 +20,14 @@ export async function fetchSnapshot(listId: UUID) {
 
 export async function renameList(listId: UUID, payload: { name: string }) {
   const res = await http.patch<MutationResponse<ItemListResponse>>(`/lists/${listId}`, payload);
+  return res.data;
+}
+
+export async function fetchListsMeta(listIds: UUID[]) {
+  const params = new URLSearchParams();
+  for (const id of listIds) {
+    params.append('listIds', id);
+  }
+  const res = await http.get<ListMetaItem[]>(`/lists/meta?${params.toString()}`);
   return res.data;
 }

--- a/frontend/src/pages/WelcomePage.vue
+++ b/frontend/src/pages/WelcomePage.vue
@@ -50,8 +50,9 @@ export default {
         if (removed.length > 0) {
           this.listHistory = this.listHistory.filter((e) => returnedIds.has(e.listId));
         }
-      } catch {
+      } catch (error) {
         // メタ取得失敗時はキャッシュのリスト名のみ表示継続（UX劣化なし）
+        console.error('Failed to load list metadata', error);
       } finally {
         this.metaLoading = false;
       }
@@ -66,8 +67,9 @@ export default {
     formatLastActivity(isoString) {
       if (!isoString) return null;
       const date = new Date(isoString);
+      if (isNaN(date.getTime())) return null;
       const now = new Date();
-      const diffMs = now.getTime() - date.getTime();
+      const diffMs = Math.max(0, now.getTime() - date.getTime());
       const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
       if (diffDays === 0) {
         return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
@@ -76,6 +78,18 @@ export default {
       } else {
         return date.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' });
       }
+    }
+  },
+  computed: {
+    formattedListMeta() {
+      const result = {};
+      for (const [listId, meta] of Object.entries(this.listMeta)) {
+        result[listId] = {
+          ...meta,
+          formattedActivity: this.formatLastActivity(meta.lastItemActivityAt)
+        };
+      }
+      return result;
     }
   }
 };
@@ -126,15 +140,14 @@ export default {
                 <template v-if="metaLoading">
                   <span class="text-xs text-charcoal-300 animate-pulse">···</span>
                 </template>
-                <template v-else-if="listMeta[entry.listId]">
+                <template v-else-if="formattedListMeta[entry.listId]">
                   <span class="text-xs text-charcoal-500">
-                    {{ listMeta[entry.listId].incompleteCount }}/{{ listMeta[entry.listId].itemCount }}件
+                    {{ formattedListMeta[entry.listId].incompleteCount }}/{{
+                      formattedListMeta[entry.listId].itemCount
+                    }}件
                   </span>
-                  <span
-                    v-if="formatLastActivity(listMeta[entry.listId].lastItemActivityAt)"
-                    class="text-xs text-charcoal-400"
-                  >
-                    {{ formatLastActivity(listMeta[entry.listId].lastItemActivityAt) }}
+                  <span v-if="formattedListMeta[entry.listId].formattedActivity" class="text-xs text-charcoal-400">
+                    {{ formattedListMeta[entry.listId].formattedActivity }}
                   </span>
                 </template>
               </span>

--- a/frontend/src/pages/WelcomePage.vue
+++ b/frontend/src/pages/WelcomePage.vue
@@ -4,6 +4,7 @@ import MainButton from '../components/MainButton.vue';
 import SwipeContainer from '../components/SwipeContainer.vue';
 import BadgeTag from '../components/BadgeTag.vue';
 import { getListHistory, removeListHistoryEntry } from '@/lib/userCache';
+import { fetchListsMeta } from '@/api/list';
 import { FEEDBACK_URL } from '@/lib/appConstants';
 
 export default {
@@ -17,19 +18,64 @@ export default {
   data() {
     return {
       listHistory: [],
+      listMeta: {},
+      metaLoading: false,
       feedbackUrl: FEEDBACK_URL
     };
   },
-  created() {
+  async created() {
     this.listHistory = getListHistory();
+    await this.loadMeta();
   },
   methods: {
+    async loadMeta() {
+      if (this.listHistory.length === 0) return;
+      this.metaLoading = true;
+      try {
+        const ids = this.listHistory.map((e) => e.listId);
+        const metaList = await fetchListsMeta(ids);
+
+        const metaMap = {};
+        for (const m of metaList) {
+          metaMap[m.listId] = m;
+        }
+        this.listMeta = metaMap;
+
+        // 返ってこなかったIDは削除済みとみなしてlocalStorageから除去
+        const returnedIds = new Set(metaList.map((m) => m.listId));
+        const removed = ids.filter((id) => !returnedIds.has(id));
+        for (const id of removed) {
+          removeListHistoryEntry(id);
+        }
+        if (removed.length > 0) {
+          this.listHistory = this.listHistory.filter((e) => returnedIds.has(e.listId));
+        }
+      } catch {
+        // メタ取得失敗時はキャッシュのリスト名のみ表示継続（UX劣化なし）
+      } finally {
+        this.metaLoading = false;
+      }
+    },
     navigateToCreateList() {
       this.$router.push('/create-list');
     },
     removeHistoryEntry(listId) {
       removeListHistoryEntry(listId);
       this.listHistory = this.listHistory.filter((e) => e.listId !== listId);
+    },
+    formatLastActivity(isoString) {
+      if (!isoString) return null;
+      const date = new Date(isoString);
+      const now = new Date();
+      const diffMs = now.getTime() - date.getTime();
+      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      if (diffDays === 0) {
+        return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+      } else if (diffDays < 7) {
+        return `${diffDays}日前`;
+      } else {
+        return date.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' });
+      }
     }
   }
 };
@@ -73,7 +119,25 @@ export default {
               class="flex items-center px-4 py-3 bg-white border border-charcoal-200 rounded-lg hover:bg-charcoal-50 transition-colors"
             >
               <span class="text-charcoal-400 mr-3 text-base" aria-hidden="true">📋</span>
-              <span class="text-sm text-charcoal-700 font-medium truncate flex-1">{{ entry.name }}</span>
+              <span class="text-sm text-charcoal-700 font-medium truncate flex-1">
+                {{ listMeta[entry.listId]?.name ?? entry.name }}
+              </span>
+              <span class="flex items-center gap-2 ml-2 shrink-0">
+                <template v-if="metaLoading">
+                  <span class="text-xs text-charcoal-300 animate-pulse">···</span>
+                </template>
+                <template v-else-if="listMeta[entry.listId]">
+                  <span class="text-xs text-charcoal-500">
+                    {{ listMeta[entry.listId].incompleteCount }}/{{ listMeta[entry.listId].itemCount }}件
+                  </span>
+                  <span
+                    v-if="formatLastActivity(listMeta[entry.listId].lastItemActivityAt)"
+                    class="text-xs text-charcoal-400"
+                  >
+                    {{ formatLastActivity(listMeta[entry.listId].lastItemActivityAt) }}
+                  </span>
+                </template>
+              </span>
               <span class="text-charcoal-300 text-xs ml-2" aria-hidden="true">›</span>
             </router-link>
             <template #hiddenActions>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -51,6 +51,14 @@ export type ItemListResponse = {
   updatedAt?: string;
 };
 
+export type ListMetaItem = {
+  listId: UUID;
+  name: string;
+  itemCount: number;
+  incompleteCount: number;
+  lastItemActivityAt: string | null;
+};
+
 /**
  * Delete API response invariant:
  * at least one deleted target id is always present.


### PR DESCRIPTION
This pull request implements a new batch endpoint to retrieve metadata for multiple item lists at once and uses it to enhance the list history display on the welcome page. The backend adds a `/api/lists/meta` endpoint that returns metadata (name, item counts, last activity) for up to 10 list IDs, omitting any that no longer exist. The frontend calls this endpoint to show up-to-date information for each list in the user's history, including handling deleted lists gracefully.

**Backend: Batch List Metadata API**

- Added the `/api/lists/meta` endpoint in `ItemListQueryController`, which accepts up to 10 list IDs and returns metadata for each existing list. Lists that no longer exist are omitted from the response. [[1]](diffhunk://#diff-1cf1f33a0a29d5ef8d72053e4f3a9991ce2b6c12747b593cdf7349556b14ca08R3-R23) [[2]](diffhunk://#diff-1cf1f33a0a29d5ef8d72053e4f3a9991ce2b6c12747b593cdf7349556b14ca08R40-R53)
- Introduced the `ListMetaItemResponse` DTO to represent the metadata for each list, including item count, incomplete item count, and last activity timestamp.
- Implemented an aggregate query in `ItemRepository` to efficiently summarize item counts and last activity for multiple lists, and exposed a projection interface for the results. [[1]](diffhunk://#diff-4660237e44ab5271c063d9db0958deaebeaa8d0246ad9f73e1ea82aa29561e3eR3) [[2]](diffhunk://#diff-4660237e44ab5271c063d9db0958deaebeaa8d0246ad9f73e1ea82aa29561e3eR38-R61)
- Added `getListsMeta` to `ListQueryService` to coordinate fetching existing lists, aggregating item data, and mapping results to the response DTO. [[1]](diffhunk://#diff-ee111bf8f0e982fd55aeee68d1386465cc9a8f750b16f9477ad482e6eb8370beR6-R15) [[2]](diffhunk://#diff-ee111bf8f0e982fd55aeee68d1386465cc9a8f750b16f9477ad482e6eb8370beR71-R103)

**Frontend: Enhanced List History Display**

- Added the `fetchListsMeta` API function to call the new backend endpoint and retrieve metadata for a batch of list IDs. [[1]](diffhunk://#diff-a9821c472df2c19117d284e2615aa57e4b3544644855ec80bd4e9fff74cd7025R6) [[2]](diffhunk://#diff-a9821c472df2c19117d284e2615aa57e4b3544644855ec80bd4e9fff74cd7025R25-R33)
- Updated the Welcome page to fetch and display live metadata (name, item/incomplete counts, last activity) for each list in the user's history, handle loading states, and remove deleted lists from local storage. [[1]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408R7) [[2]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408R21-R78) [[3]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408L76-R140)
- Defined the `ListMetaItem` type in the frontend API types for type safety.