### PR TITLE
Prioritize 'bring' preparation type in item sorting logic

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
@@ -11,12 +11,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.atoook.otsukailist.model.Item;
+import com.atoook.otsukailist.model.ItemPreparationType;
 
 public interface ItemRepository extends JpaRepository<Item, UUID> {
   // 基本的なCRUD操作は JpaRepository が自動提供
   // ※ findAll() や条件なし検索は使用禁止（設計思想に反する）
 
-  // 一覧表示用の並び順（未完了: 追加順の最新先頭 / 完了: 完了日時の新しい順）
+  // 一覧表示用の並び順（未完了: 持参じゃないものを優先して追加順の最新先頭 / 完了: 完了日時の新しい順）
   @EntityGraph(attributePaths = "quantified")
   @Query(
       """
@@ -25,12 +26,20 @@ public interface ItemRepository extends JpaRepository<Item, UUID> {
       WHERE i.itemList.id = :itemListId
       ORDER BY
         i.completed ASC,
+        CASE
+          WHEN i.completed = false
+            AND i.preparationType = :preparationType
+          THEN 1
+          ELSE 0
+        END ASC,
         CASE WHEN i.completed = false THEN i.createdAt ELSE NULL END DESC,
         CASE WHEN i.completed = true AND i.completedAt IS NULL THEN 1 ELSE 0 END ASC,
         CASE WHEN i.completed = true THEN i.completedAt ELSE NULL END DESC,
         i.id ASC
       """)
-  List<Item> findByItemListIdOrderByDisplayRules(@Param("itemListId") UUID itemListId);
+  List<Item> findByItemListIdOrderByDisplayRules(
+      @Param("itemListId") UUID itemListId,
+      @Param("preparationType") ItemPreparationType preparationType);
 
   // 特定のアイテムを取得
   @EntityGraph(attributePaths = "quantified")

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListQueryService.java
@@ -19,6 +19,7 @@ import com.atoook.otsukailist.mapper.ItemMapper;
 import com.atoook.otsukailist.mapper.MemberMapper;
 import com.atoook.otsukailist.model.Item;
 import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.ItemPreparationType;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.ItemRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
@@ -51,7 +52,8 @@ public class ListQueryService {
     List<MemberResponse> members =
         memberRepo.findByItemListId(listId).stream().map(MemberMapper::toResponse).toList();
 
-    List<Item> itemEntities = itemRepo.findByItemListIdOrderByDisplayRules(listId);
+    List<Item> itemEntities =
+        itemRepo.findByItemListIdOrderByDisplayRules(listId, ItemPreparationType.BRING);
     List<ItemResponse> items = itemEntities.stream().map(ItemMapper::toResponse).toList();
 
     Instant lastItemActivityAt =

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -21,7 +21,14 @@ const ITEM_GROUP_DEFINITIONS: GroupDefinition<Item>[] = [
     key: 'incomplete',
     label: '未完了',
     predicate: (item) => !item.completed,
-    comparator: (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    comparator: (a, b) => {
+      const aBringOrder = a.preparationType === 'bring' ? 1 : 0;
+      const bBringOrder = b.preparationType === 'bring' ? 1 : 0;
+      if (aBringOrder !== bBringOrder) {
+        return aBringOrder - bBringOrder;
+      }
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    },
     showHeader: false,
     collapsible: false,
     defaultCollapsed: false

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -27,7 +27,11 @@ const ITEM_GROUP_DEFINITIONS: GroupDefinition<Item>[] = [
       if (aBringOrder !== bBringOrder) {
         return aBringOrder - bBringOrder;
       }
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      const createdAtOrder = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      if (createdAtOrder !== 0) {
+        return createdAtOrder;
+      }
+      return a.id.localeCompare(b.id);
     },
     showHeader: false,
     collapsible: false,


### PR DESCRIPTION
This pull request updates both backend and frontend logic to prioritize displaying items that are not of the "bring" preparation type at the top of incomplete item lists. The backend query and service have been updated to support this new ordering, and the frontend comparator logic has been aligned accordingly.

**Backend changes:**

* Enhanced the `findByItemListIdOrderByDisplayRules` query in `ItemRepository` to order incomplete items by prioritizing those that are not of the `BRING` preparation type, and updated its method signature to accept an `ItemPreparationType` parameter.
* Updated `ListQueryService` to pass `ItemPreparationType.BRING` when calling the updated repository method, ensuring consistent ordering in API responses.
* Added necessary import for `ItemPreparationType` in both `ItemRepository` and `ListQueryService`. [[1]](diffhunk://#diff-4660237e44ab5271c063d9db0958deaebeaa8d0246ad9f73e1ea82aa29561e3eR14-R20) [[2]](diffhunk://#diff-ee111bf8f0e982fd55aeee68d1386465cc9a8f750b16f9477ad482e6eb8370beR22)

**Frontend changes:**

* Modified the comparator for the "incomplete" group in `ItemGroupList.vue` to match backend logic, so that items with `preparationType !== 'bring'` are shown before those with `preparationType === 'bring'`, and then sorted by creation date.…e in incomplete items