### PR TITLE
Enhance delete button UX with pointer event handling

### DIFF
--- a/frontend/src/components/ItemBox.test.ts
+++ b/frontend/src/components/ItemBox.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import ItemBox from './ItemBox.vue';
+
+type ItemBoxOptions = {
+  data: () => Record<string, unknown>;
+  methods: Record<string, (this: Record<string, unknown>, ...args: unknown[]) => unknown>;
+};
+
+function createVm(overrides: Record<string, unknown> = {}) {
+  const component = ItemBox as unknown as ItemBoxOptions;
+  const vm: Record<string, unknown> = {
+    ...component.data(),
+    $emit: vi.fn(),
+    ...overrides
+  };
+
+  Object.entries(component.methods).forEach(([name, method]) => {
+    vm[name] = method.bind(vm);
+  });
+
+  return vm;
+}
+
+function createPointerEvent(overrides: Partial<PointerEvent> = {}) {
+  return {
+    button: 0,
+    isPrimary: true,
+    ...overrides
+  } as PointerEvent;
+}
+
+describe('ItemBox', () => {
+  describe('削除ボタンの pointer 操作', () => {
+    it('pointerup で delete を1回だけ emit し、直後の click は無視する', () => {
+      const vm = createVm();
+      const itemId = 'item-1';
+
+      (vm.handleDeletePointerStart as (event: PointerEvent) => void)(createPointerEvent());
+      (vm.handleDeletePointerEnd as (event: PointerEvent, itemId: string) => void)(createPointerEvent(), itemId);
+      (vm.handleDeleteClick as (itemId: string) => void)(itemId);
+
+      expect(vm.$emit).toHaveBeenCalledTimes(1);
+      expect(vm.$emit).toHaveBeenCalledWith('delete', itemId);
+    });
+
+    it('非 primary button では delete を emit しない', () => {
+      const vm = createVm();
+      const itemId = 'item-1';
+      const secondaryPointer = createPointerEvent({ button: 2 });
+
+      (vm.handleDeletePointerStart as (event: PointerEvent) => void)(secondaryPointer);
+      (vm.handleDeletePointerEnd as (event: PointerEvent, itemId: string) => void)(secondaryPointer, itemId);
+
+      expect(vm.$emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -101,8 +101,8 @@
     <template #hiddenActions>
       <button
         type="button"
-        @pointerdown="handleDeletePointerStart"
-        @pointerup="handleDeletePointerEnd(item.id)"
+        @pointerdown="handleDeletePointerStart($event)"
+        @pointerup="handleDeletePointerEnd($event, item.id)"
         @pointercancel="handleDeletePointerCancel"
         @click="handleDeleteClick(item.id)"
         :disabled="isDeleteLoading"
@@ -274,11 +274,19 @@ export default {
     handleInfo(item: Item) {
       this.$emit('info', item);
     },
-    handleDeletePointerStart() {
+    isPrimaryDeletePointer(event: PointerEvent) {
+      return event.isPrimary !== false && event.button === 0;
+    },
+    handleDeletePointerStart(event: PointerEvent) {
+      if (!this.isPrimaryDeletePointer(event)) {
+        this.deletePointerStarted = false;
+        return;
+      }
       this.deletePointerStarted = true;
     },
-    handleDeletePointerEnd(itemId: ItemId) {
-      if (!this.deletePointerStarted) {
+    handleDeletePointerEnd(event: PointerEvent, itemId: ItemId) {
+      if (!this.deletePointerStarted || !this.isPrimaryDeletePointer(event)) {
+        this.deletePointerStarted = false;
         return;
       }
       this.deletePointerStarted = false;

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -101,7 +101,10 @@
     <template #hiddenActions>
       <button
         type="button"
-        @click="handleDelete(item.id)"
+        @pointerdown="handleDeletePointerStart"
+        @pointerup="handleDeletePointerEnd(item.id)"
+        @pointercancel="handleDeletePointerCancel"
+        @click="handleDeleteClick(item.id)"
         :disabled="isDeleteLoading"
         :aria-busy="isDeleteLoading"
         :aria-label="`${item.name}を削除`"
@@ -163,7 +166,9 @@ export default {
       newName: '',
       isInputFocused: false,
       showSaveIndicator: false,
-      saveIndicatorTimer: null as number | null
+      saveIndicatorTimer: null as number | null,
+      deletePointerStarted: false,
+      lastPointerDeleteAt: 0
     };
   },
   props: {
@@ -268,6 +273,26 @@ export default {
     },
     handleInfo(item: Item) {
       this.$emit('info', item);
+    },
+    handleDeletePointerStart() {
+      this.deletePointerStarted = true;
+    },
+    handleDeletePointerEnd(itemId: ItemId) {
+      if (!this.deletePointerStarted) {
+        return;
+      }
+      this.deletePointerStarted = false;
+      this.lastPointerDeleteAt = Date.now();
+      this.handleDelete(itemId);
+    },
+    handleDeletePointerCancel() {
+      this.deletePointerStarted = false;
+    },
+    handleDeleteClick(itemId: ItemId) {
+      if (Date.now() - this.lastPointerDeleteAt < 500) {
+        return;
+      }
+      this.handleDelete(itemId);
     },
     handleDelete(itemId: ItemId) {
       this.$emit('delete', itemId);

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -147,6 +147,9 @@ import { UNIT_DEFINITIONS } from '@/types/list-generation';
 import { ITEM_CATEGORIES, type ItemCategory } from '@/types/item-category';
 import { ITEM_PREPARATION_TYPES, type ItemPreparationType } from '@/types/item-preparation-type';
 
+// pointerup 直後に合成 click が続く場合があるため、短時間だけ click 側を抑止する。
+const CLICK_SUPPRESSION_MS = 500;
+
 export default {
   name: 'ItemBox',
   components: {
@@ -297,7 +300,7 @@ export default {
       this.deletePointerStarted = false;
     },
     handleDeleteClick(itemId: ItemId) {
-      if (Date.now() - this.lastPointerDeleteAt < 500) {
+      if (Date.now() - this.lastPointerDeleteAt < CLICK_SUPPRESSION_MS) {
         return;
       }
       this.handleDelete(itemId);


### PR DESCRIPTION
This pull request updates the delete button behavior in the `ItemBox.vue` component to improve handling of pointer and click events, making deletion more robust across different input types (mouse, touch, etc.). The main changes introduce logic to distinguish between pointer and click events and prevent accidental double deletion.

**Delete button event handling improvements:**

* The delete button now listens to `@pointerdown`, `@pointerup`, and `@pointercancel` events in addition to `@click`, enabling more precise control over user intent and supporting both mouse and touch interactions.
* New state variables `deletePointerStarted` and `lastPointerDeleteAt` are added to track pointer interactions and prevent rapid double deletions.

**New methods for delete interaction:**

* Added `handleDeletePointerStart`, `handleDeletePointerEnd`, and `handleDeletePointerCancel` methods to manage the pointer-based deletion flow, ensuring that deletion only occurs on a proper pointer up event.
* Updated `handleDeleteClick` to ignore click events that occur within 500ms of a pointer-based delete, preventing duplicate deletions from overlapping events.