### PR TITLE
Update import path for MaintenancePage

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,7 +2,7 @@
 import AppLayout from './components/AppLayout.vue';
 import AppHeader from './components/AppHeader.vue';
 import AppFooter from './components/AppFooter.vue';
-import MaintenancePage from './components/MaintenancePage.vue';
+import MaintenancePage from './pages/MaintenancePage.vue';
 import { isMaintenanceMode } from '@/lib/maintenance';
 
 export default {

--- a/frontend/src/pages/MaintenancePage.vue
+++ b/frontend/src/pages/MaintenancePage.vue
@@ -1,3 +1,13 @@
+<script>
+import AppLayout from '../components/AppLayout.vue';
+import ContentArea from '../components/ContentArea.vue';
+
+export default {
+  name: 'MaintenancePage',
+  components: { AppLayout, ContentArea }
+};
+</script>
+
 <template>
   <AppLayout>
     <ContentArea layout="center">
@@ -28,14 +38,3 @@
     </ContentArea>
   </AppLayout>
 </template>
-
-<script>
-import AppLayout from './AppLayout.vue';
-import ContentArea from './ContentArea.vue';
-export default {
-  name: 'MaintenancePage',
-  components: { AppLayout, ContentArea }
-};
-</script>
-
-<style scoped></style>


### PR DESCRIPTION
This pull request refactors the location of the `MaintenancePage` component to improve project organization by moving it from the `components` directory to the `pages` directory. It also updates imports throughout the codebase to reflect this change.

Component organization:

* Moved `MaintenancePage.vue` from `frontend/src/components` to `frontend/src/pages` and updated its import path in `App.vue` to reflect the new location. [[1]](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878L5-R5) [[2]](diffhunk://#diff-ee153187be797d18d9c59eef53e219b4cc2b3c1f724a7812e81eb31a048b8f34R1-R10)
* Adjusted internal imports in `MaintenancePage.vue` to reference the correct relative paths for `AppLayout` and `ContentArea` after the move.
* Cleaned up redundant code and removed the unused `<style scoped></style>` section from `MaintenancePage.vue`.