### PR TITLE
Add item editing functionality with validation in ItemEditPage

### DIFF
--- a/frontend/src/components/DropDown.vue
+++ b/frontend/src/components/DropDown.vue
@@ -66,7 +66,7 @@ export default {
 
       // 幅をwidthプロパティで制御
       const widthClasses = {
-        full: 'flex-1',
+        full: 'w-full',
         fixed: 'w-28 min-[380px]:w-32'
       };
 

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -163,14 +163,15 @@ export default {
       if (this.item.itemType !== 'quantified' || !this.item.quantified) {
         return '';
       }
-      const unitLabel = UNIT_DEFINITIONS[this.item.quantified.baseUnit].label;
+      const unitDefinition = UNIT_DEFINITIONS[this.item.quantified.baseUnit];
+      const unitLabel = unitDefinition?.label ?? this.item.quantified.baseUnit ?? '';
       return `${this.item.quantified.quantity}${unitLabel}`;
     },
     categoryLabel() {
       if (!this.item.category) {
         return '';
       }
-      return ITEM_CATEGORIES[this.item.category].label;
+      return ITEM_CATEGORIES[this.item.category]?.label ?? this.item.category;
     }
   },
   watch: {

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -25,11 +25,21 @@
           @blur="handleBlur"
           variant="inline"
         />
+        <div v-if="quantifiedLabel || categoryLabel" class="mt-1 flex flex-wrap gap-1">
+          <BadgeTag v-if="quantifiedLabel" :text="quantifiedLabel" size="small" variant="secondary" />
+          <BadgeTag v-if="categoryLabel" :text="categoryLabel" size="small" variant="secondary" />
+        </div>
         <p v-if="shouldShowAutosaveHint" class="text-xs text-charcoal-500 mt-1">変更は自動保存されます</p>
       </div>
-      <span v-else class="min-w-0 flex-1 truncate line-through text-charcoal-500">
-        {{ item.name }}
-      </span>
+      <div v-else class="min-w-0 flex-1 flex flex-col">
+        <span class="truncate line-through text-charcoal-500">
+          {{ item.name }}
+        </span>
+        <div v-if="quantifiedLabel || categoryLabel" class="mt-1 flex flex-wrap gap-1">
+          <BadgeTag v-if="quantifiedLabel" :text="quantifiedLabel" size="small" variant="secondary" />
+          <BadgeTag v-if="categoryLabel" :text="categoryLabel" size="small" variant="secondary" />
+        </div>
+      </div>
       <span v-if="showSaveIndicator" class="text-success-600 flex items-center" role="status" aria-label="保存済み"
         ><IconCheck
       /></span>
@@ -83,6 +93,8 @@ import IconTrash from './icons/IconTrash.vue';
 import type { Item, ItemId } from '../types/item';
 import { isItem, isItemCompleted } from '../types/item';
 import { normalizeText } from '../utils/text-normalization';
+import { UNIT_DEFINITIONS } from '@/types/list-generation';
+import { ITEM_CATEGORIES } from '@/types/item-category';
 
 export default {
   name: 'ItemBox',
@@ -146,6 +158,19 @@ export default {
     },
     memberBadgeText() {
       return this.memberName.trim().charAt(0);
+    },
+    quantifiedLabel() {
+      if (this.item.itemType !== 'quantified' || !this.item.quantified) {
+        return '';
+      }
+      const unitLabel = UNIT_DEFINITIONS[this.item.quantified.baseUnit].label;
+      return `${this.item.quantified.quantity}${unitLabel}`;
+    },
+    categoryLabel() {
+      if (!this.item.category) {
+        return '';
+      }
+      return ITEM_CATEGORIES[this.item.category].label;
     }
   },
   watch: {

--- a/frontend/src/pages/ItemEditPage.test.ts
+++ b/frontend/src/pages/ItemEditPage.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import ItemEditPage from './ItemEditPage.vue';
+
+type ItemEditPageOptions = {
+  data: () => Record<string, unknown>;
+  methods: Record<string, (this: Record<string, unknown>, ...args: unknown[]) => unknown>;
+  computed: Record<string, (this: Record<string, unknown>) => unknown>;
+};
+
+function createVm(overrides: Record<string, unknown> = {}) {
+  const component = ItemEditPage as unknown as ItemEditPageOptions;
+  const vm: Record<string, unknown> = {
+    ...component.data(),
+    ...overrides
+  };
+
+  Object.entries(component.methods).forEach(([name, method]) => {
+    vm[name] = method.bind(vm);
+  });
+  Object.entries(component.computed).forEach(([name, getter]) => {
+    Object.defineProperty(vm, name, {
+      get: () => getter.call(vm)
+    });
+  });
+
+  return vm;
+}
+
+describe('ItemEditPage', () => {
+  describe('数量付き入力のバリデーション', () => {
+    it('数量だけ入力されて単位が未選択の場合は更新不可にする', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        quantifiedQuantity: '1000',
+        quantifiedBaseUnit: ''
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(true);
+      expect(vm.hasValidQuantifiedInput).toBe(false);
+      expect(vm.hasRequiredInput).toBe(false);
+    });
+
+    it('単位だけ選択されて数量が空の場合は更新不可にする', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        quantifiedQuantity: '',
+        quantifiedBaseUnit: 'g'
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(true);
+      expect(vm.hasValidQuantifiedInput).toBe(false);
+      expect(vm.hasRequiredInput).toBe(false);
+    });
+
+    it('数量0と単位が入力されている場合は更新可能にする', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        quantifiedQuantity: '0',
+        quantifiedBaseUnit: 'g'
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(true);
+      expect(vm.hasValidQuantifiedInput).toBe(true);
+      expect(vm.hasRequiredInput).toBe(true);
+    });
+  });
+
+  describe('数量付きアイテムの更新payload', () => {
+    it('plain は通常アイテムとして送信する', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        selectedCategory: 'meat',
+        itemEditMode: 'plain',
+        quantifiedQuantity: '',
+        quantifiedBaseUnit: ''
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
+
+      expect(payload).toMatchObject({
+        name: '牛肉',
+        category: 'meat',
+        itemType: 'plain'
+      });
+      expect(payload.quantified).toBeUndefined();
+    });
+
+    it('manual_none は手入力の数量付きアイテムとして送信する', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        selectedCategory: 'meat',
+        itemEditMode: 'manual_none',
+        quantifiedQuantity: '1000',
+        quantifiedBaseUnit: 'g',
+        quantifiedGeneratorKey: ''
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
+
+      expect(payload.category).toBe('meat');
+      expect(payload.itemType).toBe('quantified');
+      expect(payload.quantified).toMatchObject({
+        quantity: 1000,
+        baseUnit: 'g',
+        origin: 'manual',
+        regenerationPolicy: 'none',
+        generatorKey: null
+      });
+    });
+
+    it('generated_auto は生成ルール由来カテゴリを送信する', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        selectedCategory: 'sweets',
+        itemEditMode: 'generated_auto',
+        quantifiedQuantity: '1000',
+        quantifiedBaseUnit: 'g',
+        quantifiedGeneratorKey: 'beef'
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
+
+      expect(payload.category).toBe('meat');
+      expect(payload.itemType).toBe('quantified');
+      expect(payload.quantified).toMatchObject({
+        quantity: 1000,
+        baseUnit: 'g',
+        origin: 'generated',
+        regenerationPolicy: 'auto',
+        generatorKey: 'beef'
+      });
+    });
+
+    it('generated_locked は既存の選択カテゴリを保持して送信する', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        selectedCategory: 'sweets',
+        itemEditMode: 'generated_locked',
+        quantifiedQuantity: '1000',
+        quantifiedBaseUnit: 'g',
+        quantifiedGeneratorKey: 'beef'
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
+
+      expect(payload.category).toBe('sweets');
+      expect(payload.itemType).toBe('quantified');
+      expect(payload.quantified).toMatchObject({
+        quantity: 1000,
+        baseUnit: 'g',
+        origin: 'generated',
+        regenerationPolicy: 'locked',
+        generatorKey: 'beef'
+      });
+    });
+  });
+});

--- a/frontend/src/pages/ItemEditPage.test.ts
+++ b/frontend/src/pages/ItemEditPage.test.ts
@@ -63,6 +63,18 @@ describe('ItemEditPage', () => {
       expect(vm.hasValidQuantifiedInput).toBe(true);
       expect(vm.hasRequiredInput).toBe(true);
     });
+
+    it('JSで安全に表現できない整数は更新不可にする', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        quantifiedQuantity: String(Number.MAX_SAFE_INTEGER + 1),
+        quantifiedBaseUnit: 'g'
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(true);
+      expect(vm.hasValidQuantifiedInput).toBe(false);
+      expect(vm.hasRequiredInput).toBe(false);
+    });
   });
 
   describe('数量付きアイテムの更新payload', () => {

--- a/frontend/src/pages/ItemEditPage.vue
+++ b/frontend/src/pages/ItemEditPage.vue
@@ -3,28 +3,38 @@ import { defineComponent } from 'vue';
 import { NavigationFailureType, isNavigationFailure } from 'vue-router';
 import ContentArea from '../components/ContentArea.vue';
 import MainButton from '../components/MainButton.vue';
-import TextInputWithLabel from '../components/TextInputWithLabel.vue';
+import TextInput from '../components/TextInput.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
+import DropDown from '../components/DropDown.vue';
 import IconTools from '../components/icons/IconTools.vue';
 import IconUsers from '../components/icons/IconUsers.vue';
 import type { Item } from '../types/item';
+import { ITEM_CATEGORIES, type ItemCategory } from '../types/item-category';
 import type { Member, MemberId } from '../types/member';
+import { UNIT_DEFINITIONS, type BaseUnit, type ItemOrigin, type RegenerationPolicy } from '../types/list-generation';
 import { normalizeText } from '../utils/text-normalization';
 import { useListStore } from '@/stores/list';
 import { useMutation } from '@/composables/useMutation';
 import { updateItem, type UpdateItemPayload } from '@/api/item';
 import { fetchSnapshot } from '@/api/list';
 import { getErrorMessage } from '@/lib/http';
+import { BBQ_GENERATION_RULES } from '@/lib/listGenerationConstants';
 
 const UNASSIGNED_MEMBER_VALUE = '';
+const UNCATEGORIZED_VALUE = '';
+const UNSET_GENERATOR_KEY_VALUE = '';
+const UNSELECTED_BASE_UNIT_VALUE = '';
+
+type ItemEditMode = 'plain' | 'manual_none' | 'generated_auto' | 'generated_locked';
 
 export default defineComponent({
   name: 'ItemEditPage',
   components: {
     ContentArea,
     MainButton,
-    TextInputWithLabel,
+    TextInput,
     LoadingSpinner,
+    DropDown,
     IconTools,
     IconUsers
   },
@@ -38,6 +48,11 @@ export default defineComponent({
     currentItemId: string | null;
     errorMessage: string;
     snapshotLoading: boolean;
+    selectedCategory: ItemCategory | typeof UNCATEGORIZED_VALUE;
+    itemEditMode: ItemEditMode;
+    quantifiedQuantity: string;
+    quantifiedBaseUnit: BaseUnit | typeof UNSELECTED_BASE_UNIT_VALUE;
+    quantifiedGeneratorKey: string | typeof UNSET_GENERATOR_KEY_VALUE;
   } {
     return {
       currentListId: null,
@@ -48,7 +63,12 @@ export default defineComponent({
       selectedMemberId: UNASSIGNED_MEMBER_VALUE,
       currentItemId: null,
       errorMessage: '',
-      snapshotLoading: false
+      snapshotLoading: false,
+      selectedCategory: UNCATEGORIZED_VALUE,
+      itemEditMode: 'plain',
+      quantifiedQuantity: '',
+      quantifiedBaseUnit: UNSELECTED_BASE_UNIT_VALUE,
+      quantifiedGeneratorKey: UNSET_GENERATOR_KEY_VALUE
     };
   },
   setup() {
@@ -92,7 +112,35 @@ export default defineComponent({
       this.originalAssignedMemberId = item.assignedMemberId ?? null;
       this.selectedMemberId =
         (item.completed ? item.completedByMemberId : item.assignedMemberId) ?? UNASSIGNED_MEMBER_VALUE;
+      this.selectedCategory = item.category ?? UNCATEGORIZED_VALUE;
       this.members = this.listStore.members.map((m) => ({ ...m }));
+      this.applyQuantifiedItem(item);
+    },
+    applyQuantifiedItem(item: Item): void {
+      if (item.itemType !== 'quantified' || !item.quantified) {
+        this.itemEditMode = 'plain';
+        this.quantifiedQuantity = '';
+        this.quantifiedBaseUnit = UNSELECTED_BASE_UNIT_VALUE;
+        this.quantifiedGeneratorKey = UNSET_GENERATOR_KEY_VALUE;
+        return;
+      }
+
+      this.itemEditMode = this.resolveItemEditMode(item.quantified.origin, item.quantified.regenerationPolicy);
+      this.quantifiedQuantity = String(item.quantified.quantity);
+      this.quantifiedBaseUnit = item.quantified.baseUnit;
+      this.quantifiedGeneratorKey = item.quantified.generatorKey ?? UNSET_GENERATOR_KEY_VALUE;
+      if (this.usesGeneratedCategory && this.selectedGeneratorRule) {
+        this.selectedCategory = this.selectedGeneratorRule.category;
+      }
+    },
+    resolveItemEditMode(origin: ItemOrigin, regenerationPolicy: RegenerationPolicy): ItemEditMode {
+      if (origin === 'generated' && regenerationPolicy === 'auto') {
+        return 'generated_auto';
+      }
+      if (origin === 'generated' && regenerationPolicy === 'locked') {
+        return 'generated_locked';
+      }
+      return 'manual_none';
     },
     async loadSnapshot(listId: string): Promise<void> {
       this.snapshotLoading = true;
@@ -114,10 +162,39 @@ export default defineComponent({
     getCurrentSelectedMemberId(): MemberId | null {
       return this.selectedMemberId || null;
     },
+    getSelectedCategory(): ItemCategory | null {
+      if (this.hasSelectedBaseUnit && this.usesGeneratedCategory && this.selectedGeneratorRule) {
+        return this.selectedGeneratorRule.category;
+      }
+      return this.selectedCategory || null;
+    },
+    setSelectedCategory(value: string): void {
+      this.selectedCategory = value as ItemCategory | typeof UNCATEGORIZED_VALUE;
+    },
+    setQuantifiedBaseUnit(value: string): void {
+      this.quantifiedBaseUnit = value as BaseUnit | typeof UNSELECTED_BASE_UNIT_VALUE;
+      if (this.quantifiedBaseUnit === UNSELECTED_BASE_UNIT_VALUE) {
+        this.quantifiedQuantity = '';
+      }
+    },
     buildUpdatePayload(normalizedName: string): UpdateItemPayload {
       const payload: UpdateItemPayload = {
-        name: normalizedName
+        name: normalizedName,
+        category: this.getSelectedCategory()
       };
+
+      if (this.hasSelectedBaseUnit) {
+        payload.itemType = 'quantified';
+        payload.quantified = {
+          quantity: this.parsedQuantifiedQuantity,
+          baseUnit: this.quantifiedBaseUnit as BaseUnit,
+          origin: this.currentOrigin,
+          regenerationPolicy: this.currentRegenerationPolicy,
+          generatorKey: this.isGeneratedMode ? this.quantifiedGeneratorKey || null : null
+        };
+      } else {
+        payload.itemType = 'plain';
+      }
 
       if (this.isCompleted) {
         payload.completed = true;
@@ -137,13 +214,17 @@ export default defineComponent({
         this.errorMessage = 'アイテムIDが無効です';
         return;
       }
-      const normalizedName = normalizeText(this.itemName);
+      const normalizedName = this.normalizedItemName;
       if (!normalizedName) {
         this.errorMessage = 'アイテム名を入力してください。';
         return;
       }
       if (this.isCompleted && !this.getCurrentSelectedMemberId()) {
         this.errorMessage = '買った人を選択してください。';
+        return;
+      }
+      if (this.hasQuantifiedDraftInput && !this.hasValidQuantifiedInput) {
+        this.errorMessage = '数量付きアイテムの各項目を正しく入力してください。';
         return;
       }
       try {
@@ -200,14 +281,93 @@ export default defineComponent({
     }
   },
   computed: {
+    normalizedItemName(): string {
+      return normalizeText(this.itemName);
+    },
+    normalizedQuantifiedQuantity(): string {
+      return normalizeText(this.quantifiedQuantity);
+    },
+    parsedQuantifiedQuantity(): number {
+      return Number(this.normalizedQuantifiedQuantity);
+    },
     hasRequiredInput(): boolean {
-      return !!normalizeText(this.itemName) && (!this.isCompleted || !!this.getCurrentSelectedMemberId());
+      return (
+        !!this.normalizedItemName &&
+        (!this.isCompleted || !!this.getCurrentSelectedMemberId()) &&
+        (!this.hasQuantifiedDraftInput || this.hasValidQuantifiedInput)
+      );
+    },
+    hasQuantifiedDraftInput(): boolean {
+      return this.hasSelectedBaseUnit || !!this.normalizedQuantifiedQuantity;
+    },
+    hasValidQuantifiedInput(): boolean {
+      return (
+        !!this.normalizedItemName &&
+        !!this.normalizedQuantifiedQuantity &&
+        Number.isInteger(this.parsedQuantifiedQuantity) &&
+        this.parsedQuantifiedQuantity >= 0 &&
+        !!this.quantifiedBaseUnit &&
+        (!this.requiresGeneratorKey || !!this.quantifiedGeneratorKey)
+      );
+    },
+    hasSelectedBaseUnit(): boolean {
+      return !!this.quantifiedBaseUnit;
+    },
+    isGeneratedMode(): boolean {
+      return this.itemEditMode === 'generated_auto' || this.itemEditMode === 'generated_locked';
+    },
+    usesGeneratedCategory(): boolean {
+      return this.itemEditMode === 'generated_auto';
+    },
+    requiresGeneratorKey(): boolean {
+      return this.isGeneratedMode;
+    },
+    currentOrigin(): ItemOrigin {
+      return this.isGeneratedMode ? 'generated' : 'manual';
+    },
+    currentRegenerationPolicy(): RegenerationPolicy {
+      if (this.itemEditMode === 'generated_auto') {
+        return 'auto';
+      }
+      if (this.itemEditMode === 'generated_locked') {
+        return 'locked';
+      }
+      return 'none';
+    },
+    currentCategoryLabel(): string {
+      const category = this.getSelectedCategory();
+      if (!category) {
+        return '未分類';
+      }
+      return Object.values(ITEM_CATEGORIES).find((itemCategory) => itemCategory.code === category)?.label ?? category;
+    },
+    selectedGeneratorRule(): (typeof BBQ_GENERATION_RULES)[keyof typeof BBQ_GENERATION_RULES] | undefined {
+      if (!this.quantifiedGeneratorKey) {
+        return undefined;
+      }
+      return Object.values(BBQ_GENERATION_RULES).find((rule) => rule.generatorKey === this.quantifiedGeneratorKey);
     },
     isLoading(): boolean {
       return this.mutationLoading || this.snapshotLoading;
     },
     memberLabel(): string {
       return this.isCompleted ? '買った人' : '買う人';
+    },
+    categoryOptions(): Array<{ id: string; name: string }> {
+      return [
+        { id: UNCATEGORIZED_VALUE, name: '未分類' },
+        ...Object.values(ITEM_CATEGORIES)
+          .sort((a, b) => a.sortOrder - b.sortOrder)
+          .map((category) => ({ id: category.code, name: category.label }))
+      ];
+    },
+    baseUnitOptions(): Array<{ id: string; name: string }> {
+      return [
+        { id: UNSELECTED_BASE_UNIT_VALUE, name: '未選択' },
+        ...Object.values(UNIT_DEFINITIONS)
+          .filter((definition) => definition.code === definition.baseUnit)
+          .map((definition) => ({ id: definition.baseUnit, name: definition.label }))
+      ];
     }
   }
 });
@@ -223,15 +383,65 @@ export default defineComponent({
       <h2 class="text-2xl font-bold text-charcoal-800">アイテムを編集</h2>
     </div>
 
-    <div class="mb-6">
-      <TextInputWithLabel
-        input-id="itemName"
-        placeholder="例：牛肉"
-        :model-value="itemName"
-        @update:model-value="onItemNameInput"
-      >
-        <template #label>アイテム名</template>
-      </TextInputWithLabel>
+    <div class="mb-8 rounded-xl border border-wood-200 bg-wood-50 p-4">
+      <div class="grid gap-5">
+        <div>
+          <div class="mb-2">
+            <label for="itemName" class="text-sm font-medium text-charcoal-700">
+              アイテム名 <span class="text-ember-600">*</span>
+            </label>
+          </div>
+          <TextInput
+            input-id="itemName"
+            placeholder="例：マシュマロ"
+            :model-value="itemName"
+            @update:model-value="onItemNameInput"
+          />
+        </div>
+
+        <div>
+          <label for="itemCategory" class="mb-2 block text-sm font-medium text-charcoal-700">
+            カテゴリ
+            <span v-if="hasSelectedBaseUnit && usesGeneratedCategory" class="text-xs font-normal text-charcoal-500">
+              （自動設定）
+            </span>
+          </label>
+          <template v-if="hasSelectedBaseUnit && usesGeneratedCategory">
+            <p class="rounded-lg border border-wood-200 bg-white px-3 py-2 text-sm font-semibold text-charcoal-700">
+              {{ currentCategoryLabel }}
+            </p>
+          </template>
+          <DropDown
+            v-else
+            select-id="itemCategory"
+            select-name="itemCategory"
+            :model-value="selectedCategory"
+            :option-items="categoryOptions"
+            @update:model-value="setSelectedCategory"
+          />
+        </div>
+
+        <div>
+          <label for="quantifiedQuantity" class="mb-2 block text-sm font-medium text-charcoal-700"> 数量(単位) </label>
+          <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+            <TextInput
+              input-id="quantifiedQuantity"
+              placeholder="例：1000"
+              :model-value="quantifiedQuantity"
+              @update:model-value="quantifiedQuantity = $event"
+            />
+            <DropDown
+              select-id="quantifiedBaseUnit"
+              select-name="quantifiedBaseUnit"
+              :model-value="quantifiedBaseUnit"
+              :option-items="baseUnitOptions"
+              width="fixed"
+              :show-arrow="true"
+              @update:model-value="setQuantifiedBaseUnit"
+            />
+          </div>
+        </div>
+      </div>
     </div>
 
     <div v-if="errorMessage" class="mb-4 p-3 bg-ember-100 border border-ember-300 text-ember-700 rounded-lg text-sm">

--- a/frontend/src/pages/ItemEditPage.vue
+++ b/frontend/src/pages/ItemEditPage.vue
@@ -305,6 +305,7 @@ export default defineComponent({
         !!this.normalizedItemName &&
         !!this.normalizedQuantifiedQuantity &&
         Number.isInteger(this.parsedQuantifiedQuantity) &&
+        Number.isSafeInteger(this.parsedQuantifiedQuantity) &&
         this.parsedQuantifiedQuantity >= 0 &&
         !!this.quantifiedBaseUnit &&
         (!this.requiresGeneratorKey || !!this.quantifiedGeneratorKey)

--- a/frontend/src/types/item-category.ts
+++ b/frontend/src/types/item-category.ts
@@ -7,7 +7,7 @@ export const ITEM_CATEGORIES = {
   drinks: { code: 'drinks', label: '飲み物', sortOrder: 60 },
   seasonings: { code: 'seasonings', label: '調味料', sortOrder: 70 },
   sweets: { code: 'sweets', label: 'お菓子', sortOrder: 80 },
-  dailyGoods: { code: 'daily_goods', label: '日用品', sortOrder: 90 },
+  daily_goods: { code: 'daily_goods', label: '日用品', sortOrder: 90 },
   supplies: { code: 'supplies', label: '消耗品', sortOrder: 100 },
   other: { code: 'other', label: 'その他', sortOrder: 999 }
 } as const;


### PR DESCRIPTION
This pull request introduces significant improvements to the item editing experience, especially for handling items with quantities and categories. The main focus is to support "quantified" items (items with a quantity and unit), improve input validation, and enhance the UI for editing these properties. Additionally, it adds comprehensive unit tests for the new logic.

The most important changes are:

**Quantified Item Support and Validation**
* Added support for editing "quantified" items, including quantity, unit, and generator key, with appropriate UI elements and state handling in `ItemEditPage.vue`. [[1]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fL6-R37) [[2]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR51-R55) [[3]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fL51-R71) [[4]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR115-R143) [[5]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR165-R198) [[6]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fL140-R217) [[7]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR226-R229) [[8]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR284-R370) [[9]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fL226-R444)
* Implemented robust validation logic for quantified items, ensuring that both quantity and unit are provided and valid before allowing updates. [[1]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR284-R370) [[2]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fR226-R229) [[3]](diffhunk://#diff-af8eaea8494bbd9854bd106a1db4ccb4737533d43240d6e180007694c36506d7R1-R157)

**UI/UX Improvements**
* Redesigned the item edit form to display and edit item name, category (with auto-assignment for generated items), quantity, and unit using new and improved input components (`TextInput`, `DropDown`). [[1]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fL6-R37) [[2]](diffhunk://#diff-cf39718e77e8c2a8925e96e35c1fb68775067423e564dc5bef96111b1a09db6fL226-R444) [[3]](diffhunk://#diff-edeb8761304af2257986748eaacb7416b302515db9f44ef52ab7deaef07956b8L69-R69)
* Updated `ItemBox.vue` to show badge tags for quantity/unit and category, both in normal and completed states, for better item information visibility. [[1]](diffhunk://#diff-9e2748eef2abd338f8fc3ade6112c13e12c2d7801c071ca328463fce5484be35R28-R42) [[2]](diffhunk://#diff-9e2748eef2abd338f8fc3ade6112c13e12c2d7801c071ca328463fce5484be35R161-R173) [[3]](diffhunk://#diff-9e2748eef2abd338f8fc3ade6112c13e12c2d7801c071ca328463fce5484be35R96-R97)

**Testing**
* Added a new test file `ItemEditPage.test.ts` with comprehensive tests for quantified item validation and payload generation, covering various input scenarios and edit modes.

**Data Consistency**
* Fixed a typo in the `ITEM_CATEGORIES` definition to ensure consistent category codes (`daily_goods` instead of `dailyGoods`).

These changes collectively make the item editing interface more robust, user-friendly, and reliable, especially for items that require quantity and unit information.…mEditPage