### PR TITLE
Improve layout and responsiveness of UI components

### DIFF
--- a/frontend/src/components/DropDown.vue
+++ b/frontend/src/components/DropDown.vue
@@ -67,7 +67,7 @@ export default {
       // 幅をwidthプロパティで制御
       const widthClasses = {
         full: 'flex-1',
-        fixed: 'w-32'
+        fixed: 'w-28 min-[380px]:w-32'
       };
 
       const rightPadding = this.showArrow ? 'pr-8' : 'pr-3';

--- a/frontend/src/components/MainButton.vue
+++ b/frontend/src/components/MainButton.vue
@@ -28,6 +28,8 @@ export default {
   computed: {
     buttonClass() {
       const baseClass = [
+        // Layout
+        'inline-flex shrink-0 items-center justify-center whitespace-nowrap',
         // Base shape (rounded corners)
         'rounded-lg',
         // Typography

--- a/frontend/src/components/TextInput.vue
+++ b/frontend/src/components/TextInput.vue
@@ -100,7 +100,7 @@ export default {
         ].join(' '),
         inline: [
           // Flexible inline input (no padding - container provides it)
-          'flex-1',
+          'min-w-0 flex-1',
           // Minimal styling for inline use
           'border-transparent bg-transparent',
           // No focus ring for inline

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -237,12 +237,18 @@ export default defineComponent({
         </div>
       </div>
       <!-- チェック時に記録する購入者選択 + サマリー -->
-      <div v-if="filteredItems.length > 0" class="w-full flex justify-between items-center mb-2">
-        <div class="flex flex-col gap-0.5">
-          <span class="text-xs text-charcoal-600"
+      <div
+        v-if="filteredItems.length > 0"
+        class="@container flex w-full flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-2"
+      >
+        <div class="flex min-w-max flex-col gap-0.5 @max-[19rem]:mx-auto">
+          <span class="inline-flex whitespace-nowrap text-xs text-charcoal-600"
             >{{ itemSummary }}<IconCelebration v-if="allCompleted" class="ml-1"
           /></span>
-          <span v-if="formattedLastItemActivityAt" class="text-xs text-charcoal-500 flex items-center gap-1">
+          <span
+            v-if="formattedLastItemActivityAt"
+            class="inline-flex items-center gap-1 whitespace-nowrap text-xs text-charcoal-500"
+          >
             最終更新: {{ formattedLastItemActivityAt }}
             <IconButton
               @click="currentListId && loadSnapshot(currentListId)"
@@ -256,9 +262,9 @@ export default defineComponent({
             </IconButton>
           </span>
         </div>
-        <div class="flex items-center gap-2 text-sm">
+        <div class="ml-auto flex shrink-0 items-center gap-2 text-sm">
           <label for="memberSelect">
-            <span class="text-charcoal-600 font-medium">買った人</span>
+            <span class="whitespace-nowrap text-charcoal-600 font-medium">買った人</span>
           </label>
           <DropDown
             selectId="memberSelect"


### PR DESCRIPTION
This pull request makes several improvements to the UI layout and responsiveness across multiple components, focusing on better flexbox usage, whitespace handling, and adaptive sizing for small screens. The changes enhance the visual consistency and adaptability of the interface, especially in the `ItemListPage`, `DropDown`, `MainButton`, and `TextInput` components.

**Responsive and Layout Improvements:**

* [`ItemListPage.vue`](diffhunk://#diff-3f5818ec33d23995f71d69557331222dbef5378c72bcae26f63c25605e8b2ef3L240-R251): Refactored the summary and purchaser selection section to use more responsive flex and wrapping classes, improving layout on small screens and ensuring elements don't overflow. Added container queries and whitespace utilities for better adaptability.
* [`ItemListPage.vue`](diffhunk://#diff-3f5818ec33d23995f71d69557331222dbef5378c72bcae26f63c25605e8b2ef3L259-R267): Improved alignment and spacing of the purchaser dropdown by making the container shrinkable and ensuring the label text doesn't wrap unnecessarily.

**Component Styling Updates:**

* [`DropDown.vue`](diffhunk://#diff-edeb8761304af2257986748eaacb7416b302515db9f44ef52ab7deaef07956b8L70-R70): Adjusted the fixed width option to use a smaller base width (`w-28`) and expand to `w-32` on screens wider than 380px, making dropdowns more responsive.
* [`MainButton.vue`](diffhunk://#diff-658044b3694f40718b986cb8098bac3c1e9c672a6df2c13ba483b587f365386bR31-R32): Added a set of flexbox and whitespace utility classes to the button base, ensuring consistent alignment and preventing text overflow.
* [`TextInput.vue`](diffhunk://#diff-72a3fb97e51717a372bfd317e7c7acdd29dcaa0ed128b315b7d00ca3f8debe19L103-R103): Added `min-w-0` to the inline input style to prevent flexbox children from exceeding their container's width.