### PR TITLE
Improve pointer capture for swipe interactions

### DIFF
--- a/frontend/src/components/SwipeContainer.vue
+++ b/frontend/src/components/SwipeContainer.vue
@@ -85,11 +85,14 @@ export default {
   methods: {
     // 統一されたポインターイベント（マウス・タッチ・ペン全対応）
     handlePointerStart(e) {
+      if (this.isDragging || this.activePointerId !== null) {
+        return;
+      }
       this.activePointerId = e.pointerId;
       this.startDrag(e.clientX, e.clientY);
     },
     handlePointerMove(e) {
-      if (!this.isDragging) {
+      if (!this.isDragging || e.pointerId !== this.activePointerId) {
         return;
       }
 
@@ -111,6 +114,9 @@ export default {
       this.updateDrag(e.clientX);
     },
     handlePointerEnd(e) {
+      if (e.pointerId !== this.activePointerId) {
+        return;
+      }
       this.releasePointer(e);
       this.endDrag();
     },

--- a/frontend/src/components/SwipeContainer.vue
+++ b/frontend/src/components/SwipeContainer.vue
@@ -75,6 +75,7 @@ export default {
   },
   unmounted() {
     document.removeEventListener('click', this.handleOutsideClick);
+    this.removeWindowPointerListeners();
   },
   watch: {
     showHiddenActions(newValue) {
@@ -152,6 +153,7 @@ export default {
       this.startX = clientX;
       this.startY = clientY;
       this.currentX = clientX;
+      this.addWindowPointerListeners();
     },
     updateDrag(clientX) {
       this.currentX = clientX;
@@ -166,11 +168,20 @@ export default {
       this.isDragging = false;
       this.isSwiping = false;
       this.activePointerId = null;
+      this.removeWindowPointerListeners();
 
       // しきい値を超えていない場合は元に戻す
       if (this.swipeOffset > -this.threshold) {
         this.resetSwipe();
       }
+    },
+    addWindowPointerListeners() {
+      window.addEventListener('pointerup', this.handlePointerEnd);
+      window.addEventListener('pointercancel', this.handlePointerEnd);
+    },
+    removeWindowPointerListeners() {
+      window.removeEventListener('pointerup', this.handlePointerEnd);
+      window.removeEventListener('pointercancel', this.handlePointerEnd);
     },
     resetSwipe() {
       this.swipeOffset = 0;

--- a/frontend/src/components/SwipeContainer.vue
+++ b/frontend/src/components/SwipeContainer.vue
@@ -60,7 +60,8 @@ export default {
       isSwiping: false,
       startX: 0,
       startY: 0,
-      currentX: 0
+      currentX: 0,
+      activePointerId: null
     };
   },
   computed: {
@@ -84,14 +85,7 @@ export default {
   methods: {
     // 統一されたポインターイベント（マウス・タッチ・ペン全対応）
     handlePointerStart(e) {
-      // ポインターをキャプチャ（追跡を継続）
-      try {
-        e.target.setPointerCapture(e.pointerId);
-      } catch (error) {
-        // ポインターキャプチャに失敗（無効なpointerIdや切断された要素など）
-        // ドラッグフローは継続
-        console.warn('Failed to capture pointer:', error);
-      }
+      this.activePointerId = e.pointerId;
       this.startDrag(e.clientX, e.clientY);
     },
     handlePointerMove(e) {
@@ -110,21 +104,39 @@ export default {
           return;
         }
         this.isSwiping = true;
+        this.capturePointer(e);
       }
 
       e.preventDefault();
       this.updateDrag(e.clientX);
     },
     handlePointerEnd(e) {
-      // ポインターキャプチャを解放
-      try {
-        e.target.releasePointerCapture(e.pointerId);
-      } catch (error) {
-        // ポインターキャプチャの解放に失敗（無効なpointerIdや切断された要素など）
-        // ドラッグフローは継続
-        console.warn('Failed to release pointer capture:', error);
-      }
+      this.releasePointer(e);
       this.endDrag();
+    },
+    capturePointer(e) {
+      if (this.activePointerId === null || !e.currentTarget?.setPointerCapture) {
+        return;
+      }
+      try {
+        e.currentTarget.setPointerCapture(this.activePointerId);
+      } catch (error) {
+        // ポインターキャプチャに失敗してもドラッグフローは継続
+        console.warn('Failed to capture pointer:', error);
+      }
+    },
+    releasePointer(e) {
+      if (this.activePointerId === null || !e.currentTarget?.releasePointerCapture) {
+        return;
+      }
+      try {
+        e.currentTarget.releasePointerCapture(this.activePointerId);
+      } catch (error) {
+        // ポインターキャプチャの解放に失敗しても後続処理は継続
+        console.warn('Failed to release pointer capture:', error);
+      } finally {
+        this.activePointerId = null;
+      }
     },
 
     // 共通のドラッグロジック
@@ -147,6 +159,7 @@ export default {
     endDrag() {
       this.isDragging = false;
       this.isSwiping = false;
+      this.activePointerId = null;
 
       // しきい値を超えていない場合は元に戻す
       if (this.swipeOffset > -this.threshold) {

--- a/frontend/src/components/SwipeContainer.vue
+++ b/frontend/src/components/SwipeContainer.vue
@@ -176,10 +176,12 @@ export default {
       }
     },
     addWindowPointerListeners() {
+      window.addEventListener('pointermove', this.handlePointerMove);
       window.addEventListener('pointerup', this.handlePointerEnd);
       window.addEventListener('pointercancel', this.handlePointerEnd);
     },
     removeWindowPointerListeners() {
+      window.removeEventListener('pointermove', this.handlePointerMove);
       window.removeEventListener('pointerup', this.handlePointerEnd);
       window.removeEventListener('pointercancel', this.handlePointerEnd);
     },


### PR DESCRIPTION
This pull request updates the pointer event handling logic in `SwipeContainer.vue` to improve the robustness and correctness of swipe gesture detection, especially around pointer capture and release. The key changes involve tracking the active pointer ID, properly capturing and releasing pointer events, and refactoring related methods for clarity and reliability.

**Pointer event handling improvements:**

* Added an `activePointerId` state property to track the currently active pointer for swipe gestures.
* Refactored pointer capture and release logic into dedicated `capturePointer` and `releasePointer` methods, ensuring pointer events are correctly managed and errors are handled gracefully. [[1]](diffhunk://#diff-48fb083945cf42e77b1bb7a0820edae3e78bf6a778def1013ca24c9f0241fdbaL87-R88) [[2]](diffhunk://#diff-48fb083945cf42e77b1bb7a0820edae3e78bf6a778def1013ca24c9f0241fdbaR107-L127)
* Updated the swipe gesture flow to use the new pointer management methods, reducing the risk of pointer-related bugs and improving cross-device compatibility.

**State management improvements:**

* Ensured `activePointerId` is reset to `null` when a drag ends to prevent stale state.