### PR TITLE
Enhance SwipeContainer for improved gesture handling and offset management

### DIFF
--- a/frontend/src/components/SwipeContainer.test.ts
+++ b/frontend/src/components/SwipeContainer.test.ts
@@ -23,6 +23,14 @@ function createVm(overrides: Record<string, unknown> = {}) {
   return vm;
 }
 
+function createPointerMoveEvent(clientX: number, clientY = 0) {
+  return {
+    clientX,
+    clientY,
+    preventDefault: vi.fn()
+  } as unknown as PointerEvent;
+}
+
 describe('SwipeContainer', () => {
   it('閉じている状態では右スワイプで offset を増やさない', () => {
     const vm = createVm();
@@ -50,5 +58,29 @@ describe('SwipeContainer', () => {
     (vm.endDrag as () => void)();
 
     expect(vm.swipeOffset).toBe(0);
+  });
+
+  it('閉じている状態の右スワイプでは swipe を開始せず preventDefault もしない', () => {
+    const vm = createVm();
+    const event = createPointerMoveEvent(140);
+
+    (vm.startDrag as (clientX: number, clientY: number) => void)(100, 0);
+    (vm.handlePointerMove as (event: PointerEvent) => void)(event);
+
+    expect(vm.isSwiping).toBe(false);
+    expect(vm.swipeOffset).toBe(0);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('開いている状態の右スワイプでは swipe を開始して offset を戻す', () => {
+    const vm = createVm({ swipeOffset: -100 });
+    const event = createPointerMoveEvent(140);
+
+    (vm.startDrag as (clientX: number, clientY: number) => void)(100, 0);
+    (vm.handlePointerMove as (event: PointerEvent) => void)(event);
+
+    expect(vm.isSwiping).toBe(true);
+    expect(vm.swipeOffset).toBe(-60);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/SwipeContainer.test.ts
+++ b/frontend/src/components/SwipeContainer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import SwipeContainer from './SwipeContainer.vue';
+
+type SwipeContainerOptions = {
+  data: () => Record<string, unknown>;
+  methods: Record<string, (this: Record<string, unknown>, ...args: unknown[]) => unknown>;
+};
+
+function createVm(overrides: Record<string, unknown> = {}) {
+  const component = SwipeContainer as unknown as SwipeContainerOptions;
+  const vm: Record<string, unknown> = {
+    threshold: 60,
+    maxSwipe: 100,
+    ...component.data(),
+    $emit: vi.fn(),
+    ...overrides
+  };
+
+  Object.entries(component.methods).forEach(([name, method]) => {
+    vm[name] = method.bind(vm);
+  });
+
+  return vm;
+}
+
+describe('SwipeContainer', () => {
+  it('閉じている状態では右スワイプで offset を増やさない', () => {
+    const vm = createVm();
+
+    (vm.startDrag as (clientX: number, clientY: number) => void)(100, 0);
+    (vm.updateDrag as (clientX: number) => void)(140);
+
+    expect(vm.swipeOffset).toBe(0);
+  });
+
+  it('開いている状態では右スワイプで offset を戻せる', () => {
+    const vm = createVm({ swipeOffset: -100 });
+
+    (vm.startDrag as (clientX: number, clientY: number) => void)(100, 0);
+    (vm.updateDrag as (clientX: number) => void)(140);
+
+    expect(vm.swipeOffset).toBe(-60);
+  });
+
+  it('開いている状態から右へ戻しきると閉じる', () => {
+    const vm = createVm({ swipeOffset: -100 });
+
+    (vm.startDrag as (clientX: number, clientY: number) => void)(100, 0);
+    (vm.updateDrag as (clientX: number) => void)(240);
+    (vm.endDrag as () => void)();
+
+    expect(vm.swipeOffset).toBe(0);
+  });
+});

--- a/frontend/src/components/SwipeContainer.vue
+++ b/frontend/src/components/SwipeContainer.vue
@@ -60,6 +60,7 @@ export default {
       isSwiping: false,
       startX: 0,
       startY: 0,
+      startOffset: 0,
       currentX: 0
     };
   },
@@ -106,7 +107,10 @@ export default {
         if (Math.abs(diffX) < SWIPE_START_THRESHOLD) {
           return;
         }
-        if (Math.abs(diffY) > Math.abs(diffX) || diffX > 0) {
+        if (Math.abs(diffY) > Math.abs(diffX)) {
+          return;
+        }
+        if (this.startOffset === 0 && diffX > 0) {
           return;
         }
         this.isSwiping = true;
@@ -133,16 +137,16 @@ export default {
       this.isSwiping = false;
       this.startX = clientX;
       this.startY = clientY;
+      this.startOffset = this.swipeOffset;
       this.currentX = clientX;
     },
     updateDrag(clientX) {
       this.currentX = clientX;
       const diff = this.currentX - this.startX;
+      const nextOffset = this.startOffset + diff;
 
-      // 左スワイプ（負の値）のみ許可
-      if (diff <= 0) {
-        this.swipeOffset = Math.max(diff, -this.maxSwipe);
-      }
+      // 閉じている状態からは左スワイプのみ、開いている状態からは右スワイプで戻せるようにする
+      this.swipeOffset = Math.min(0, Math.max(nextOffset, -this.maxSwipe));
     },
     endDrag() {
       this.isDragging = false;


### PR DESCRIPTION
This pull request introduces improvements to the swipe gesture logic in the `SwipeContainer.vue` component and adds comprehensive unit tests. The main focus is to refine how swipe offsets are handled, especially differentiating between closed and open states, and to ensure the component behaves correctly through new tests.

### Swipe gesture logic improvements

* Added a new `startOffset` property to the component's data to accurately track the swipe offset at the start of a drag, improving the calculation of the swipe offset during gestures.
* Updated the swipe logic so that when the container is closed, right swipes do not increase the offset, but when open, right swipes can return the offset toward zero. This ensures correct behavior for both opening and closing gestures. [[1]](diffhunk://#diff-48fb083945cf42e77b1bb7a0820edae3e78bf6a778def1013ca24c9f0241fdbaL109-R113) [[2]](diffhunk://#diff-48fb083945cf42e77b1bb7a0820edae3e78bf6a778def1013ca24c9f0241fdbaR140-R149)

### Testing

* Added a new test file `SwipeContainer.test.ts` with unit tests covering key swipe behaviors, including preventing right swipes when closed, allowing right swipes to return the offset when open, and closing the container when fully swiped right.