### PR TITLE
Add maintenance mode functionality and enhance MaintenancePage layout

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# 環境変数例
+VITE_API_BASE_URL=/api
+VITE_BASE_URL=
+VITE_MAINTENANCE_MODE=false # メンテナンス時はtrueに

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,20 +2,33 @@
 import AppLayout from './components/AppLayout.vue';
 import AppHeader from './components/AppHeader.vue';
 import AppFooter from './components/AppFooter.vue';
+import MaintenancePage from './components/MaintenancePage.vue';
+import { isMaintenanceMode } from '@/lib/maintenance';
 
 export default {
   components: {
     AppLayout,
     AppHeader,
-    AppFooter
+    AppFooter,
+    MaintenancePage
+  },
+  data() {
+    return {
+      maintenance: isMaintenanceMode()
+    };
   }
 };
 </script>
 
 <template>
-  <AppLayout>
-    <AppHeader />
-    <router-view />
-    <AppFooter />
-  </AppLayout>
+  <div>
+    <MaintenancePage v-if="maintenance" />
+    <template v-else>
+      <AppLayout>
+        <AppHeader />
+        <router-view />
+        <AppFooter />
+      </AppLayout>
+    </template>
+  </div>
 </template>

--- a/frontend/src/components/MaintenancePage.vue
+++ b/frontend/src/components/MaintenancePage.vue
@@ -1,13 +1,14 @@
 <template>
-  <div class="min-h-[100dvh] bg-charcoal-200 flex items-center justify-center">
-    <div class="min-h-[100dvh] max-w-sm mx-auto flex flex-col w-full bg-wood-50 items-center justify-center">
-      <div class="flex flex-col items-center p-8 rounded-lg shadow-lg w-full bg-white/90 border border-charcoal-100">
+  <AppLayout>
+    <ContentArea layout="center">
+      <div class="p-8 rounded-lg shadow-lg w-full bg-white/90 border border-charcoal-100">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-16 w-16 text-ember-400 mb-4"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
+          aria-hidden="true"
         >
           <path
             stroke-linecap="round"
@@ -22,13 +23,16 @@
         </p>
         <span class="text-xs text-charcoal-300">Otsukaiリスト</span>
       </div>
-    </div>
-  </div>
+    </ContentArea>
+  </AppLayout>
 </template>
 
 <script>
+import AppLayout from './AppLayout.vue';
+import ContentArea from './ContentArea.vue';
 export default {
-  name: 'MaintenancePage'
+  name: 'MaintenancePage',
+  components: { AppLayout, ContentArea }
 };
 </script>
 

--- a/frontend/src/components/MaintenancePage.vue
+++ b/frontend/src/components/MaintenancePage.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="min-h-[100dvh] bg-charcoal-200 flex items-center justify-center">
+    <div class="min-h-[100dvh] max-w-sm mx-auto flex flex-col w-full bg-wood-50 items-center justify-center">
+      <div class="flex flex-col items-center p-8 rounded-lg shadow-lg w-full bg-white/90 border border-charcoal-100">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-16 w-16 text-ember-400 mb-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M12 20a8 8 0 100-16 8 8 0 000 16z"
+          />
+        </svg>
+        <h1 class="text-2xl font-bold mb-2 text-charcoal-700">メンテナンス中</h1>
+        <p class="text-charcoal-500 mb-4 text-center">
+          ご不便をおかけしますが、ただいまメンテナンス作業中です。<br />しばらくお待ちください。
+        </p>
+        <span class="text-xs text-charcoal-300">Otsukaiリスト</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'MaintenancePage'
+};
+</script>
+
+<style scoped></style>

--- a/frontend/src/components/MaintenancePage.vue
+++ b/frontend/src/components/MaintenancePage.vue
@@ -1,7 +1,9 @@
 <template>
   <AppLayout>
     <ContentArea layout="center">
-      <div class="p-8 rounded-lg shadow-lg w-full bg-white/90 border border-charcoal-100">
+      <div
+        class="flex flex-col items-center p-8 rounded-lg shadow-lg w-full bg-white/90 border border-charcoal-100 text-center"
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           class="h-16 w-16 text-ember-400 mb-4"
@@ -18,7 +20,7 @@
           />
         </svg>
         <h1 class="text-2xl font-bold mb-2 text-charcoal-700">メンテナンス中</h1>
-        <p class="text-charcoal-500 mb-4 text-center">
+        <p class="text-charcoal-500 mb-4">
           ご不便をおかけしますが、ただいまメンテナンス作業中です。<br />しばらくお待ちください。
         </p>
         <span class="text-xs text-charcoal-300">Otsukaiリスト</span>

--- a/frontend/src/lib/maintenance.ts
+++ b/frontend/src/lib/maintenance.ts
@@ -1,0 +1,3 @@
+export function isMaintenanceMode(): boolean {
+  return import.meta.env.VITE_MAINTENANCE_MODE === 'true';
+}


### PR DESCRIPTION
This pull request adds a maintenance mode feature to the frontend, allowing the application to display a dedicated maintenance page when the `VITE_MAINTENANCE_MODE` environment variable is set to `true`. The main changes include introducing a new environment variable, displaying a maintenance page, and providing a utility function to check maintenance mode.

**Maintenance mode implementation:**

* Added a new environment variable `VITE_MAINTENANCE_MODE` in `.env.example` to control maintenance mode.
* Added a utility function `isMaintenanceMode` in `src/lib/maintenance.ts` to determine if maintenance mode is enabled.
* Updated `App.vue` to conditionally render the new `MaintenancePage` component when maintenance mode is active.
* Added a new `MaintenancePage.vue` component to display a user-friendly maintenance message.