### PR TITLE
Enhance item model with preparation type and filtering functionality

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 import com.atoook.otsukailist.model.ItemCategory;
+import com.atoook.otsukailist.model.ItemPreparationType;
 import com.atoook.otsukailist.model.ItemType;
 
 import lombok.AllArgsConstructor;
@@ -31,6 +32,8 @@ public class CreateItemRequest {
   @Builder.Default private ItemType itemType = ItemType.PLAIN;
 
   private ItemCategory category;
+
+  private ItemPreparationType preparationType;
 
   @Valid private QuantifiedItemRequest quantified;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ItemResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ItemResponse.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import com.atoook.otsukailist.model.ItemCategory;
+import com.atoook.otsukailist.model.ItemPreparationType;
 import com.atoook.otsukailist.model.ItemType;
 
 import lombok.AllArgsConstructor;
@@ -25,6 +26,8 @@ public class ItemResponse {
   private ItemType itemType;
 
   private ItemCategory category;
+
+  private ItemPreparationType preparationType;
 
   private QuantifiedItemResponse quantified;
 

--- a/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 
 import com.atoook.otsukailist.model.ItemCategory;
+import com.atoook.otsukailist.model.ItemPreparationType;
 import com.atoook.otsukailist.model.ItemType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -37,6 +38,10 @@ public class UpdateItemRequest {
 
   @JsonIgnore private boolean categoryPresent;
 
+  private ItemPreparationType preparationType;
+
+  @JsonIgnore private boolean preparationTypePresent;
+
   private UUID assignedMemberId;
 
   @JsonIgnore private boolean assignedMemberIdPresent;
@@ -50,6 +55,16 @@ public class UpdateItemRequest {
   public void setCategory(ItemCategory category) {
     this.category = category;
     this.categoryPresent = true;
+  }
+
+  @JsonSetter("preparationType")
+  public void setPreparationType(ItemPreparationType preparationType) {
+    this.preparationType = preparationType;
+    this.preparationTypePresent = true;
+  }
+
+  public ItemPreparationType getPreparationTypeOrDefault(ItemPreparationType defaultValue) {
+    return preparationTypePresent ? preparationType : defaultValue;
   }
 
   @JsonSetter("assignedMemberId")
@@ -72,6 +87,12 @@ public class UpdateItemRequest {
     public UpdateItemRequestBuilder category(ItemCategory category) {
       this.category = category;
       this.categoryPresent = true;
+      return this;
+    }
+
+    public UpdateItemRequestBuilder preparationType(ItemPreparationType preparationType) {
+      this.preparationType = preparationType;
+      this.preparationTypePresent = true;
       return this;
     }
   }

--- a/backend/src/main/java/com/atoook/otsukailist/generation/ItemPreparationTypes.java
+++ b/backend/src/main/java/com/atoook/otsukailist/generation/ItemPreparationTypes.java
@@ -11,11 +11,8 @@ public class ItemPreparationTypes {
   public static final Map<ItemPreparationType, ItemPreparationTypeDefinition> VALUES =
       Map.ofEntries(
           Map.entry(
-              ItemPreparationType.BUY,
-              new ItemPreparationTypeDefinition(ItemPreparationType.BUY, "購入", 10)),
-          Map.entry(
               ItemPreparationType.BRING,
-              new ItemPreparationTypeDefinition(ItemPreparationType.BRING, "持参", 20)));
+              new ItemPreparationTypeDefinition(ItemPreparationType.BRING, "持参", 10)));
 
   public record ItemPreparationTypeDefinition(
       ItemPreparationType code, String label, int sortOrder) {}

--- a/backend/src/main/java/com/atoook/otsukailist/generation/ItemPreparationTypes.java
+++ b/backend/src/main/java/com/atoook/otsukailist/generation/ItemPreparationTypes.java
@@ -1,0 +1,22 @@
+package com.atoook.otsukailist.generation;
+
+import java.util.Map;
+
+import com.atoook.otsukailist.model.ItemPreparationType;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ItemPreparationTypes {
+  public static final Map<ItemPreparationType, ItemPreparationTypeDefinition> VALUES =
+      Map.ofEntries(
+          Map.entry(
+              ItemPreparationType.BUY,
+              new ItemPreparationTypeDefinition(ItemPreparationType.BUY, "購入", 10)),
+          Map.entry(
+              ItemPreparationType.BRING,
+              new ItemPreparationTypeDefinition(ItemPreparationType.BRING, "持参", 20)));
+
+  public record ItemPreparationTypeDefinition(
+      ItemPreparationType code, String label, int sortOrder) {}
+}

--- a/backend/src/main/java/com/atoook/otsukailist/mapper/ItemMapper.java
+++ b/backend/src/main/java/com/atoook/otsukailist/mapper/ItemMapper.java
@@ -24,6 +24,7 @@ public class ItemMapper {
         .name(entity.getName().trim())
         .itemType(entity.getItemType() == null ? ItemType.PLAIN : entity.getItemType())
         .category(entity.getCategory())
+        .preparationType(entity.getPreparationType())
         .quantified(toQuantifiedResponse(entity.getQuantified()))
         .completed(entity.isCompleted())
         .assignedMemberId(entity.getAssignedMemberId())

--- a/backend/src/main/java/com/atoook/otsukailist/model/Item.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/Item.java
@@ -40,6 +40,9 @@ public class Item {
   @Column(name = "category", columnDefinition = "text")
   private ItemCategory category;
 
+  @Column(name = "preparation_type", columnDefinition = "text")
+  private ItemPreparationType preparationType;
+
   // DB物理名: is_completed（TINYINT(1)）
   @Column(name = "is_completed", nullable = false)
   private boolean completed;

--- a/backend/src/main/java/com/atoook/otsukailist/model/ItemPreparationType.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/ItemPreparationType.java
@@ -1,0 +1,30 @@
+package com.atoook.otsukailist.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ItemPreparationType {
+  BUY("buy"),
+  BRING("bring");
+
+  private final String value;
+
+  ItemPreparationType(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @JsonCreator
+  public static ItemPreparationType fromValue(String value) {
+    for (ItemPreparationType preparationType : values()) {
+      if (preparationType.value.equals(value)) {
+        return preparationType;
+      }
+    }
+    throw new IllegalArgumentException("Unknown item preparation type: " + value);
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/model/ItemPreparationType.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/ItemPreparationType.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ItemPreparationType {
-  BUY("buy"),
   BRING("bring");
 
   private final String value;

--- a/backend/src/main/java/com/atoook/otsukailist/model/converter/ItemPreparationTypeConverter.java
+++ b/backend/src/main/java/com/atoook/otsukailist/model/converter/ItemPreparationTypeConverter.java
@@ -1,0 +1,29 @@
+package com.atoook.otsukailist.model.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import com.atoook.otsukailist.model.ItemPreparationType;
+
+@Converter(autoApply = true)
+public class ItemPreparationTypeConverter
+    implements AttributeConverter<ItemPreparationType, String> {
+
+  @Override
+  public String convertToDatabaseColumn(ItemPreparationType attribute) {
+    return attribute == null ? null : attribute.getValue();
+  }
+
+  @Override
+  public ItemPreparationType convertToEntityAttribute(String dbData) {
+    if (dbData == null) {
+      return null;
+    }
+    for (ItemPreparationType preparationType : ItemPreparationType.values()) {
+      if (preparationType.getValue().equals(dbData)) {
+        return preparationType;
+      }
+    }
+    throw new IllegalArgumentException("Unknown item preparation type: " + dbData);
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
@@ -73,6 +73,7 @@ public class ItemCommandService {
     item.setName(resolveItemName(req));
     item.setItemType(itemType);
     item.setCategory(resolveCategory(req.getCategory(), req.getQuantified()));
+    item.setPreparationType(req.getPreparationType());
     item.setCompleted(false);
     item.setAssignedMemberId(null);
     item.setCompletedByMemberId(null);
@@ -159,6 +160,7 @@ public class ItemCommandService {
     boolean quantifiedDetailsEdited = req.getQuantified() != null;
 
     updateItemName(item, req);
+    item.setPreparationType(req.getPreparationTypeOrDefault(item.getPreparationType()));
     rejectQuantifiedDetailsForPlainRequest(req, quantifiedDetailsEdited);
     if (revertingToPlain) {
       item.setCategory(requestedCategory);

--- a/backend/src/main/resources/db/migration/V5__add_item_preparation_type.sql
+++ b/backend/src/main/resources/db/migration/V5__add_item_preparation_type.sql
@@ -1,0 +1,4 @@
+ALTER TABLE item
+ADD COLUMN IF NOT EXISTS preparation_type TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_item_list_preparation_type ON item (list_id, preparation_type);

--- a/backend/src/main/resources/db/migration/V5__add_item_preparation_type.sql
+++ b/backend/src/main/resources/db/migration/V5__add_item_preparation_type.sql
@@ -1,4 +1,17 @@
 ALTER TABLE item
 ADD COLUMN IF NOT EXISTS preparation_type TEXT NULL;
 
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'ck_item_preparation_type'
+    ) THEN
+        ALTER TABLE item
+        ADD CONSTRAINT ck_item_preparation_type
+        CHECK (preparation_type IN ('bring'));
+    END IF;
+END $$;
+
 CREATE INDEX IF NOT EXISTS idx_item_list_preparation_type ON item (list_id, preparation_type);

--- a/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
@@ -102,7 +102,7 @@ class JsonSerializationTest {
             .name("牛肉")
             .itemType(ItemType.QUANTIFIED)
             .category(ItemCategory.MEAT)
-            .preparationType(ItemPreparationType.BUY)
+            .preparationType(null)
             .quantified(
                 QuantifiedItemResponse.builder()
                     .quantity(1000L)
@@ -121,7 +121,7 @@ class JsonSerializationTest {
 
     assertThat(jsonNode.get("itemType").asText()).isEqualTo("quantified");
     assertThat(jsonNode.get("category").asText()).isEqualTo("meat");
-    assertThat(jsonNode.get("preparationType").asText()).isEqualTo("buy");
+    assertThat(jsonNode.get("preparationType").isNull()).isTrue();
     assertThat(jsonNode.get("quantified").has("name")).isFalse();
     assertThat(jsonNode.get("quantified").get("quantity").asLong()).isEqualTo(1000L);
     assertThat(jsonNode.get("quantified").get("baseUnit").asText()).isEqualTo("g");
@@ -160,7 +160,7 @@ class JsonSerializationTest {
                     "name": "牛肉 1000g",
                     "itemType": "quantified",
                     "category": "meat",
-                    "preparationType": "buy",
+                    "preparationType": "bring",
                     "quantified": {
                       "quantity": 1000,
                       "baseUnit": "g",
@@ -175,7 +175,7 @@ class JsonSerializationTest {
 
     assertThat(request.getItemType()).isEqualTo(ItemType.QUANTIFIED);
     assertThat(request.getCategory()).isEqualTo(ItemCategory.MEAT);
-    assertThat(request.getPreparationType()).isEqualTo(ItemPreparationType.BUY);
+    assertThat(request.getPreparationType()).isEqualTo(ItemPreparationType.BRING);
     assertThat(request.getQuantified().getQuantity()).isEqualTo(1000L);
     assertThat(request.getQuantified().getBaseUnit()).isEqualTo(BaseUnit.G);
     assertThat(request.getQuantified().getOrigin()).isEqualTo(Origin.GENERATED);

--- a/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 import com.atoook.otsukailist.model.BaseUnit;
 import com.atoook.otsukailist.model.ItemCategory;
+import com.atoook.otsukailist.model.ItemPreparationType;
 import com.atoook.otsukailist.model.ItemType;
 import com.atoook.otsukailist.model.Origin;
 import com.atoook.otsukailist.model.RegenerationPolicy;
@@ -44,6 +45,7 @@ class JsonSerializationTest {
             .name("テストアイテム")
             .itemType(ItemType.PLAIN)
             .category(ItemCategory.SWEETS)
+            .preparationType(ItemPreparationType.BRING)
             .quantified(null)
             .completed(true)
             .assignedMemberId(assignedMemberId)
@@ -61,6 +63,7 @@ class JsonSerializationTest {
     assertThat(jsonNode.get("id").asText()).isEqualTo(id.toString());
     assertThat(jsonNode.get("itemType").asText()).isEqualTo("plain");
     assertThat(jsonNode.get("category").asText()).isEqualTo("sweets");
+    assertThat(jsonNode.get("preparationType").asText()).isEqualTo("bring");
     assertThat(jsonNode.get("quantified").isNull()).isTrue();
     assertThat(jsonNode.get("completed").asBoolean()).isTrue();
     assertThat(jsonNode.get("assignedMemberId").asText()).isEqualTo(assignedMemberId.toString());
@@ -82,6 +85,7 @@ class JsonSerializationTest {
     assertThat(deserialized.getName()).isEqualTo("テストアイテム");
     assertThat(deserialized.getItemType()).isEqualTo(ItemType.PLAIN);
     assertThat(deserialized.getCategory()).isEqualTo(ItemCategory.SWEETS);
+    assertThat(deserialized.getPreparationType()).isEqualTo(ItemPreparationType.BRING);
     assertThat(deserialized.getQuantified()).isNull();
   }
 
@@ -98,6 +102,7 @@ class JsonSerializationTest {
             .name("牛肉")
             .itemType(ItemType.QUANTIFIED)
             .category(ItemCategory.MEAT)
+            .preparationType(ItemPreparationType.BUY)
             .quantified(
                 QuantifiedItemResponse.builder()
                     .quantity(1000L)
@@ -116,6 +121,7 @@ class JsonSerializationTest {
 
     assertThat(jsonNode.get("itemType").asText()).isEqualTo("quantified");
     assertThat(jsonNode.get("category").asText()).isEqualTo("meat");
+    assertThat(jsonNode.get("preparationType").asText()).isEqualTo("buy");
     assertThat(jsonNode.get("quantified").has("name")).isFalse();
     assertThat(jsonNode.get("quantified").get("quantity").asLong()).isEqualTo(1000L);
     assertThat(jsonNode.get("quantified").get("baseUnit").asText()).isEqualTo("g");
@@ -154,6 +160,7 @@ class JsonSerializationTest {
                     "name": "牛肉 1000g",
                     "itemType": "quantified",
                     "category": "meat",
+                    "preparationType": "buy",
                     "quantified": {
                       "quantity": 1000,
                       "baseUnit": "g",
@@ -168,6 +175,7 @@ class JsonSerializationTest {
 
     assertThat(request.getItemType()).isEqualTo(ItemType.QUANTIFIED);
     assertThat(request.getCategory()).isEqualTo(ItemCategory.MEAT);
+    assertThat(request.getPreparationType()).isEqualTo(ItemPreparationType.BUY);
     assertThat(request.getQuantified().getQuantity()).isEqualTo(1000L);
     assertThat(request.getQuantified().getBaseUnit()).isEqualTo(BaseUnit.G);
     assertThat(request.getQuantified().getOrigin()).isEqualTo(Origin.GENERATED);

--- a/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
@@ -16,6 +16,7 @@ import com.atoook.otsukailist.model.BaseUnit;
 import com.atoook.otsukailist.model.Item;
 import com.atoook.otsukailist.model.ItemCategory;
 import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.ItemPreparationType;
 import com.atoook.otsukailist.model.ItemQuantified;
 import com.atoook.otsukailist.model.ItemType;
 import com.atoook.otsukailist.model.Origin;
@@ -62,6 +63,23 @@ class ItemCommandServiceTest {
     assertThat(result.getData().getName()).isEqualTo("牛乳");
     assertThat(result.getData().getItemType()).isEqualTo(ItemType.PLAIN);
     assertThat(result.getData().getQuantified()).isNull();
+  }
+
+  @Test
+  @DisplayName("作成時に指定された準備方法を保存すること")
+  void createItemStoresPreparationType() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList("買い物");
+    CreateItemRequest request =
+        CreateItemRequest.builder().name("包丁").preparationType(ItemPreparationType.BRING).build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.save(any(Item.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
+
+    var result = service.createItem(listId, request);
+
+    assertThat(result.getData().getPreparationType()).isEqualTo(ItemPreparationType.BRING);
   }
 
   @Test
@@ -222,6 +240,26 @@ class ItemCommandServiceTest {
     assertThat(item.getQuantified().getBaseUnit()).isEqualTo(BaseUnit.G);
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.AUTO);
     assertThat(result.getData().getName()).isEqualTo("直接編集された名前");
+  }
+
+  @Test
+  @DisplayName("更新時に準備方法を変更できること")
+  void updateItemChangesPreparationType() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    Item item = plainItem("包丁");
+    item.setPreparationType(ItemPreparationType.BUY);
+    UpdateItemRequest request =
+        UpdateItemRequest.builder().preparationType(ItemPreparationType.BRING).build();
+
+    when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
+    when(itemRepo.save(item)).thenReturn(item);
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
+
+    var result = service.updateItem(listId, itemId, request);
+
+    assertThat(item.getPreparationType()).isEqualTo(ItemPreparationType.BRING);
+    assertThat(result.getData().getPreparationType()).isEqualTo(ItemPreparationType.BRING);
   }
 
   @Test

--- a/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
@@ -248,7 +248,7 @@ class ItemCommandServiceTest {
     UUID listId = UUID.randomUUID();
     UUID itemId = UUID.randomUUID();
     Item item = plainItem("包丁");
-    item.setPreparationType(ItemPreparationType.BUY);
+    item.setPreparationType(null);
     UpdateItemRequest request =
         UpdateItemRequest.builder().preparationType(ItemPreparationType.BRING).build();
 

--- a/docs/list-generation-automation.md
+++ b/docs/list-generation-automation.md
@@ -82,6 +82,7 @@ MVP では以下を DB マスタ化しない。
 
 - 単位定義
 - item カテゴリ
+- item 準備方法
 - BBQ 生成ルール
 
 理由:
@@ -94,6 +95,7 @@ MVP では以下を DB マスタ化しない。
 
 - Backend: `backend/src/main/java/com/atoook/otsukailist/generation`
 - Frontend category values/labels/sort order: `frontend/src/types/item-category.ts`
+- Frontend preparation type values/labels/sort order: `frontend/src/types/item-preparation-type.ts`
 - Frontend unit/generation values: `frontend/src/types/list-generation.ts`
 
 ---
@@ -142,12 +144,13 @@ MVP では以下を DB マスタ化しない。
 - `item_quantified` による数量付き item 詳細の保存
 - `list_generation_config` による将来の生成条件保存先の確保
 - `item.category` による plain / quantified 共通カテゴリの保存
+- `item.preparationType` による購入 / 持参などの準備方法の保存
 - `generated` item に対する `generator_key` 必須バリデーション
 - `generated + auto` のカテゴリを生成ルールから決定する処理
 - `generated + auto` item 更新時の `locked` 遷移
 - `quantified -> plain` への戻し処理
-- API レスポンスでの `itemType` / `category` / `quantified` 返却
-- Frontend 型定義での `ItemType` / `BaseUnit` / `ItemCategory` / `QuantifiedItem` 分離
+- API レスポンスでの `itemType` / `category` / `preparationType` / `quantified` 返却
+- Frontend 型定義での `ItemType` / `BaseUnit` / `ItemCategory` / `ItemPreparationType` / `QuantifiedItem` 分離
 
 ---
 

--- a/docs/list-generation-automation.md
+++ b/docs/list-generation-automation.md
@@ -144,7 +144,7 @@ MVP では以下を DB マスタ化しない。
 - `item_quantified` による数量付き item 詳細の保存
 - `list_generation_config` による将来の生成条件保存先の確保
 - `item.category` による plain / quantified 共通カテゴリの保存
-- `item.preparationType` による購入 / 持参などの準備方法の保存
+- `item.preparationType` による持参物の保存（`null` は購入扱い、`bring` は持参）
 - `generated` item に対する `generator_key` 必須バリデーション
 - `generated + auto` のカテゴリを生成ルールから決定する処理
 - `generated + auto` item 更新時の `locked` 遷移

--- a/frontend/src/api/item.ts
+++ b/frontend/src/api/item.ts
@@ -1,12 +1,14 @@
 import { http } from '@/lib/http';
 import type { DeleteResponse, Item, MutationResponse, UUID } from '@/types/api';
 import type { ItemCategory } from '@/types/item-category';
+import type { ItemPreparationType } from '@/types/item-preparation-type';
 import type { ItemType, QuantifiedItem } from '@/types/list-generation';
 
 export type UpdateItemPayload = {
   name?: string;
   itemType?: ItemType;
   category?: ItemCategory | null;
+  preparationType?: ItemPreparationType | null;
   completed?: boolean;
   assignedMemberId?: UUID | null;
   completedByMemberId?: UUID | null;
@@ -16,6 +18,7 @@ export type UpdateItemPayload = {
 type CreateItemPayloadBase = {
   name: string;
   category?: ItemCategory | null;
+  preparationType?: ItemPreparationType | null;
 };
 
 type CreatePlainItemPayload = CreateItemPayloadBase & {

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -25,8 +25,18 @@
           @blur="handleBlur"
           variant="inline"
         />
-        <div v-if="quantifiedLabel || categoryLabel" class="mt-1 flex flex-wrap gap-1">
-          <BadgeTag v-if="quantifiedLabel" :text="quantifiedLabel" size="small" variant="secondary" />
+        <div v-if="quantifiedLabel || categoryLabel || preparationTypeLabel" class="mt-1 flex flex-wrap gap-1">
+          <FilterBadgeButton
+            v-if="preparationTypeLabel"
+            :text="preparationTypeLabel"
+            variant="secondary"
+            :active="preparationTypeFilterActive"
+            :filter-label="`${preparationTypeLabel}で絞り込む`"
+            :clear-label="`${preparationTypeLabel}の絞り込みを解除`"
+            @filter="handlePreparationTypeFilter"
+            @clear="handlePreparationTypeFilterClear"
+          />
+          <BadgeTag v-if="quantifiedLabel" :text="quantifiedLabel" size="small" variant="default" />
           <FilterBadgeButton
             v-if="categoryLabel"
             :text="categoryLabel"
@@ -44,8 +54,18 @@
         <span class="truncate line-through text-charcoal-500">
           {{ item.name }}
         </span>
-        <div v-if="quantifiedLabel || categoryLabel" class="mt-1 flex flex-wrap gap-1">
-          <BadgeTag v-if="quantifiedLabel" :text="quantifiedLabel" size="small" variant="secondary" />
+        <div v-if="quantifiedLabel || categoryLabel || preparationTypeLabel" class="mt-1 flex flex-wrap gap-1">
+          <FilterBadgeButton
+            v-if="preparationTypeLabel"
+            :text="preparationTypeLabel"
+            variant="secondary"
+            :active="preparationTypeFilterActive"
+            :filter-label="`${preparationTypeLabel}で絞り込む`"
+            :clear-label="`${preparationTypeLabel}の絞り込みを解除`"
+            @filter="handlePreparationTypeFilter"
+            @clear="handlePreparationTypeFilterClear"
+          />
+          <BadgeTag v-if="quantifiedLabel" :text="quantifiedLabel" size="small" variant="default" />
           <FilterBadgeButton
             v-if="categoryLabel"
             :text="categoryLabel"
@@ -103,6 +123,7 @@ import { isItem, isItemCompleted } from '../types/item';
 import { normalizeText } from '../utils/text-normalization';
 import { UNIT_DEFINITIONS } from '@/types/list-generation';
 import { ITEM_CATEGORIES, type ItemCategory } from '@/types/item-category';
+import { ITEM_PREPARATION_TYPES, type ItemPreparationType } from '@/types/item-preparation-type';
 
 export default {
   name: 'ItemBox',
@@ -152,6 +173,10 @@ export default {
     categoryFilterActive: {
       type: Boolean,
       default: false
+    },
+    preparationTypeFilterActive: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [
@@ -163,7 +188,9 @@ export default {
     'member-filter',
     'clear-member-filter',
     'category-filter',
-    'clear-category-filter'
+    'clear-category-filter',
+    'preparation-type-filter',
+    'clear-preparation-type-filter'
   ],
   created() {
     this.newName = this.item.name;
@@ -194,6 +221,12 @@ export default {
         return '';
       }
       return ITEM_CATEGORIES[this.item.category]?.label ?? this.item.category;
+    },
+    preparationTypeLabel() {
+      if (!this.item.preparationType) {
+        return '';
+      }
+      return ITEM_PREPARATION_TYPES[this.item.preparationType]?.label ?? this.item.preparationType;
     }
   },
   watch: {
@@ -236,6 +269,15 @@ export default {
     },
     handleCategoryFilterClear() {
       this.$emit('clear-category-filter');
+    },
+    handlePreparationTypeFilter() {
+      if (!this.item.preparationType) {
+        return;
+      }
+      this.$emit('preparation-type-filter', this.item.preparationType as ItemPreparationType);
+    },
+    handlePreparationTypeFilterClear() {
+      this.$emit('clear-preparation-type-filter');
     },
     handleKeyDown(event: KeyboardEvent) {
       // スペースキーまたはEnterキーでチェックボックストグル

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -6,6 +6,7 @@ import IconChevronDown from './icons/IconChevronDown.vue';
 import IconTired from './icons/IconTired.vue';
 import type { Item, ItemId } from '../types/item';
 import type { ItemCategory } from '../types/item-category';
+import type { ItemPreparationType } from '../types/item-preparation-type';
 import type { MemberId } from '../types/member';
 import { normalizeText } from '../utils/text-normalization';
 import { deleteItem as deleteItemApi, updateItem } from '@/api/item';
@@ -67,9 +68,20 @@ export default defineComponent({
     categoryFilter: {
       type: String as PropType<ItemCategory | null>,
       default: null
+    },
+    preparationTypeFilter: {
+      type: String as PropType<ItemPreparationType | null>,
+      default: null
     }
   },
-  emits: ['member-filter', 'clear-member-filter', 'category-filter', 'clear-category-filter'],
+  emits: [
+    'member-filter',
+    'clear-member-filter',
+    'category-filter',
+    'clear-category-filter',
+    'preparation-type-filter',
+    'clear-preparation-type-filter'
+  ],
   setup() {
     const listStore = useListStore();
     const { run, loading } = useMutation();
@@ -260,6 +272,7 @@ export default defineComponent({
           :member-id="getItemMemberId(item) || undefined"
           :member-filter-active="getItemMemberId(item) === memberFilterId"
           :category-filter-active="item.category === categoryFilter"
+          :preparation-type-filter-active="item.preparationType === preparationTypeFilter"
           @toggle="toggleItem"
           @delete="deleteItem"
           @modify="modifyItem"
@@ -268,6 +281,8 @@ export default defineComponent({
           @clear-member-filter="$emit('clear-member-filter')"
           @category-filter="$emit('category-filter', $event)"
           @clear-category-filter="$emit('clear-category-filter')"
+          @preparation-type-filter="$emit('preparation-type-filter', $event)"
+          @clear-preparation-type-filter="$emit('clear-preparation-type-filter')"
         />
       </template>
     </template>

--- a/frontend/src/pages/ItemEditPage.test.ts
+++ b/frontend/src/pages/ItemEditPage.test.ts
@@ -82,6 +82,7 @@ describe('ItemEditPage', () => {
       const vm = createVm({
         itemName: '牛肉',
         selectedCategory: 'meat',
+        selectedPreparationType: '',
         itemEditMode: 'plain',
         quantifiedQuantity: '',
         quantifiedBaseUnit: ''
@@ -92,6 +93,7 @@ describe('ItemEditPage', () => {
       expect(payload).toMatchObject({
         name: '牛肉',
         category: 'meat',
+        preparationType: null,
         itemType: 'plain'
       });
       expect(payload.quantified).toBeUndefined();
@@ -101,6 +103,7 @@ describe('ItemEditPage', () => {
       const vm = createVm({
         itemName: '牛肉',
         selectedCategory: 'meat',
+        selectedPreparationType: '',
         itemEditMode: 'manual_none',
         quantifiedQuantity: '1000',
         quantifiedBaseUnit: 'g',
@@ -110,6 +113,7 @@ describe('ItemEditPage', () => {
       const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
 
       expect(payload.category).toBe('meat');
+      expect(payload.preparationType).toBeNull();
       expect(payload.itemType).toBe('quantified');
       expect(payload.quantified).toMatchObject({
         quantity: 1000,
@@ -164,6 +168,77 @@ describe('ItemEditPage', () => {
         regenerationPolicy: 'locked',
         generatorKey: 'beef'
       });
+    });
+
+    it('buy が選択済みでも未指定として送信する', () => {
+      const vm = createVm({
+        itemName: '包丁',
+        selectedCategory: '',
+        selectedPreparationType: 'buy',
+        itemEditMode: 'plain',
+        quantifiedQuantity: '',
+        quantifiedBaseUnit: ''
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('包丁');
+
+      expect(payload.preparationType).toBeNull();
+    });
+
+    it('持参物はカテゴリと数量を送信しない', () => {
+      const vm = createVm({
+        itemName: '包丁',
+        selectedCategory: 'daily_goods',
+        selectedPreparationType: 'bring',
+        itemEditMode: 'manual_none',
+        quantifiedQuantity: '1',
+        quantifiedBaseUnit: 'piece'
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('包丁');
+
+      expect(payload).toMatchObject({
+        name: '包丁',
+        category: null,
+        preparationType: 'bring',
+        itemType: 'plain'
+      });
+      expect(payload.quantified).toBeUndefined();
+    });
+  });
+
+  describe('持参物チェックボックス', () => {
+    it('オンにするとカテゴリと数量入力状態をクリアする', () => {
+      const vm = createVm({
+        selectedCategory: 'daily_goods',
+        selectedPreparationType: '',
+        itemEditMode: 'manual_none',
+        quantifiedQuantity: '1',
+        quantifiedBaseUnit: 'piece',
+        quantifiedGeneratorKey: 'beef'
+      });
+
+      (vm.setBringItem as (value: boolean) => void)(true);
+
+      expect(vm.selectedPreparationType).toBe('bring');
+      expect(vm.selectedCategory).toBe('');
+      expect(vm.itemEditMode).toBe('plain');
+      expect(vm.quantifiedQuantity).toBe('');
+      expect(vm.quantifiedBaseUnit).toBe('');
+      expect(vm.quantifiedGeneratorKey).toBe('');
+    });
+
+    it('オンの間は数量入力をバリデーション対象にしない', () => {
+      const vm = createVm({
+        itemName: '包丁',
+        selectedPreparationType: 'bring',
+        quantifiedQuantity: 'abc',
+        quantifiedBaseUnit: ''
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(false);
+      expect(vm.hasValidQuantifiedInput).toBe(true);
+      expect(vm.hasRequiredInput).toBe(true);
     });
   });
 });

--- a/frontend/src/pages/ItemEditPage.test.ts
+++ b/frontend/src/pages/ItemEditPage.test.ts
@@ -170,11 +170,11 @@ describe('ItemEditPage', () => {
       });
     });
 
-    it('buy が選択済みでも未指定として送信する', () => {
+    it('未指定は購入扱いとして null を送信する', () => {
       const vm = createVm({
         itemName: '包丁',
         selectedCategory: '',
-        selectedPreparationType: 'buy',
+        selectedPreparationType: '',
         itemEditMode: 'plain',
         quantifiedQuantity: '',
         quantifiedBaseUnit: ''

--- a/frontend/src/pages/ItemEditPage.vue
+++ b/frontend/src/pages/ItemEditPage.vue
@@ -9,6 +9,7 @@ import DropDown from '../components/DropDown.vue';
 import IconUsers from '../components/icons/IconUsers.vue';
 import type { Item } from '../types/item';
 import { ITEM_CATEGORIES, type ItemCategory } from '../types/item-category';
+import type { ItemPreparationType } from '../types/item-preparation-type';
 import type { Member, MemberId } from '../types/member';
 import { UNIT_DEFINITIONS, type BaseUnit, type ItemOrigin, type RegenerationPolicy } from '../types/list-generation';
 import { normalizeText } from '../utils/text-normalization';
@@ -21,6 +22,7 @@ import { BBQ_GENERATION_RULES } from '@/lib/listGenerationConstants';
 
 const UNASSIGNED_MEMBER_VALUE = '';
 const UNCATEGORIZED_VALUE = '';
+const UNSET_PREPARATION_TYPE_VALUE = '';
 const UNSET_GENERATOR_KEY_VALUE = '';
 const UNSELECTED_BASE_UNIT_VALUE = '';
 
@@ -47,6 +49,7 @@ export default defineComponent({
     errorMessage: string;
     snapshotLoading: boolean;
     selectedCategory: ItemCategory | typeof UNCATEGORIZED_VALUE;
+    selectedPreparationType: ItemPreparationType | typeof UNSET_PREPARATION_TYPE_VALUE;
     itemEditMode: ItemEditMode;
     quantifiedQuantity: string;
     quantifiedBaseUnit: BaseUnit | typeof UNSELECTED_BASE_UNIT_VALUE;
@@ -63,6 +66,7 @@ export default defineComponent({
       errorMessage: '',
       snapshotLoading: false,
       selectedCategory: UNCATEGORIZED_VALUE,
+      selectedPreparationType: UNSET_PREPARATION_TYPE_VALUE,
       itemEditMode: 'plain',
       quantifiedQuantity: '',
       quantifiedBaseUnit: UNSELECTED_BASE_UNIT_VALUE,
@@ -111,6 +115,7 @@ export default defineComponent({
       this.selectedMemberId =
         (item.completed ? item.completedByMemberId : item.assignedMemberId) ?? UNASSIGNED_MEMBER_VALUE;
       this.selectedCategory = item.category ?? UNCATEGORIZED_VALUE;
+      this.selectedPreparationType = item.preparationType ?? UNSET_PREPARATION_TYPE_VALUE;
       this.members = this.listStore.members.map((m) => ({ ...m }));
       this.applyQuantifiedItem(item);
     },
@@ -169,6 +174,25 @@ export default defineComponent({
     setSelectedCategory(value: string): void {
       this.selectedCategory = value as ItemCategory | typeof UNCATEGORIZED_VALUE;
     },
+    getSelectedPreparationType(): ItemPreparationType | null {
+      return this.selectedPreparationType === 'bring' ? 'bring' : null;
+    },
+    setBringItem(value: boolean): void {
+      this.selectedPreparationType = value ? 'bring' : UNSET_PREPARATION_TYPE_VALUE;
+      if (value) {
+        this.clearPurchaseDetails();
+      }
+    },
+    handleBringItemChange(event: Event): void {
+      this.setBringItem((event.target as HTMLInputElement).checked);
+    },
+    clearPurchaseDetails(): void {
+      this.selectedCategory = UNCATEGORIZED_VALUE;
+      this.itemEditMode = 'plain';
+      this.quantifiedQuantity = '';
+      this.quantifiedBaseUnit = UNSELECTED_BASE_UNIT_VALUE;
+      this.quantifiedGeneratorKey = UNSET_GENERATOR_KEY_VALUE;
+    },
     setQuantifiedBaseUnit(value: string): void {
       this.quantifiedBaseUnit = value as BaseUnit | typeof UNSELECTED_BASE_UNIT_VALUE;
       if (this.quantifiedBaseUnit === UNSELECTED_BASE_UNIT_VALUE) {
@@ -178,10 +202,11 @@ export default defineComponent({
     buildUpdatePayload(normalizedName: string): UpdateItemPayload {
       const payload: UpdateItemPayload = {
         name: normalizedName,
-        category: this.getSelectedCategory()
+        category: this.isBringItem ? null : this.getSelectedCategory(),
+        preparationType: this.getSelectedPreparationType()
       };
 
-      if (this.hasSelectedBaseUnit) {
+      if (!this.isBringItem && this.hasSelectedBaseUnit) {
         payload.itemType = 'quantified';
         payload.quantified = {
           quantity: this.parsedQuantifiedQuantity,
@@ -292,13 +317,16 @@ export default defineComponent({
       return (
         !!this.normalizedItemName &&
         (!this.isCompleted || !!this.getCurrentSelectedMemberId()) &&
-        (!this.hasQuantifiedDraftInput || this.hasValidQuantifiedInput)
+        (this.isBringItem || !this.hasQuantifiedDraftInput || this.hasValidQuantifiedInput)
       );
     },
     hasQuantifiedDraftInput(): boolean {
-      return this.hasSelectedBaseUnit || !!this.normalizedQuantifiedQuantity;
+      return !this.isBringItem && (this.hasSelectedBaseUnit || !!this.normalizedQuantifiedQuantity);
     },
     hasValidQuantifiedInput(): boolean {
+      if (this.isBringItem) {
+        return true;
+      }
       return (
         !!this.normalizedItemName &&
         !!this.normalizedQuantifiedQuantity &&
@@ -360,6 +388,9 @@ export default defineComponent({
           .map((category) => ({ id: category.code, name: category.label }))
       ];
     },
+    isBringItem(): boolean {
+      return this.selectedPreparationType === 'bring';
+    },
     baseUnitOptions(): Array<{ id: string; name: string }> {
       return [
         { id: UNSELECTED_BASE_UNIT_VALUE, name: '未選択' },
@@ -397,7 +428,18 @@ export default defineComponent({
           />
         </div>
 
-        <div>
+        <label class="min-w-0 flex items-center gap-2 text-sm text-charcoal-700">
+          <input
+            type="checkbox"
+            name="itemPreparationType"
+            :checked="isBringItem"
+            class="h-4 w-4 accent-wood-500"
+            @change="handleBringItemChange"
+          />
+          <span class="min-w-0 truncate">持参する</span>
+        </label>
+
+        <div v-if="!isBringItem">
           <label for="itemCategory" class="mb-2 block text-sm font-medium text-charcoal-700">
             カテゴリ
             <span v-if="hasSelectedBaseUnit && usesGeneratedCategory" class="text-xs font-normal text-charcoal-500">
@@ -419,7 +461,7 @@ export default defineComponent({
           />
         </div>
 
-        <div>
+        <div v-if="!isBringItem">
           <label for="quantifiedQuantity" class="mb-2 block text-sm font-medium text-charcoal-700"> 数量(単位) </label>
           <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
             <TextInput

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -12,6 +12,7 @@ import IconRefresh from '../components/icons/IconRefresh.vue';
 import IconCelebration from '../components/icons/IconCelebration.vue';
 import type { Item } from '../types/item';
 import type { ItemCategory } from '../types/item-category';
+import type { ItemPreparationType } from '../types/item-preparation-type';
 import { normalizeInput } from '../utils/text-normalization';
 import { formatActivityAt } from '../utils/date-format';
 import type { Member, MemberId } from '@/types/member';
@@ -42,6 +43,7 @@ export default defineComponent({
     selectedMemberId: MemberId | null;
     memberFilterId: MemberId | null;
     categoryFilter: ItemCategory | null;
+    preparationTypeFilter: ItemPreparationType | null;
     errorMessage: string;
     fallbackListName: string;
     snapshotLoading: boolean;
@@ -52,6 +54,7 @@ export default defineComponent({
       selectedMemberId: null,
       memberFilterId: null,
       categoryFilter: null,
+      preparationTypeFilter: null,
       errorMessage: '',
       fallbackListName: '',
       snapshotLoading: false
@@ -89,7 +92,8 @@ export default defineComponent({
       return filterItems(this.items, {
         searchQuery: this.searchQuery,
         memberId: this.memberFilterId,
-        category: this.categoryFilter
+        category: this.categoryFilter,
+        preparationType: this.preparationTypeFilter
       });
     },
     memberNames(): string {
@@ -184,6 +188,12 @@ export default defineComponent({
     },
     clearCategoryFilter(): void {
       this.categoryFilter = null;
+    },
+    handlePreparationTypeFilter(preparationType: ItemPreparationType): void {
+      this.preparationTypeFilter = preparationType;
+    },
+    clearPreparationTypeFilter(): void {
+      this.preparationTypeFilter = null;
     },
     navigateToListEdit() {
       this.$router.push({
@@ -285,10 +295,13 @@ export default defineComponent({
         :selected-member-id="selectedMemberId"
         :member-filter-id="memberFilterId"
         :category-filter="categoryFilter"
+        :preparation-type-filter="preparationTypeFilter"
         @member-filter="handleMemberFilter"
         @clear-member-filter="clearMemberFilter"
         @category-filter="handleCategoryFilter"
         @clear-category-filter="clearCategoryFilter"
+        @preparation-type-filter="handlePreparationTypeFilter"
+        @clear-preparation-type-filter="clearPreparationTypeFilter"
       />
     </div>
   </ContentArea>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,5 +1,6 @@
 import type { ItemType, QuantifiedItem } from './list-generation';
 import type { ItemCategory } from './item-category';
+import type { ItemPreparationType } from './item-preparation-type';
 
 export type UUID = string;
 
@@ -25,6 +26,7 @@ export type Item = {
   name: string;
   itemType: ItemType;
   category: ItemCategory | null;
+  preparationType: ItemPreparationType | null;
   quantified: QuantifiedItem | null;
   completed: boolean;
   assignedMemberId: UUID | null;

--- a/frontend/src/types/item-preparation-type.ts
+++ b/frontend/src/types/item-preparation-type.ts
@@ -1,0 +1,11 @@
+export const ITEM_PREPARATION_TYPES = {
+  buy: { code: 'buy', label: '購入', sortOrder: 10 },
+  bring: { code: 'bring', label: '持参', sortOrder: 20 }
+} as const;
+
+export type ItemPreparationType =
+  (typeof ITEM_PREPARATION_TYPES)[keyof typeof ITEM_PREPARATION_TYPES]['code'];
+
+export const ITEM_PREPARATION_TYPE_VALUES = Object.values(ITEM_PREPARATION_TYPES).map(
+  (preparationType) => preparationType.code
+);

--- a/frontend/src/types/item-preparation-type.ts
+++ b/frontend/src/types/item-preparation-type.ts
@@ -1,6 +1,5 @@
 export const ITEM_PREPARATION_TYPES = {
-  buy: { code: 'buy', label: '購入', sortOrder: 10 },
-  bring: { code: 'bring', label: '持参', sortOrder: 20 }
+  bring: { code: 'bring', label: '持参', sortOrder: 10 }
 } as const;
 
 export type ItemPreparationType =

--- a/frontend/src/types/item.ts
+++ b/frontend/src/types/item.ts
@@ -1,6 +1,10 @@
 import type { Item as ApiItem, UUID } from './api';
 import { ITEM_CATEGORY_VALUES, type ItemCategory } from './item-category';
 import {
+  ITEM_PREPARATION_TYPE_VALUES,
+  type ItemPreparationType
+} from './item-preparation-type';
+import {
   BASE_UNIT_VALUES,
   ITEM_ORIGIN_VALUES,
   ITEM_TYPE_VALUES,
@@ -26,6 +30,7 @@ export function isItem(value: unknown): value is Item {
     typeof candidate.name === 'string' &&
     isItemType(candidate.itemType) &&
     isItemCategory(candidate.category) &&
+    isItemPreparationType(candidate.preparationType) &&
     isQuantifiedItemForType(candidate) &&
     typeof candidate.completed === 'boolean' &&
     (candidate.assignedMemberId === null || isItemId(candidate.assignedMemberId)) &&
@@ -38,6 +43,13 @@ export function isItem(value: unknown): value is Item {
 
 function isItemCategory(value: unknown): value is ItemCategory | null {
   return value === null || (typeof value === 'string' && ITEM_CATEGORY_VALUES.includes(value as ItemCategory));
+}
+
+function isItemPreparationType(value: unknown): value is ItemPreparationType | null {
+  return (
+    value === null ||
+    (typeof value === 'string' && ITEM_PREPARATION_TYPE_VALUES.includes(value as ItemPreparationType))
+  );
 }
 
 function isItemType(value: unknown): value is ItemType {

--- a/frontend/src/utils/item-filtering.test.ts
+++ b/frontend/src/utils/item-filtering.test.ts
@@ -44,27 +44,43 @@ describe('item-filtering', () => {
     const items: Item[] = [
       item({ id: 'meat-1', name: '牛肉', category: 'meat', assignedMemberId: 'member-1' }),
       item({ id: 'drink-1', name: 'お茶', category: 'drinks', assignedMemberId: 'member-2' }),
-      item({ id: 'meat-2', name: '豚肉', category: 'meat', completed: true, completedByMemberId: 'member-2' })
+      item({ id: 'meat-2', name: '豚肉', category: 'meat', completed: true, completedByMemberId: 'member-2' }),
+      item({ id: 'bring-1', name: '包丁', category: null, preparationType: 'bring' })
     ];
 
     it('カテゴリーで絞り込む', () => {
       expect(
-        filterItems(items, { searchQuery: '', memberId: null, category: 'meat' }).map((candidate) => candidate.id)
+        filterItems(items, { searchQuery: '', memberId: null, category: 'meat', preparationType: null }).map(
+          (candidate) => candidate.id
+        )
       ).toEqual(['meat-1', 'meat-2']);
     });
 
     it('member とカテゴリーを組み合わせて絞り込む', () => {
       expect(
-        filterItems(items, { searchQuery: '', memberId: 'member-2', category: 'meat' }).map((candidate) => candidate.id)
+        filterItems(items, { searchQuery: '', memberId: 'member-2', category: 'meat', preparationType: null }).map(
+          (candidate) => candidate.id
+        )
       ).toEqual(['meat-2']);
     });
 
     it('検索語も他のフィルターと組み合わせる', () => {
       expect(
-        filterItems(items, { searchQuery: '茶', memberId: 'member-2', category: 'drinks' }).map(
+        filterItems(items, {
+          searchQuery: '茶',
+          memberId: 'member-2',
+          category: 'drinks',
+          preparationType: null
+        }).map((candidate) => candidate.id)
+      ).toEqual(['drink-1']);
+    });
+
+    it('準備方法で絞り込む', () => {
+      expect(
+        filterItems(items, { searchQuery: '', memberId: null, category: null, preparationType: 'bring' }).map(
           (candidate) => candidate.id
         )
-      ).toEqual(['drink-1']);
+      ).toEqual(['bring-1']);
     });
   });
 });

--- a/frontend/src/utils/item-filtering.test.ts
+++ b/frontend/src/utils/item-filtering.test.ts
@@ -7,6 +7,7 @@ const baseItem: Item = {
   name: '牛肉',
   itemType: 'plain',
   category: 'meat',
+  preparationType: null,
   quantified: null,
   completed: false,
   assignedMemberId: null,

--- a/frontend/src/utils/item-filtering.ts
+++ b/frontend/src/utils/item-filtering.ts
@@ -1,5 +1,6 @@
 import type { Item } from '@/types/item';
 import type { ItemCategory } from '@/types/item-category';
+import type { ItemPreparationType } from '@/types/item-preparation-type';
 import type { MemberId } from '@/types/member';
 import { normalizeForSearch } from './text-normalization';
 
@@ -7,6 +8,7 @@ export type ItemFilters = {
   searchQuery: string;
   memberId: MemberId | null;
   category: ItemCategory | null;
+  preparationType: ItemPreparationType | null;
 };
 
 export function getItemFilterMemberId(item: Item): MemberId | null {
@@ -22,6 +24,10 @@ export function filterItems(items: Item[], filters: ItemFilters): Item[] {
     }
 
     if (filters.category && item.category !== filters.category) {
+      return false;
+    }
+
+    if (filters.preparationType && item.preparationType !== filters.preparationType) {
       return false;
     }
 


### PR DESCRIPTION
This pull request adds support for item preparation types (such as "bring") to the backend. It introduces the `ItemPreparationType` enum and integrates it throughout the data model, API DTOs, service logic, and migrations. The changes also include updates to documentation and comprehensive tests to ensure correct serialization, deserialization, and business logic.

**Item Preparation Type Support**

* Added the `ItemPreparationType` enum (`bring`) and a corresponding JPA converter for database persistence. (`backend/src/main/java/com/atoook/otsukailist/model/ItemPreparationType.java`, `backend/src/main/java/com/atoook/otsukailist/model/converter/ItemPreparationTypeConverter.java`) [[1]](diffhunk://#diff-b77793299877a4350dbd1ec7f9c732d48188e4d65c74b59f341655d2f672320cR1-R29) [[2]](diffhunk://#diff-db3a7cef46e0c60875c52514f7e7b4bf8f62403841b8de04119f01f49ca29aa2R1-R29)
* Updated the `Item` entity, create/update request/response DTOs, and mapping logic to include the new `preparationType` field. (`backend/src/main/java/com/atoook/otsukailist/model/Item.java`, `backend/src/main/java/com/atoook/otsukailist/dto/CreateItemRequest.java`, `backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java`, `backend/src/main/java/com/atoook/otsukailist/dto/ItemResponse.java`, `backend/src/main/java/com/atoook/otsukailist/mapper/ItemMapper.java`) [[1]](diffhunk://#diff-ab6dce9141fab4f8b3a590f15def4db7098460b7548c815259fbdfa7a532b1a9R43-R45) [[2]](diffhunk://#diff-90d5880300472c29951d444629131c427310ca090040db11fc76873162b1d1b5R36-R37) [[3]](diffhunk://#diff-1dbff0eae83c634ea37116445e780e47636b761e503b3eb0a6b01d4403eda1d9R41-R44) [[4]](diffhunk://#diff-8b04b1295721393200455291a6c52dad818135d724a6e3d12518891f7c3a4069R30-R31) [[5]](diffhunk://#diff-09e31e7dbbaca5cd6a3d8d9b10d216466d6d424ad70e704905ec4dd3673421b9R27)

**Service and Persistence Logic**

* Enhanced item creation and update logic to handle the new `preparationType` field, including default handling and field presence tracking. (`backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java`, `backend/src/main/java/com/atoook/otsukailist/dto/UpdateItemRequest.java`) [[1]](diffhunk://#diff-abe0caa3cb9b2b9132e71c2aae0257752277219a6fc3a50ceb95d3c012377642R76) [[2]](diffhunk://#diff-abe0caa3cb9b2b9132e71c2aae0257752277219a6fc3a50ceb95d3c012377642R163) [[3]](diffhunk://#diff-1dbff0eae83c634ea37116445e780e47636b761e503b3eb0a6b01d4403eda1d9R60-R69) [[4]](diffhunk://#diff-1dbff0eae83c634ea37116445e780e47636b761e503b3eb0a6b01d4403eda1d9R92-R97)
* Added a Flyway migration to introduce the `preparation_type` column, a constraint, and an index to the `item` table. (`backend/src/main/resources/db/migration/V5__add_item_preparation_type.sql`)

**Testing**

* Extended and added tests to verify correct serialization/deserialization of `preparationType` and to ensure that item creation and updates properly store and modify this field. (`backend/src/test/java/com/atoook/otsukailist/dto/JsonSerializationTest.java`, `backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java`) [[1]](diffhunk://#diff-ad9fd720a9e88826dbc9d7bab7dfe80a01ed67fb703c6cc94dcf505d01f673acR48) [[2]](diffhunk://#diff-ad9fd720a9e88826dbc9d7bab7dfe80a01ed67fb703c6cc94dcf505d01f673acR66) [[3]](diffhunk://#diff-30a3e61fcab362fad269cbe0d8d96802483450d810283a15a36df32b7d8673f4R68-R84) [[4]](diffhunk://#diff-30a3e61fcab362fad269cbe0d8d96802483450d810283a15a36df32b7d8673f4R245-R264)

**Documentation**

* Updated documentation to reflect the addition of item preparation types, their handling in the backend, and their representation in API responses and frontend types. (`docs/list-generation-automation.md`) [[1]](diffhunk://#diff-6c89953adb45ea23f4e6d3571fdae0d93287e26b41f2d03a340a1abb01e286acR85) [[2]](diffhunk://#diff-6c89953adb45ea23f4e6d3571fdae0d93287e26b41f2d03a340a1abb01e286acR98) [[3]](diffhunk://#diff-6c89953adb45ea23f4e6d3571fdae0d93287e26b41f2d03a340a1abb01e286acR147-R153)

**Supporting Structures**

* Added a utility class for preparation type definitions, including labels and sort order, to support list generation and frontend mapping. (`backend/src/main/java/com/atoook/otsukailist/generation/ItemPreparationTypes.java`)