### PR TITLE
Update application configuration for HikariCP settings

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -4,6 +4,9 @@ spring:
     url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT:5432}/${POSTGRES_DB}?sslmode=${POSTGRES_SSL_MODE:require}${POSTGRES_PARAMS:}
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
+    hikari:
+      minimum-idle: ${DB_POOL_MINIMUM_IDLE:0}
+      idle-timeout: ${DB_POOL_IDLE_TIMEOUT_MS:60000}
   jpa:
     show-sql: false
     properties:

--- a/docs/backend-deploy-operations.md
+++ b/docs/backend-deploy-operations.md
@@ -62,11 +62,14 @@ curl -i http://localhost:10000/actuator/health/liveness
 - `POSTGRES_PORT` (default: `5432`)
 - `POSTGRES_SSL_MODE` (default: `require`)
 - `POSTGRES_PARAMS`
+- `DB_POOL_MINIMUM_IDLE` (default: `0`)
+- `DB_POOL_IDLE_TIMEOUT_MS` (default: `60000`)
 
 補足:
 
 - `PORT` は Render が注入するため、通常は手動設定不要
 - アプリ側は `server.port=${PORT:8080}` 前提
+- Neon を inactive に戻せるよう、本番では DB pool の idle connection を保持しない設定
 
 ## 3. デプロイ後のスモークチェック
 


### PR DESCRIPTION
Add HikariCP settings to the application configuration, including parameters for minimum idle connections and idle timeout for the database connection pool. Update documentation to reflect these new configuration options.