### PR TITLE
Enhance health check endpoint with liveness and update documentation

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -35,6 +35,8 @@ management:
         enabled: true
       show-details: never
   health:
+    db:
+      enabled: false
     livenessstate:
       enabled: true
     readinessstate:

--- a/docs/backend-deploy-operations.md
+++ b/docs/backend-deploy-operations.md
@@ -27,7 +27,7 @@ docker run --rm \
 起動確認:
 
 ```bash
-curl -i http://localhost:10000/actuator/health
+curl -i http://localhost:10000/actuator/health/liveness
 ```
 
 期待値:
@@ -44,7 +44,7 @@ curl -i http://localhost:10000/actuator/health
 - Branch: `main`
 - Root Directory: `backend`
 - Dockerfile: `backend/Dockerfile`
-- Health Check Path: `/actuator/health`
+- Health Check Path: `/actuator/health/liveness`
 
 ### 環境変数
 
@@ -71,7 +71,7 @@ curl -i http://localhost:10000/actuator/health
 ## 3. デプロイ後のスモークチェック
 
 ```bash
-curl -i https://<your-render-service>/actuator/health
+curl -i https://<your-render-service>/actuator/health/liveness
 ```
 
 ```bash

--- a/workers/cron/src/index.ts
+++ b/workers/cron/src/index.ts
@@ -3,7 +3,7 @@ type CronEnv = {
   API_BASE_URL?: string;
   /**
    * Explicit warmup URL. Takes precedence over API_BASE_URL.
-   * Use this to override the default /actuator/health derivation.
+   * Use this to override the default /actuator/health/liveness derivation.
    */
   WARMUP_URL?: string;
 };
@@ -28,12 +28,12 @@ function resolveWarmupUrl(env: CronEnv): WarmupUrlResult {
     const url = new URL(env.API_BASE_URL);
     const pathSegments = url.pathname.split("/").filter(Boolean);
 
-    // API_BASE_URL usually ends with /api. Warm up backend health endpoint directly.
+    // API_BASE_URL usually ends with /api. Warm up the service without touching DB health.
     if (pathSegments[pathSegments.length - 1] === "api") {
       pathSegments.pop();
     }
 
-    url.pathname = `/${[...pathSegments, "actuator", "health"].join("/")}`;
+    url.pathname = `/${[...pathSegments, "actuator", "health", "liveness"].join("/")}`;
     url.search = "";
     url.hash = "";
     return { ok: true, url: url.toString() };


### PR DESCRIPTION
This pull request updates the backend health check configuration to avoid hitting the database during liveness checks and aligns the worker warmup logic accordingly. The main focus is to ensure that warmup and health endpoints do not depend on database availability, improving reliability during deployments and restarts.

Configuration changes:

* Disabled the database health indicator in the production Spring Boot configuration by setting `management.health.db.enabled` to `false` in `application-prod.yml`. This prevents liveness checks from failing due to database issues.

Worker warmup logic updates:

* Updated the comment for the `WARMUP_URL` environment variable to clarify that it now overrides the default `/actuator/health/liveness` endpoint, not just `/actuator/health`.
* Modified the warmup URL resolution logic in `index.ts` to use `/actuator/health/liveness` instead of `/actuator/health`, ensuring the warmup check does not depend on database health.…mup URL documentation