### PR TITLE
Remove unused feedback URL and related constants from appConstants

### DIFF
--- a/frontend/src/lib/appConstants.ts
+++ b/frontend/src/lib/appConstants.ts
@@ -1,8 +1,1 @@
-import type { UUID } from '@/types/api';
-
-export const FEEDBACK_LIST_ID: UUID = 'f16857f7-f612-4fa3-9786-aca965e13b83';
-
-const baseUrl = import.meta.env.VITE_BASE_URL ?? window.location.origin;
-
-export const FEEDBACK_URL = `${baseUrl}/lists/${FEEDBACK_LIST_ID}`;
 export const CONTACT_FORM_URL = import.meta.env.VITE_CONTACT_FORM_URL;

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -20,7 +20,6 @@ import { fetchSnapshot } from '@/api/list';
 import { useListStore } from '@/stores/list';
 import { getErrorMessage } from '@/lib/http';
 import { getSelectedMemberId, setSelectedMemberId, addOrUpdateListHistory } from '@/lib/userCache';
-import { FEEDBACK_LIST_ID } from '@/lib/appConstants';
 import { filterItems } from '@/utils/item-filtering';
 
 export default defineComponent({
@@ -157,10 +156,7 @@ export default defineComponent({
           this.selectedMemberId = snapshot.members[0]?.id ?? null;
         }
 
-        // リスト履歴に追加/更新（フィードバックリストは除外）
-        if (listId !== FEEDBACK_LIST_ID) {
-          addOrUpdateListHistory({ listId, name: snapshot.name });
-        }
+        addOrUpdateListHistory({ listId, name: snapshot.name });
       } catch (err: unknown) {
         console.error('Failed to load snapshot', err);
         this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';

--- a/frontend/src/pages/PrivacyPolicyPage.vue
+++ b/frontend/src/pages/PrivacyPolicyPage.vue
@@ -80,7 +80,7 @@ export default {
       <section class="space-y-2">
         <h2 class="text-base font-semibold text-charcoal-800">7. お問い合わせ</h2>
         <p class="text-sm leading-relaxed">
-          本ポリシーに関する問い合わせは、本サービス上のフィードバック導線、または運営者が別途指定する方法によりご連絡ください。
+          本ポリシーに関する問い合わせは、本サービス上のお問い合わせ導線、または運営者が別途指定する方法によりご連絡ください。
         </p>
       </section>
 

--- a/frontend/src/pages/WelcomePage.vue
+++ b/frontend/src/pages/WelcomePage.vue
@@ -7,7 +7,6 @@ import IconBbq from '../components/icons/IconBbq.vue';
 import IconClipboard from '../components/icons/IconClipboard.vue';
 import { getListHistory, removeListHistoryEntry } from '@/lib/userCache';
 import { fetchListsMeta } from '@/api/list';
-import { FEEDBACK_URL } from '@/lib/appConstants';
 
 export default {
   name: 'WelcomePage',
@@ -23,8 +22,7 @@ export default {
     return {
       listHistory: [],
       listMeta: {},
-      metaLoading: false,
-      feedbackUrl: FEEDBACK_URL
+      metaLoading: false
     };
   },
   async created() {


### PR DESCRIPTION
This pull request removes all references to the feedback list and its associated constants, and updates related UI text to reflect this change. The main focus is to clean up code and UI that previously referenced the feedback list, ensuring that user flows and documentation now refer to the appropriate contact methods.

**Removal of feedback list references:**

* Removed the `FEEDBACK_LIST_ID` and `FEEDBACK_URL` constants from `appConstants.ts`, as well as their imports and usage in `ItemListPage.vue` and `WelcomePage.vue`. [[1]](diffhunk://#diff-6850f5c67567ce6a89520b67c5f012f7e5480eca2a5daefae3a743cedd768ba6L1-L7) [[2]](diffhunk://#diff-3f5818ec33d23995f71d69557331222dbef5378c72bcae26f63c25605e8b2ef3L23) [[3]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408L10) [[4]](diffhunk://#diff-96cc72cdeeac7a957fb3d74d6aed358390ddb0f4b8f73c28fcd9d91eb0ccf408L26-R25)
* Updated logic in `ItemListPage.vue` to no longer exclude the feedback list when updating list history.

**UI and documentation updates:**

* Updated the privacy policy in `PrivacyPolicyPage.vue` to refer to the "contact" method instead of the "feedback" method for inquiries.