### PR TITLE
Add BBQ generation functionality with localization and quantity display

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/GeneratedItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/GeneratedItemCommandController.java
@@ -1,0 +1,40 @@
+package com.atoook.otsukailist.api.controller;
+
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.SyncGeneratedItemsRequest;
+import com.atoook.otsukailist.dto.SyncGeneratedItemsResponse;
+import com.atoook.otsukailist.service.GeneratedItemCommandService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lists/{listId}/generated-items")
+public class GeneratedItemCommandController {
+
+  private final GeneratedItemCommandService generatedItemCommandService;
+
+  /**
+   * Sync generated item candidates to a list.
+   *
+   * @param listId target list ID
+   * @param req generated item candidates and generator-key scope
+   * @return synced items with latest list revision
+   */
+  @PostMapping("/sync")
+  public ResponseEntity<MutationResponse<SyncGeneratedItemsResponse>> syncGeneratedItems(
+      @PathVariable("listId") UUID listId, @Valid @RequestBody SyncGeneratedItemsRequest req) {
+    return ResponseEntity.ok(generatedItemCommandService.syncGeneratedItems(listId, req));
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ListGenerationConfigController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ListGenerationConfigController.java
@@ -1,0 +1,57 @@
+package com.atoook.otsukailist.api.controller;
+
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.atoook.otsukailist.dto.ListGenerationConfigRequest;
+import com.atoook.otsukailist.dto.ListGenerationConfigResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.service.ListGenerationConfigService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/lists/{listId}/generation-configs")
+public class ListGenerationConfigController {
+
+  private final ListGenerationConfigService listGenerationConfigService;
+
+  /**
+   * Get the saved generation config for the specified list and type.
+   *
+   * @param listId target list ID
+   * @param configType generation config type value
+   * @return saved generation config
+   */
+  @GetMapping("/{configType}")
+  public ResponseEntity<ListGenerationConfigResponse> getConfig(
+      @PathVariable("listId") UUID listId, @PathVariable("configType") String configType) {
+    return ResponseEntity.ok(listGenerationConfigService.getConfig(listId, configType));
+  }
+
+  /**
+   * Create or update the generation config for the specified list and type.
+   *
+   * @param listId target list ID
+   * @param configType generation config type value
+   * @param req generation config payload
+   * @return saved generation config with latest list revision
+   */
+  @PutMapping("/{configType}")
+  public ResponseEntity<MutationResponse<ListGenerationConfigResponse>> upsertConfig(
+      @PathVariable("listId") UUID listId,
+      @PathVariable("configType") String configType,
+      @Valid @RequestBody ListGenerationConfigRequest req) {
+    return ResponseEntity.ok(listGenerationConfigService.upsertConfig(listId, configType, req));
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ListGenerationConfigRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ListGenerationConfigRequest.java
@@ -1,0 +1,21 @@
+package com.atoook.otsukailist.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ListGenerationConfigRequest {
+
+  @NotNull(message = "生成条件は必須です")
+  private JsonNode configJson;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/dto/ListGenerationConfigResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/ListGenerationConfigResponse.java
@@ -1,0 +1,23 @@
+package com.atoook.otsukailist.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.atoook.otsukailist.model.GenerationConfigType;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ListGenerationConfigResponse {
+  private UUID id;
+  private UUID listId;
+  private GenerationConfigType configType;
+  private JsonNode configJson;
+  private Instant createdAt;
+  private Instant updatedAt;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/dto/SyncGeneratedItemsRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/SyncGeneratedItemsRequest.java
@@ -1,0 +1,29 @@
+package com.atoook.otsukailist.dto;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SyncGeneratedItemsRequest {
+
+  @Size(min = 1, max = 100, message = "生成ルールIDは1件以上100件以下で指定してください")
+  @NotNull(message = "生成ルールID一覧は必須です")
+  private List<String> generatorKeysInScope;
+
+  @NotNull(message = "生成アイテム一覧は必須です")
+  @Size(max = 100, message = "生成アイテムは100件以下で指定してください")
+  private List<@Valid CreateItemRequest> items;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/dto/SyncGeneratedItemsResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/SyncGeneratedItemsResponse.java
@@ -1,0 +1,16 @@
+package com.atoook.otsukailist.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SyncGeneratedItemsResponse {
+  private List<ItemResponse> items;
+  private List<UUID> deletedItemIds;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/generation/BBQGenerationRules.java
+++ b/backend/src/main/java/com/atoook/otsukailist/generation/BBQGenerationRules.java
@@ -10,13 +10,52 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class BBQGenerationRules {
   public static final Map<String, BBQGenerationRule> VALUES =
-      Map.of(
-          "beef", new BBQGenerationRule("beef", ItemCategory.MEAT, BaseUnit.G, "kg"),
-          "pork", new BBQGenerationRule("pork", ItemCategory.MEAT, BaseUnit.G, "kg"),
-          "vegetables",
-              new BBQGenerationRule("vegetables", ItemCategory.VEGETABLES, BaseUnit.G, "g"),
-          "yakisoba",
-              new BBQGenerationRule("yakisoba", ItemCategory.STAPLE, BaseUnit.PIECE, "piece"));
+      Map.ofEntries(
+          Map.entry("beef", new BBQGenerationRule("beef", ItemCategory.MEAT, BaseUnit.G, "g")),
+          Map.entry("pork", new BBQGenerationRule("pork", ItemCategory.MEAT, BaseUnit.G, "g")),
+          Map.entry(
+              "chicken", new BBQGenerationRule("chicken", ItemCategory.MEAT, BaseUnit.G, "g")),
+          Map.entry(
+              "sausage", new BBQGenerationRule("sausage", ItemCategory.MEAT, BaseUnit.G, "g")),
+          Map.entry(
+              "vegetable_onion",
+              new BBQGenerationRule(
+                  "vegetable_onion", ItemCategory.VEGETABLES, BaseUnit.PIECE, "piece")),
+          Map.entry(
+              "vegetable_bell_pepper",
+              new BBQGenerationRule(
+                  "vegetable_bell_pepper", ItemCategory.VEGETABLES, BaseUnit.PIECE, "piece")),
+          Map.entry(
+              "vegetable_corn",
+              new BBQGenerationRule(
+                  "vegetable_corn", ItemCategory.VEGETABLES, BaseUnit.PIECE, "piece")),
+          Map.entry(
+              "vegetable_potato",
+              new BBQGenerationRule(
+                  "vegetable_potato", ItemCategory.VEGETABLES, BaseUnit.PIECE, "piece")),
+          Map.entry(
+              "vegetable_mushrooms",
+              new BBQGenerationRule(
+                  "vegetable_mushrooms", ItemCategory.VEGETABLES, BaseUnit.PACK, "pack")),
+          Map.entry(
+              "seafood_shrimp",
+              new BBQGenerationRule("seafood_shrimp", ItemCategory.SEAFOOD, BaseUnit.PACK, "pack")),
+          Map.entry(
+              "seafood_scallop",
+              new BBQGenerationRule(
+                  "seafood_scallop", ItemCategory.SEAFOOD, BaseUnit.PACK, "pack")),
+          Map.entry(
+              "seafood_squid",
+              new BBQGenerationRule("seafood_squid", ItemCategory.SEAFOOD, BaseUnit.PACK, "pack")),
+          Map.entry(
+              "soft_drinks",
+              new BBQGenerationRule("soft_drinks", ItemCategory.DRINKS, BaseUnit.ML, "l")),
+          Map.entry(
+              "alcohol",
+              new BBQGenerationRule("alcohol", ItemCategory.DRINKS, BaseUnit.PIECE, "piece")),
+          Map.entry(
+              "yakisoba",
+              new BBQGenerationRule("yakisoba", ItemCategory.STAPLE, BaseUnit.PIECE, "piece")));
 
   public record BBQGenerationRule(
       String generatorKey, ItemCategory category, BaseUnit baseUnit, String displayUnit)

--- a/backend/src/main/java/com/atoook/otsukailist/generation/UnitDefinitions.java
+++ b/backend/src/main/java/com/atoook/otsukailist/generation/UnitDefinitions.java
@@ -10,12 +10,12 @@ import lombok.experimental.UtilityClass;
 public class UnitDefinitions {
   public static final Map<String, UnitDefinition> VALUES =
       Map.of(
-          "g", new UnitDefinition("g", "g", BaseUnit.G, 1),
-          "kg", new UnitDefinition("kg", "kg", BaseUnit.G, 1000),
-          "ml", new UnitDefinition("ml", "ml", BaseUnit.ML, 1),
-          "l", new UnitDefinition("l", "L", BaseUnit.ML, 1000),
-          "piece", new UnitDefinition("piece", "個", BaseUnit.PIECE, 1),
-          "pack", new UnitDefinition("pack", "袋", BaseUnit.PACK, 1));
+          "g", new UnitDefinition("g", BaseUnit.G, 1),
+          "kg", new UnitDefinition("kg", BaseUnit.G, 1000),
+          "ml", new UnitDefinition("ml", BaseUnit.ML, 1),
+          "l", new UnitDefinition("l", BaseUnit.ML, 1000),
+          "piece", new UnitDefinition("piece", BaseUnit.PIECE, 1),
+          "pack", new UnitDefinition("pack", BaseUnit.PACK, 1));
 
-  public record UnitDefinition(String code, String label, BaseUnit baseUnit, long factor) {}
+  public record UnitDefinition(String code, BaseUnit baseUnit, long factor) {}
 }

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
@@ -48,6 +48,19 @@ public interface ItemRepository extends JpaRepository<Item, UUID> {
   // リスト内のアイテム存在チェック
   boolean existsByIdAndItemListId(UUID itemId, UUID itemListId);
 
+  @EntityGraph(attributePaths = "quantified")
+  @Query(
+      """
+      SELECT i
+      FROM Item i
+      JOIN i.quantified q
+      WHERE i.itemList.id = :itemListId
+        AND q.origin = com.atoook.otsukailist.model.Origin.GENERATED
+        AND q.generatorKey IN :generatorKeys
+      """)
+  List<Item> findGeneratedItemsByGeneratorKeys(
+      @Param("itemListId") UUID itemListId, @Param("generatorKeys") List<String> generatorKeys);
+
   /** 複数リストのアイテム集計をまとめて取得する。 存在しないlistIdは結果に含まれない（削除済み判定に使う）。 */
   @Query(
       """

--- a/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemCommandService.java
@@ -1,0 +1,163 @@
+package com.atoook.otsukailist.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.atoook.otsukailist.dto.CreateItemRequest;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.QuantifiedItemRequest;
+import com.atoook.otsukailist.dto.SyncGeneratedItemsRequest;
+import com.atoook.otsukailist.dto.SyncGeneratedItemsResponse;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.generation.GenerationRule;
+import com.atoook.otsukailist.generation.GenerationRules;
+import com.atoook.otsukailist.model.ItemType;
+import com.atoook.otsukailist.model.Origin;
+import com.atoook.otsukailist.model.RegenerationPolicy;
+import com.atoook.otsukailist.service.GeneratedItemSyncCommandService.GeneratedItemUpdateCommand;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GeneratedItemCommandService {
+
+  private static final String MSG_GENERATED_ITEM_REQUIRED = "生成アイテムの形式が不正です";
+  private static final String MSG_GENERATOR_KEY_REQUIRED = "自動生成アイテムには生成ルールIDが必須です";
+  private static final String MSG_GENERATOR_KEY_UNKNOWN = "未知の生成ルールIDです";
+  private static final String MSG_GENERATOR_KEY_DUPLICATED = "生成ルールIDが重複しています";
+  private static final String MSG_GENERATOR_KEY_SCOPE_REQUIRED = "生成ルールID一覧が不正です";
+  private static final String MSG_ITEM_NAME_REQUIRED = "アイテム名は必須です";
+
+  private final GeneratedItemSyncCommandService generatedItemSyncCommandService;
+
+  /**
+   * Validate and sync generated item candidates without locking existing generated-auto items.
+   *
+   * @param listId target list ID
+   * @param req generated item candidates and generator-key scope
+   * @return synced items with latest list revision
+   */
+  public MutationResponse<SyncGeneratedItemsResponse> syncGeneratedItems(
+      UUID listId, SyncGeneratedItemsRequest req) {
+    List<String> generatorKeysInScope = validateGeneratorKeysInScope(req.getGeneratorKeysInScope());
+    List<CreateItemRequest> requests = req.getItems() == null ? List.of() : req.getItems();
+    List<GeneratedItemUpdateCommand> commands = validateAndBuildCommands(requests);
+    validateCommandKeysInScope(commands, generatorKeysInScope);
+    return generatedItemSyncCommandService.syncGeneratedItems(
+        listId, commands, generatorKeysInScope);
+  }
+
+  private static List<String> validateGeneratorKeysInScope(List<String> generatorKeysInScope) {
+    if (generatorKeysInScope == null || generatorKeysInScope.isEmpty()) {
+      throw new BadRequestException(MSG_GENERATOR_KEY_SCOPE_REQUIRED);
+    }
+    Set<String> uniqueKeys = new HashSet<>();
+    List<String> normalizedKeys = new ArrayList<>();
+    for (String key : generatorKeysInScope) {
+      String generatorKey = normalizeNullableText(key);
+      if (generatorKey == null || !GenerationRules.containsGeneratorKey(generatorKey)) {
+        throw new BadRequestException(MSG_GENERATOR_KEY_UNKNOWN);
+      }
+      if (!uniqueKeys.add(generatorKey)) {
+        throw new BadRequestException(MSG_GENERATOR_KEY_DUPLICATED);
+      }
+      normalizedKeys.add(generatorKey);
+    }
+    return normalizedKeys;
+  }
+
+  private static void validateCommandKeysInScope(
+      List<GeneratedItemUpdateCommand> commands, List<String> generatorKeysInScope) {
+    Set<String> scopeKeys = new HashSet<>(generatorKeysInScope);
+    for (GeneratedItemUpdateCommand command : commands) {
+      if (!scopeKeys.contains(command.generatorKey())) {
+        throw new BadRequestException(MSG_GENERATOR_KEY_SCOPE_REQUIRED);
+      }
+    }
+  }
+
+  private static List<GeneratedItemUpdateCommand> validateAndBuildCommands(
+      List<CreateItemRequest> requests) {
+    Set<String> generatorKeys = new HashSet<>();
+    List<GeneratedItemUpdateCommand> commands = new ArrayList<>();
+    for (CreateItemRequest request : requests) {
+      validateGeneratedItemRequest(request);
+      String generatorKey = request.getQuantified().getGeneratorKey().trim();
+      if (!generatorKeys.add(generatorKey)) {
+        throw new BadRequestException(MSG_GENERATOR_KEY_DUPLICATED);
+      }
+      commands.add(toGeneratedItemUpdateCommand(request, generatorKey));
+    }
+    return commands;
+  }
+
+  private static GeneratedItemUpdateCommand toGeneratedItemUpdateCommand(
+      CreateItemRequest request, String generatorKey) {
+    QuantifiedItemRequest quantifiedRequest = request.getQuantified();
+    GenerationRule rule = GenerationRules.findByGeneratorKey(generatorKey);
+    return new GeneratedItemUpdateCommand(
+        normalizeRequiredText(request.getName(), MSG_ITEM_NAME_REQUIRED),
+        rule.category(),
+        request.getPreparationType(),
+        request.getAssignedMemberId(),
+        QuantifiedItemRequest.builder()
+            .quantity(quantifiedRequest.getQuantity())
+            .baseUnit(quantifiedRequest.getBaseUnit())
+            .origin(Origin.GENERATED)
+            .regenerationPolicy(RegenerationPolicy.AUTO)
+            .generatorKey(generatorKey)
+            .build());
+  }
+
+  private static void validateGeneratedItemRequest(CreateItemRequest request) {
+    if (!isGeneratedAutoQuantifiedRequest(request)) {
+      throw new BadRequestException(MSG_GENERATED_ITEM_REQUIRED);
+    }
+
+    validateGeneratorKey(request.getQuantified());
+  }
+
+  private static boolean isGeneratedAutoQuantifiedRequest(CreateItemRequest request) {
+    return request != null
+        && request.getItemType() == ItemType.QUANTIFIED
+        && request.getQuantified() != null
+        && request.getQuantified().getOrigin() == Origin.GENERATED
+        && request.getQuantified().getRegenerationPolicy() == RegenerationPolicy.AUTO;
+  }
+
+  private static void validateGeneratorKey(QuantifiedItemRequest quantified) {
+    String generatorKey = normalizeNullableText(quantified.getGeneratorKey());
+    if (generatorKey == null) {
+      throw new BadRequestException(MSG_GENERATOR_KEY_REQUIRED);
+    }
+    if (!GenerationRules.containsGeneratorKey(generatorKey)) {
+      throw new BadRequestException(MSG_GENERATOR_KEY_UNKNOWN);
+    }
+    if (!Objects.equals(
+        quantified.getBaseUnit(), GenerationRules.findByGeneratorKey(generatorKey).baseUnit())) {
+      throw new BadRequestException(MSG_GENERATED_ITEM_REQUIRED);
+    }
+  }
+
+  private static String normalizeNullableText(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    return value.trim();
+  }
+
+  private static String normalizeRequiredText(String value, String message) {
+    String normalizedValue = normalizeNullableText(value);
+    if (normalizedValue == null) {
+      throw new BadRequestException(message);
+    }
+    return normalizedValue;
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
@@ -1,0 +1,148 @@
+package com.atoook.otsukailist.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.dto.QuantifiedItemRequest;
+import com.atoook.otsukailist.dto.SyncGeneratedItemsResponse;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.mapper.ItemMapper;
+import com.atoook.otsukailist.model.Item;
+import com.atoook.otsukailist.model.ItemCategory;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.ItemPreparationType;
+import com.atoook.otsukailist.model.ItemQuantified;
+import com.atoook.otsukailist.model.ItemType;
+import com.atoook.otsukailist.model.Origin;
+import com.atoook.otsukailist.model.RegenerationPolicy;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ItemRepository;
+import com.atoook.otsukailist.service.message.ErrorMessages;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GeneratedItemSyncCommandService {
+
+  private final ItemRepository itemRepo;
+  private final ItemListRepository itemListRepo;
+  private final ListRevisionService listRevisionService;
+
+  public record GeneratedItemUpdateCommand(
+      String name,
+      ItemCategory category,
+      ItemPreparationType preparationType,
+      UUID assignedMemberId,
+      QuantifiedItemRequest quantified) {
+
+    public String generatorKey() {
+      return quantified.getGeneratorKey();
+    }
+  }
+
+  @Transactional
+  public MutationResponse<SyncGeneratedItemsResponse> syncGeneratedItems(
+      UUID listId, List<GeneratedItemUpdateCommand> commands, List<String> generatorKeysInScope) {
+    ItemList list =
+        itemListRepo
+            .findById(listId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+
+    List<GeneratedItemUpdateCommand> safeCommands = commands == null ? List.of() : commands;
+    List<String> safeGeneratorKeysInScope =
+        generatorKeysInScope == null ? List.of() : generatorKeysInScope;
+    Set<String> generatedKeys =
+        safeCommands.stream()
+            .map(GeneratedItemUpdateCommand::generatorKey)
+            .collect(Collectors.toSet());
+    Map<String, Item> existingItems =
+        safeGeneratorKeysInScope.isEmpty()
+            ? Map.of()
+            : itemRepo.findGeneratedItemsByGeneratorKeys(listId, safeGeneratorKeysInScope).stream()
+                .collect(
+                    Collectors.toMap(
+                        item -> item.getQuantified().getGeneratorKey(), Function.identity()));
+
+    List<Item> changedItems =
+        safeCommands.stream()
+            .map(command -> upsertGeneratedItem(list, command, existingItems))
+            .filter(Objects::nonNull)
+            .toList();
+
+    List<Item> deletedItems =
+        existingItems.values().stream()
+            .filter(item -> !generatedKeys.contains(item.getQuantified().getGeneratorKey()))
+            .filter(item -> item.getQuantified().getRegenerationPolicy() == RegenerationPolicy.AUTO)
+            .toList();
+
+    List<Item> savedItems = itemRepo.saveAll(changedItems);
+    itemRepo.deleteAll(deletedItems);
+    long revision = listRevisionService.incrementAndGet(listId);
+
+    SyncGeneratedItemsResponse data =
+        SyncGeneratedItemsResponse.builder()
+            .items(savedItems.stream().map(ItemMapper::toResponse).toList())
+            .deletedItemIds(deletedItems.stream().map(Item::getId).toList())
+            .build();
+
+    return MutationResponse.<SyncGeneratedItemsResponse>builder()
+        .revision(revision)
+        .data(data)
+        .build();
+  }
+
+  private Item upsertGeneratedItem(
+      ItemList list, GeneratedItemUpdateCommand command, Map<String, Item> existingItems) {
+    Item existingItem = existingItems.get(command.generatorKey());
+    if (existingItem != null) {
+      if (existingItem.getQuantified().getRegenerationPolicy() == RegenerationPolicy.LOCKED) {
+        return null;
+      }
+      updateExistingGeneratedAutoItem(existingItem, command);
+      return existingItem;
+    }
+
+    return createGeneratedItem(list, command);
+  }
+
+  private static Item createGeneratedItem(ItemList list, GeneratedItemUpdateCommand command) {
+    Item item = new Item();
+    item.setName(command.name());
+    item.setItemType(ItemType.QUANTIFIED);
+    item.setCategory(command.category());
+    item.setPreparationType(command.preparationType());
+    item.setCompleted(false);
+    item.setAssignedMemberId(command.assignedMemberId());
+    item.setCompletedByMemberId(null);
+    item.setCompletedAt(null);
+    item.setItemList(list);
+    item.setQuantified(ItemMapper.toQuantifiedEntity(command.quantified()));
+    return item;
+  }
+
+  private static void updateExistingGeneratedAutoItem(
+      Item item, GeneratedItemUpdateCommand command) {
+    ItemQuantified quantified = item.getQuantified();
+    if (quantified == null) {
+      throw new BadRequestException("生成アイテムの形式が不正です");
+    }
+    quantified.setQuantity(command.quantified().getQuantity());
+    quantified.setBaseUnit(command.quantified().getBaseUnit());
+    quantified.setOrigin(Origin.GENERATED);
+    quantified.setRegenerationPolicy(RegenerationPolicy.AUTO);
+    quantified.setGeneratorKey(command.generatorKey());
+    item.setCategory(command.category());
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
@@ -27,6 +27,7 @@ import com.atoook.otsukailist.model.Origin;
 import com.atoook.otsukailist.model.RegenerationPolicy;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.ItemRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
 
 import lombok.RequiredArgsConstructor;
@@ -37,8 +38,13 @@ public class GeneratedItemSyncCommandService {
 
   private final ItemRepository itemRepo;
   private final ItemListRepository itemListRepo;
+  private final MemberRepository memberRepo;
   private final ListRevisionService listRevisionService;
 
+  private static final String MSG_ASSIGNED_MEMBER_NOT_IN_LIST = "指定された担当者はリストのメンバーではありません";
+  private static final String MSG_GENERATED_ITEM_DUPLICATED = "生成アイテムが重複しています";
+
+  /** Generated item update command normalized from a sync request. */
   public record GeneratedItemUpdateCommand(
       String name,
       ItemCategory category,
@@ -46,11 +52,20 @@ public class GeneratedItemSyncCommandService {
       UUID assignedMemberId,
       QuantifiedItemRequest quantified) {
 
+    /** Returns the stable generator key for matching generated items. */
     public String generatorKey() {
       return quantified.getGeneratorKey();
     }
   }
 
+  /**
+   * Sync generated item candidates within the provided generator-key scope.
+   *
+   * @param listId target list ID
+   * @param commands generated item update commands
+   * @param generatorKeysInScope generator keys managed by the current template
+   * @return synced items and deleted item IDs with latest list revision
+   */
   @Transactional
   public MutationResponse<SyncGeneratedItemsResponse> syncGeneratedItems(
       UUID listId, List<GeneratedItemUpdateCommand> commands, List<String> generatorKeysInScope) {
@@ -63,6 +78,7 @@ public class GeneratedItemSyncCommandService {
     List<GeneratedItemUpdateCommand> safeCommands = commands == null ? List.of() : commands;
     List<String> safeGeneratorKeysInScope =
         generatorKeysInScope == null ? List.of() : generatorKeysInScope;
+    validateAssignedMembers(listId, safeCommands);
     Set<String> generatedKeys =
         safeCommands.stream()
             .map(GeneratedItemUpdateCommand::generatorKey)
@@ -70,10 +86,8 @@ public class GeneratedItemSyncCommandService {
     Map<String, Item> existingItems =
         safeGeneratorKeysInScope.isEmpty()
             ? Map.of()
-            : itemRepo.findGeneratedItemsByGeneratorKeys(listId, safeGeneratorKeysInScope).stream()
-                .collect(
-                    Collectors.toMap(
-                        item -> item.getQuantified().getGeneratorKey(), Function.identity()));
+            : toExistingItemMap(
+                itemRepo.findGeneratedItemsByGeneratorKeys(listId, safeGeneratorKeysInScope));
 
     List<Item> changedItems =
         safeCommands.stream()
@@ -115,6 +129,27 @@ public class GeneratedItemSyncCommandService {
     }
 
     return createGeneratedItem(list, command);
+  }
+
+  private void validateAssignedMembers(UUID listId, List<GeneratedItemUpdateCommand> commands) {
+    for (GeneratedItemUpdateCommand command : commands) {
+      UUID assignedMemberId = command.assignedMemberId();
+      if (assignedMemberId != null
+          && !memberRepo.existsByIdAndItemListId(assignedMemberId, listId)) {
+        throw new BadRequestException(MSG_ASSIGNED_MEMBER_NOT_IN_LIST);
+      }
+    }
+  }
+
+  private static Map<String, Item> toExistingItemMap(List<Item> items) {
+    return items.stream()
+        .collect(
+            Collectors.toMap(
+                item -> item.getQuantified().getGeneratorKey(),
+                Function.identity(),
+                (left, right) -> {
+                  throw new BadRequestException(MSG_GENERATED_ITEM_DUPLICATED);
+                }));
   }
 
   private static Item createGeneratedItem(ItemList list, GeneratedItemUpdateCommand command) {

--- a/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
@@ -161,7 +161,6 @@ public class ItemCommandService {
 
   private static void updateNameCategoryAndQuantified(Item item, UpdateItemRequest req) {
     ItemCategory requestedCategory = resolveRequestedCategory(item, req);
-    boolean categoryEdited = isUserCategoryEdit(item, req, requestedCategory);
     boolean revertingToPlain =
         item.getItemType() == ItemType.QUANTIFIED && req.getItemType() == ItemType.PLAIN;
     boolean quantifiedDetailsEdited = req.getQuantified() != null;
@@ -175,9 +174,8 @@ public class ItemCommandService {
       return;
     }
     boolean quantifiedDetailsChanged = updateQuantifiedDetails(item, req);
-    boolean shouldLockGeneratedAuto = categoryEdited || quantifiedDetailsChanged;
-    item.setCategory(resolveCategoryAfterUpdate(requestedCategory, req, shouldLockGeneratedAuto));
-    if (shouldLockGeneratedAuto) {
+    item.setCategory(resolveCategoryAfterUpdate(item, requestedCategory));
+    if (quantifiedDetailsChanged) {
       lockGeneratedAutoQuantifiedItem(item);
     }
   }
@@ -276,35 +274,15 @@ public class ItemCommandService {
     return generatedCategory == null ? requestedCategory : generatedCategory;
   }
 
-  private static boolean isUserCategoryEdit(
-      Item item, UpdateItemRequest req, ItemCategory requestedCategory) {
-    if (!req.isCategoryPresent() || Objects.equals(item.getCategory(), requestedCategory)) {
-      return false;
-    }
-    ItemCategory generatedCategory = resolveGeneratedCategory(item, req);
-    return generatedCategory == null || !Objects.equals(requestedCategory, generatedCategory);
-  }
-
-  private static ItemCategory resolveGeneratedCategory(Item item, UpdateItemRequest req) {
-    if (req.getQuantified() != null) {
-      return resolveGeneratedCategory(req.getQuantified());
-    }
-    return resolveGeneratedCategory(item.getQuantified());
-  }
-
   private static ItemCategory resolveGeneratedCategory(ItemQuantified quantified) {
-    if (quantified == null
-        || quantified.getOrigin() != Origin.GENERATED
-        || quantified.getRegenerationPolicy() != RegenerationPolicy.AUTO) {
+    if (quantified == null || quantified.getOrigin() != Origin.GENERATED) {
       return null;
     }
     return resolveGeneratedCategory(quantified.getGeneratorKey());
   }
 
   private static ItemCategory resolveGeneratedCategory(QuantifiedItemRequest quantified) {
-    if (quantified == null
-        || quantified.getOrigin() != Origin.GENERATED
-        || quantified.getRegenerationPolicy() != RegenerationPolicy.AUTO) {
+    if (quantified == null || quantified.getOrigin() != Origin.GENERATED) {
       return null;
     }
     return resolveGeneratedCategory(quantified.getGeneratorKey());
@@ -327,11 +305,9 @@ public class ItemCommandService {
   }
 
   private static ItemCategory resolveCategoryAfterUpdate(
-      ItemCategory requestedCategory, UpdateItemRequest req, boolean shouldLockGeneratedAuto) {
-    if (shouldLockGeneratedAuto) {
-      return requestedCategory;
-    }
-    return resolveCategory(requestedCategory, req.getQuantified());
+      Item item, ItemCategory requestedCategory) {
+    ItemCategory generatedCategory = resolveGeneratedCategory(item.getQuantified());
+    return generatedCategory == null ? requestedCategory : generatedCategory;
   }
 
   private static void validateQuantifiedState(QuantifiedItemRequest quantified) {

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListGenerationConfigService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListGenerationConfigService.java
@@ -1,0 +1,132 @@
+package com.atoook.otsukailist.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.atoook.otsukailist.dto.ListGenerationConfigRequest;
+import com.atoook.otsukailist.dto.ListGenerationConfigResponse;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.model.GenerationConfigType;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.ListGenerationConfig;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ListGenerationConfigRepository;
+import com.atoook.otsukailist.service.message.ErrorMessages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ListGenerationConfigService {
+
+  private static final String MSG_CONFIG_TYPE_UNKNOWN = "未知の生成設定タイプです";
+  private static final String MSG_CONFIG_JSON_INVALID = "生成条件の形式が不正です";
+
+  private final ItemListRepository itemListRepo;
+  private final ListGenerationConfigRepository listGenerationConfigRepo;
+  private final ListRevisionService listRevisionService;
+  private final ObjectMapper objectMapper;
+
+  /**
+   * Get the saved generation config for a list.
+   *
+   * @param listId target list ID
+   * @param configTypeValue generation config type value
+   * @return saved generation config
+   */
+  @Transactional(readOnly = true)
+  public ListGenerationConfigResponse getConfig(UUID listId, String configTypeValue) {
+    GenerationConfigType configType = resolveConfigType(configTypeValue);
+    ensureListExists(listId);
+
+    ListGenerationConfig config =
+        listGenerationConfigRepo
+            .findByItemListIdAndConfigType(listId, configType)
+            .orElseThrow(
+                () ->
+                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "生成設定")));
+
+    return toResponse(config);
+  }
+
+  /**
+   * Create or update the generation config for a list.
+   *
+   * @param listId target list ID
+   * @param configTypeValue generation config type value
+   * @param req generation config payload
+   * @return saved generation config with latest list revision
+   */
+  @Transactional
+  public MutationResponse<ListGenerationConfigResponse> upsertConfig(
+      UUID listId, String configTypeValue, ListGenerationConfigRequest req) {
+    GenerationConfigType configType = resolveConfigType(configTypeValue);
+    ItemList list = ensureListExists(listId);
+
+    ListGenerationConfig config =
+        listGenerationConfigRepo
+            .findByItemListIdAndConfigType(listId, configType)
+            .orElseGet(ListGenerationConfig::new);
+
+    config.setItemList(list);
+    config.setConfigType(configType);
+    config.setConfigJson(writeConfigJson(req.getConfigJson()));
+
+    ListGenerationConfig saved = listGenerationConfigRepo.save(config);
+    long revision = listRevisionService.incrementAndGet(listId);
+
+    return MutationResponse.<ListGenerationConfigResponse>builder()
+        .revision(revision)
+        .data(toResponse(saved))
+        .build();
+  }
+
+  private ItemList ensureListExists(UUID listId) {
+    return itemListRepo
+        .findById(listId)
+        .orElseThrow(
+            () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+  }
+
+  private static GenerationConfigType resolveConfigType(String configTypeValue) {
+    try {
+      return GenerationConfigType.fromValue(configTypeValue);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(MSG_CONFIG_TYPE_UNKNOWN, e);
+    }
+  }
+
+  private String writeConfigJson(JsonNode configJson) {
+    try {
+      return objectMapper.writeValueAsString(configJson);
+    } catch (JsonProcessingException e) {
+      throw new BadRequestException(MSG_CONFIG_JSON_INVALID, e);
+    }
+  }
+
+  private JsonNode readConfigJson(String configJson) {
+    try {
+      return objectMapper.readTree(configJson);
+    } catch (JsonProcessingException e) {
+      throw new BadRequestException(MSG_CONFIG_JSON_INVALID, e);
+    }
+  }
+
+  private ListGenerationConfigResponse toResponse(ListGenerationConfig config) {
+    return ListGenerationConfigResponse.builder()
+        .id(config.getId())
+        .listId(config.getItemList().getId())
+        .configType(config.getConfigType())
+        .configJson(readConfigJson(config.getConfigJson()))
+        .createdAt(config.getCreatedAt())
+        .updatedAt(config.getUpdatedAt())
+        .build();
+  }
+}

--- a/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
@@ -23,6 +23,7 @@ import com.atoook.otsukailist.model.Origin;
 import com.atoook.otsukailist.model.RegenerationPolicy;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.ItemRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +37,7 @@ class GeneratedItemCommandServiceTest {
 
   @Mock private ItemRepository itemRepo;
   @Mock private ItemListRepository itemListRepo;
+  @Mock private MemberRepository memberRepo;
   @Mock private ListRevisionService listRevisionService;
 
   private GeneratedItemCommandService service;
@@ -43,7 +45,8 @@ class GeneratedItemCommandServiceTest {
   @BeforeEach
   void setUp() {
     GeneratedItemSyncCommandService generatedItemSyncCommandService =
-        new GeneratedItemSyncCommandService(itemRepo, itemListRepo, listRevisionService);
+        new GeneratedItemSyncCommandService(
+            itemRepo, itemListRepo, memberRepo, listRevisionService);
     service = new GeneratedItemCommandService(generatedItemSyncCommandService);
   }
 
@@ -201,6 +204,48 @@ class GeneratedItemCommandServiceTest {
         .hasMessage("生成ルールID一覧が不正です");
   }
 
+  @Test
+  @DisplayName("担当者がリストのメンバーでない場合はエラーにすること")
+  void syncGeneratedItemsRejectsAssignedMemberOutsideList() {
+    UUID listId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef", memberId)))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(memberRepo.existsByIdAndItemListId(memberId, listId)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.syncGeneratedItems(listId, request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessage("指定された担当者はリストのメンバーではありません");
+  }
+
+  @Test
+  @DisplayName("同じgeneratorKeyの既存生成itemが重複している場合はエラーにすること")
+  void syncGeneratedItemsRejectsDuplicatedExistingGeneratedItems() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item first = generatedAutoItem(list, "牛肉1", 1000L, "beef");
+    Item second = generatedAutoItem(list, "牛肉2", 1200L, "beef");
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
+        .thenReturn(List.of(first, second));
+
+    assertThatThrownBy(() -> service.syncGeneratedItems(listId, request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessage("生成アイテムが重複しています");
+  }
+
   private static ItemList itemList(UUID listId) {
     ItemList list = new ItemList();
     list.setId(listId);
@@ -228,9 +273,15 @@ class GeneratedItemCommandServiceTest {
 
   private static CreateItemRequest generatedItemRequest(
       String name, long quantity, String generatorKey) {
+    return generatedItemRequest(name, quantity, generatorKey, null);
+  }
+
+  private static CreateItemRequest generatedItemRequest(
+      String name, long quantity, String generatorKey, UUID assignedMemberId) {
     return CreateItemRequest.builder()
         .name(name)
         .itemType(ItemType.QUANTIFIED)
+        .assignedMemberId(assignedMemberId)
         .quantified(
             QuantifiedItemRequest.builder()
                 .quantity(quantity)

--- a/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
@@ -1,0 +1,262 @@
+package com.atoook.otsukailist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.atoook.otsukailist.dto.CreateItemRequest;
+import com.atoook.otsukailist.dto.QuantifiedItemRequest;
+import com.atoook.otsukailist.dto.SyncGeneratedItemsRequest;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.model.BaseUnit;
+import com.atoook.otsukailist.model.Item;
+import com.atoook.otsukailist.model.ItemCategory;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.ItemQuantified;
+import com.atoook.otsukailist.model.ItemType;
+import com.atoook.otsukailist.model.Origin;
+import com.atoook.otsukailist.model.RegenerationPolicy;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ItemRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GeneratedItemCommandServiceTest {
+
+  @Mock private ItemRepository itemRepo;
+  @Mock private ItemListRepository itemListRepo;
+  @Mock private ListRevisionService listRevisionService;
+
+  private GeneratedItemCommandService service;
+
+  @BeforeEach
+  void setUp() {
+    GeneratedItemSyncCommandService generatedItemSyncCommandService =
+        new GeneratedItemSyncCommandService(itemRepo, itemListRepo, listRevisionService);
+    service = new GeneratedItemCommandService(generatedItemSyncCommandService);
+  }
+
+  @Test
+  @DisplayName("既存のgenerated+auto itemはlockせず数量を更新し名称を保持すること")
+  void syncGeneratedItemsUpdatesExistingAutoItemWithoutLockingOrRenaming() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item existingItem = generatedAutoItem(list, "牛肉カスタム", 1000L, "beef");
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
+        .thenReturn(List.of(existingItem));
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(result.getRevision()).isEqualTo(2L);
+    assertThat(existingItem.getName()).isEqualTo("牛肉カスタム");
+    assertThat(existingItem.getQuantified().getQuantity()).isEqualTo(1500L);
+    assertThat(existingItem.getQuantified().getRegenerationPolicy())
+        .isEqualTo(RegenerationPolicy.AUTO);
+    assertThat(result.getData().getItems()).hasSize(1);
+    assertThat(result.getData().getItems().get(0).getName()).isEqualTo("牛肉カスタム");
+    assertThat(result.getData().getDeletedItemIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("既存auto itemがない生成候補は新規itemとして追加すること")
+  void syncGeneratedItemsCreatesMissingCandidate() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("yakisoba"))
+            .items(List.of(generatedItemRequest("焼きそば", 4L, "yakisoba")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("yakisoba")))
+        .thenReturn(List.of());
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(result.getData().getItems()).hasSize(1);
+    assertThat(result.getData().getItems().get(0).getName()).isEqualTo("焼きそば");
+    assertThat(result.getData().getItems().get(0).getCategory()).isEqualTo(ItemCategory.STAPLE);
+    assertThat(result.getData().getItems().get(0).getQuantified().getGeneratorKey())
+        .isEqualTo("yakisoba");
+    assertThat(result.getData().getDeletedItemIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("既存のgenerated+locked itemは更新も重複追加もしないこと")
+  void syncGeneratedItemsSkipsExistingLockedItem() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item existingItem = generatedLockedItem(list, "牛肉カスタム", 1000L, "beef");
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
+        .thenReturn(List.of(existingItem));
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(existingItem.getQuantified().getQuantity()).isEqualTo(1000L);
+    assertThat(existingItem.getQuantified().getRegenerationPolicy())
+        .isEqualTo(RegenerationPolicy.LOCKED);
+    assertThat(result.getData().getItems()).isEmpty();
+    assertThat(result.getData().getDeletedItemIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("生成候補から外れた既存generated+auto itemは削除すること")
+  void syncGeneratedItemsDeletesExistingAutoItemMissingFromCandidates() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item seafood = generatedAutoItem(list, "えび", 1L, "seafood_shrimp");
+    seafood.setId(UUID.randomUUID());
+    seafood.setCategory(ItemCategory.SEAFOOD);
+    seafood.getQuantified().setBaseUnit(BaseUnit.PACK);
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef", "seafood_shrimp"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
+        .thenReturn(List.of(seafood));
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(3L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(result.getRevision()).isEqualTo(3L);
+    assertThat(result.getData().getItems()).hasSize(1);
+    assertThat(result.getData().getDeletedItemIds()).containsExactly(seafood.getId());
+  }
+
+  @Test
+  @DisplayName("生成候補から外れた既存generated+locked itemは削除しないこと")
+  void syncGeneratedItemsKeepsExistingLockedItemMissingFromCandidates() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item seafood = generatedLockedItem(list, "えび", 1L, "seafood_shrimp");
+    seafood.setId(UUID.randomUUID());
+    seafood.setCategory(ItemCategory.SEAFOOD);
+    seafood.getQuantified().setBaseUnit(BaseUnit.PACK);
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef", "seafood_shrimp"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
+        .thenReturn(List.of(seafood));
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(4L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(result.getData().getItems()).hasSize(1);
+    assertThat(result.getData().getDeletedItemIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("生成候補のgeneratorKeyがscope外の場合はエラーにすること")
+  void syncGeneratedItemsRejectsCandidateOutsideScope() {
+    UUID listId = UUID.randomUUID();
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef"))
+            .items(List.of(generatedItemRequest("焼きそば", 4L, "yakisoba")))
+            .build();
+
+    assertThatThrownBy(() -> service.syncGeneratedItems(listId, request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessage("生成ルールID一覧が不正です");
+  }
+
+  private static ItemList itemList(UUID listId) {
+    ItemList list = new ItemList();
+    list.setId(listId);
+    list.setName("BBQ");
+    return list;
+  }
+
+  private static Item generatedAutoItem(
+      ItemList list, String name, long quantity, String generatorKey) {
+    Item item = new Item();
+    item.setName(name);
+    item.setItemType(ItemType.QUANTIFIED);
+    item.setCategory(ItemCategory.MEAT);
+    item.setItemList(list);
+    item.setQuantified(quantified(quantity, generatorKey));
+    return item;
+  }
+
+  private static Item generatedLockedItem(
+      ItemList list, String name, long quantity, String generatorKey) {
+    Item item = generatedAutoItem(list, name, quantity, generatorKey);
+    item.getQuantified().setRegenerationPolicy(RegenerationPolicy.LOCKED);
+    return item;
+  }
+
+  private static CreateItemRequest generatedItemRequest(
+      String name, long quantity, String generatorKey) {
+    return CreateItemRequest.builder()
+        .name(name)
+        .itemType(ItemType.QUANTIFIED)
+        .quantified(
+            QuantifiedItemRequest.builder()
+                .quantity(quantity)
+                .baseUnit(resolveBaseUnit(generatorKey))
+                .origin(Origin.GENERATED)
+                .regenerationPolicy(RegenerationPolicy.AUTO)
+                .generatorKey(generatorKey)
+                .build())
+        .build();
+  }
+
+  private static ItemQuantified quantified(long quantity, String generatorKey) {
+    ItemQuantified quantified = new ItemQuantified();
+    quantified.setQuantity(quantity);
+    quantified.setBaseUnit(BaseUnit.G);
+    quantified.setOrigin(Origin.GENERATED);
+    quantified.setRegenerationPolicy(RegenerationPolicy.AUTO);
+    quantified.setGeneratorKey(generatorKey);
+    return quantified;
+  }
+
+  private static BaseUnit resolveBaseUnit(String generatorKey) {
+    return switch (generatorKey) {
+      case "yakisoba" -> BaseUnit.PIECE;
+      case "seafood_shrimp" -> BaseUnit.PACK;
+      default -> BaseUnit.G;
+    };
+  }
+}

--- a/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
@@ -358,8 +358,8 @@ class ItemCommandServiceTest {
   }
 
   @Test
-  @DisplayName("generated auto のカテゴリを明示変更した場合は指定カテゴリを保持してロックすること")
-  void updateGeneratedAutoCategoryKeepsRequestedCategoryAndLocks() {
+  @DisplayName("generated auto のカテゴリを明示変更しても生成ルールカテゴリを保持してロックしないこと")
+  void updateGeneratedAutoCategoryKeepsGeneratedRuleCategoryWithoutLocking() {
     UUID listId = UUID.randomUUID();
     UUID itemId = UUID.randomUUID();
     Item item = quantifiedItem("牛肉", 1000L);
@@ -377,7 +377,32 @@ class ItemCommandServiceTest {
 
     service.updateItem(listId, itemId, request);
 
-    assertThat(item.getCategory()).isEqualTo(ItemCategory.SWEETS);
+    assertThat(item.getCategory()).isEqualTo(ItemCategory.MEAT);
+    assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.AUTO);
+  }
+
+  @Test
+  @DisplayName("generated locked のカテゴリを明示変更しても生成ルールカテゴリを保持すること")
+  void updateGeneratedLockedCategoryKeepsGeneratedRuleCategory() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    Item item = quantifiedItem("牛肉", 1000L);
+    item.setCategory(ItemCategory.MEAT);
+    item.getQuantified().setRegenerationPolicy(RegenerationPolicy.LOCKED);
+    UpdateItemRequest request =
+        UpdateItemRequest.builder()
+            .category(ItemCategory.SWEETS)
+            .itemType(ItemType.QUANTIFIED)
+            .quantified(generatedLockedQuantifiedRequest(1000L, "beef"))
+            .build();
+
+    when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
+    when(itemRepo.save(item)).thenReturn(item);
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
+
+    service.updateItem(listId, itemId, request);
+
+    assertThat(item.getCategory()).isEqualTo(ItemCategory.MEAT);
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.LOCKED);
   }
 
@@ -452,6 +477,17 @@ class ItemCommandServiceTest {
         .baseUnit(BaseUnit.G)
         .origin(Origin.GENERATED)
         .regenerationPolicy(RegenerationPolicy.AUTO)
+        .generatorKey(generatorKey)
+        .build();
+  }
+
+  private static QuantifiedItemRequest generatedLockedQuantifiedRequest(
+      long quantity, String generatorKey) {
+    return QuantifiedItemRequest.builder()
+        .quantity(quantity)
+        .baseUnit(BaseUnit.G)
+        .origin(Origin.GENERATED)
+        .regenerationPolicy(RegenerationPolicy.LOCKED)
         .generatorKey(generatorKey)
         .build();
   }

--- a/backend/src/test/java/com/atoook/otsukailist/service/ListGenerationConfigServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ListGenerationConfigServiceTest.java
@@ -1,0 +1,67 @@
+package com.atoook.otsukailist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.atoook.otsukailist.dto.ListGenerationConfigRequest;
+import com.atoook.otsukailist.model.GenerationConfigType;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.ListGenerationConfig;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ListGenerationConfigRepository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ListGenerationConfigServiceTest {
+
+  @Mock private ItemListRepository itemListRepo;
+  @Mock private ListGenerationConfigRepository listGenerationConfigRepo;
+  @Mock private ListRevisionService listRevisionService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private ListGenerationConfigService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ListGenerationConfigService(
+            itemListRepo, listGenerationConfigRepo, listRevisionService, objectMapper);
+  }
+
+  @Test
+  @DisplayName("生成設定をupsertしrevisionを返すこと")
+  void upsertConfigStoresJsonAndReturnsRevision() throws Exception {
+    UUID listId = UUID.randomUUID();
+    ItemList list = new ItemList();
+    list.setId(listId);
+    list.setName("BBQ");
+    var configJson = objectMapper.readTree("{\"version\":1,\"answers\":{\"adultCount\":6}}");
+    ListGenerationConfigRequest request =
+        ListGenerationConfigRequest.builder().configJson(configJson).build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(listGenerationConfigRepo.findByItemListIdAndConfigType(listId, GenerationConfigType.BBQ))
+        .thenReturn(Optional.empty());
+    when(listGenerationConfigRepo.save(any(ListGenerationConfig.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(3L);
+
+    var result = service.upsertConfig(listId, "bbq", request);
+
+    assertThat(result.getRevision()).isEqualTo(3L);
+    assertThat(result.getData().getListId()).isEqualTo(listId);
+    assertThat(result.getData().getConfigType()).isEqualTo(GenerationConfigType.BBQ);
+    assertThat(result.getData().getConfigJson().get("version").asInt()).isEqualTo(1);
+  }
+}

--- a/docs/list-generation-automation.md
+++ b/docs/list-generation-automation.md
@@ -1,189 +1,1031 @@
-# リスト自動生成基盤の方針
+# リスト自動生成機能 設計書
 
-このドキュメントは、BBQ などのテンプレートから買い物リストを自動生成するための基盤方針をまとめる。MVP では DB マスタを作らず、カテゴリ・単位・生成ルールはコード定数で管理する。
-
----
-
-## 基本方針
-
-- 通常の買い物リスト体験は `plain` item として維持する。
-- 数量を持つ item は `quantified` item として扱い、数量情報を `item_quantified` に分離する。
-- `item.name` は一覧・検索・通常編集・詳細編集すべてで使う**唯一の名称フィールド**とする。
-- `item_quantified` は名称を持たず、数量・単位・生成制御のみを担う。
-- 数量と単位は `item_quantified.quantity` / `item_quantified.base_unit` に保存し、一覧では item 名とは別の補助ラベル（バッジ）として表示する。
-- `generator_key` はカテゴリではなく、自動生成ルール ID として扱う。
-- `category` は `generator_key` とは別概念で、plain / quantified 共通の分類として `item.category` に持つ。
-- 自動生成アイテムの名称は生成ルールの label を初期値として `item.name` に設定する。
-- ユーザーが名称を編集した場合は `item.name` のみ変更し、生成由来の情報は保持する。
+このドキュメントは、テンプレートとユーザー回答から買い物リストの初期 item を自動生成する機能の設計をまとめる。対象は MVP の BBQ テンプレートで、現行の frontend / backend / DB 構成に合わせて記述する。
 
 ---
 
-## 状態モデル
+## 目的
 
-### plain
+OtsukaiList の基本体験は「自由入力できる軽い買い物リスト」である。この体験を壊さず、BBQ などのイベント向けに、テンプレートと簡単な入力条件から買い物リストの初期候補を作れるようにする。
+
+自動生成はあくまで補助機能として扱う。生成された item は通常 item と同じように編集でき、ユーザーが編集した生成 item は再生成で上書きしない。
+
+---
+
+## 現行基盤
+
+現時点で、ロジック以外の基盤はおおむね用意済み。
+
+- DB には `item.item_type`、`item_quantified`、`list_generation_config` がある。
+- Backend には `ItemType` / `BaseUnit` / `Origin` / `RegenerationPolicy` / `GenerationConfigType` / `ItemCategory` がある。
+- Backend には `backend/src/main/java/com/atoook/otsukailist/generation` 配下の生成ルール定数と registry がある。
+- Frontend には `frontend/src/types/list-generation.ts` と `frontend/src/lib/listGenerationConstants.ts` がある。
+- Item API は `plain` / `quantified` の作成・更新に対応している。
+- `generated + auto` item のカテゴリ自動解決と、ユーザー編集時の `locked` 遷移は backend の item 更新処理に入っている。
+
+次に作るべきものは、主に以下。
+
+- リスト画面上の「テンプレートから追加」導線
+- BBQ テンプレート専用ページ
+- BBQ 回答フォーム UI
+- 生成ロジック module
+- 生成結果 preview / 保存フロー
+- `list_generation_config` の保存・取得 API
+- 再生成フロー
+
+---
+
+## 用語
+
+### plain item
+
+数量を持たない通常 item。
+
+```txt
+紙皿
+マシュマロ
+氷
+```
+
+現行モデル:
 
 - `item.item_type = plain`
-- `item.name` が真実
+- `item.name` が表示名
 - `item_quantified` は持たない
-- `category` は任意
+- `item.category` は任意
+
+### quantified item
+
+数量・単位を持つ item。
+
+```txt
+牛肉 [1.2kg]
+コーラ [3本]
+```
+
+現行モデル:
+
+- `item.item_type = quantified`
+- `item.name` が表示名
+- `item.category` が分類
+- `item_quantified.quantity` が基準単位の数量
+- `item_quantified.base_unit` が保存単位
+
+### generated item
+
+テンプレート生成で作られた quantified item。
+
+現行モデル:
+
+- `item_quantified.origin = generated`
+- `item_quantified.generator_key` は必須
+
+### locked item
+
+自動生成後にユーザーが編集したため、再生成から保護する item。
+
+現行モデル:
+
+- `item_quantified.origin = generated`
+- `item_quantified.regeneration_policy = locked`
+- `generator_key` は保持する
 
 ---
 
+## 生成 item の状態モデル
+
 ### manual + none
+
+ユーザーが手動で作った数量付き item。
 
 - `item.item_type = quantified`
 - `item_quantified.origin = manual`
 - `item_quantified.regeneration_policy = none`
-- 自動生成処理の更新対象ではない
-- `generator_key` は不要
-- `item.name` が名称の真実
-
----
+- `generator_key = null`
+- 再生成対象外
 
 ### generated + auto
+
+自動生成され、まだユーザー編集で保護されていない item。
 
 - `item.item_type = quantified`
 - `item_quantified.origin = generated`
 - `item_quantified.regeneration_policy = auto`
-- 再生成時の更新対象
 - `generator_key` は必須
-- `category` は生成ルールから決定する
-- `item.name` は生成ルール label を初期値とする
-
----
+- 再生成時の更新対象
 
 ### generated + locked
+
+自動生成後にユーザーが編集した item。
 
 - `item.item_type = quantified`
 - `item_quantified.origin = generated`
 - `item_quantified.regeneration_policy = locked`
-- 自動生成後にユーザーが意図的に変更した状態
-- 再生成時の更新対象外
-- `generator_key` は保持する
-- `item.name` はユーザー編集された名称を保持する
+- `generator_key` は保持
+- 再生成対象外
 
 ---
 
-## 更新ルール
+## ロック遷移
 
-- `plain -> quantified` は、数量・単位が指定されたときに行う。
-- `quantified -> plain` は、数量付き情報を外すときに `item_quantified` を削除する。
-- 名称の編集は常に `item.name` のみを更新し、`generated + auto` のまま維持する。
-- `item_quantified` に名称フィールドは持たないため、同期処理は不要。
-- `quantity` / `base_unit` / `generator_key` / `category` が変更された場合、`generated + auto` item は `generated + locked` に遷移する。
-- 再生成で更新できるのは `generated + auto` のみ。
-- `manual` と `locked` は再生成では更新しない。
+`generated + auto` item は、以下がユーザー操作で変更された場合に `generated + locked` へ遷移する。
+
+- `quantity`
+- `base_unit`
+- `generator_key`
+- `category`
+
+現行 backend 実装では、名称変更だけでは locked にしない。`item.name` は通常の自由編集体験に寄せるため、生成 item でも編集しやすくしている。
+
+今後、名称変更も保護対象にしたい場合は `ItemCommandService` の `updateItemName` と lock 判定を見直す。ただし MVP では現行挙動を採用する。
 
 ---
 
-## カテゴリ・単位・生成ルール
+## テンプレート生成フロー
 
-MVP では以下を DB マスタ化しない。
+### 基本方針
 
-- 単位定義
-- item カテゴリ
-- item 準備方法
-- BBQ 生成ルール
+テンプレートはリスト作成時に選ばない。リストは通常どおり作成し、作成後のリスト画面で「テンプレートからアイテムを追加」する。
 
 理由:
 
-- 設定追加・変更箇所をファイル単位で明確にするため
-- マスタ移行時に差分を追いやすくするため
-- 他機能への影響範囲を小さく保つため
+- 既存のリスト作成フローを壊さない
+- `POST /api/lists` を拡張しなくてよい
+- 自動生成を「通常リストへの補助機能」として扱いやすい
+- 既存リストにも後からテンプレートを適用できる
+- 生成失敗時にリスト作成自体を失敗させずに済む
+- 初回生成と再生成の UI を同じ専用ページに置ける
 
-管理対象:
+### Step 1: 通常どおりリスト作成
 
-- Backend: `backend/src/main/java/com/atoook/otsukailist/generation`
-- Frontend category values/labels/sort order: `frontend/src/types/item-category.ts`
-- Frontend preparation type values/labels/sort order: `frontend/src/types/item-preparation-type.ts`
-- Frontend unit/generation values: `frontend/src/types/list-generation.ts`
+ユーザーは既存の `CreateListPage.vue` でリスト名とメンバーを入力し、空のリストを作成する。
+
+既存 API:
+
+```txt
+POST /api/lists
+```
+
+`CreateItemListWithMembersRequest` は `name` と `memberNames` のままでよい。テンプレート情報は持たせない。
+
+### Step 2: リスト画面で生成開始
+
+`ItemListPage.vue` にはテンプレート生成の入口だけを置き、押下時に BBQ テンプレート専用ページへ遷移する。
+
+専用ページ:
+
+```txt
+/lists/:id/templates/bbq
+```
+
+表示方針:
+
+- item が 0 件のときは、空状態の主要アクションとして「テンプレートから追加」を表示する
+- item が 1 件以上あるときは、通常の item 追加フォームの近くに控えめな操作として表示する
+- 既存 item があっても、テンプレート生成は許可する
+- BBQ の回答フォーム、量の微調整、preview は専用ページに置く
+
+UI イメージ:
+
+```txt
+空リスト:
+[テンプレートから追加] [手入力で追加]
+
+通常リスト:
++ アイテム追加フォーム
+[テンプレートから追加]
+```
+
+### Step 3: テンプレート選択
+
+MVP で UI と生成ロジックを実装するテンプレートは BBQ のみ。
+
+`GenerationConfigType` には将来候補として以下の値が既にある。
+
+- BBQ
+- キャンプ
+- 鍋
+- 旅行
+
+### Step 4: BBQ 回答フォーム
+
+ユーザーには「設定」ではなく、簡単なアンケートとして見せる。
+
+MVP 入力項目:
+
+- 大人の人数
+- 子供の人数
+- 食事量: `small` / `normal` / `large`
+- バランス: `vegetables` / `balanced` / `meat`
+- 海鮮: `none` / `included`
+- 飲み物: `small` / `normal` / `large`
+- アルコール: `none` / `included`
+- アルコール量: `small` / `normal` / `large`
+- 主食: `none` / `light` / `solid`
+
+`adjustments` は回答フォームの主操作ではなく任意の補助設定として扱う。保存済み config がある再生成 UI では「量の微調整」をデフォルトで折りたたみ、必要に応じて展開してカテゴリ別に調整する。
+
+UI 表示例:
+
+```txt
+Q. 大人は何人ですか？
+[ 6 ]
+
+Q. 子供は何人ですか？
+[ 2 ]
+
+Q. 食べる量は？
+( ) 少なめ
+(*) 普通
+( ) 多め
+```
+
+### Step 5: Preview と追加
+
+回答から生成 candidate を計算し、追加前に preview を表示する。
+
+MVP では preview 上での細かい編集は必須にしない。生成後は通常 item として編集できるため、まずは「追加する item の確認」に留める。
+
+### Step 6: 生成完了
+
+生成 item を保存し、通常のリスト画面に戻る。保存後の item は通常 item と同じ一覧に混ざる。
+
+---
+
+## 生成条件の保存
+
+生成条件は `list_generation_config` に保存する。
+
+DB:
+
+- `list_generation_config.list_id`
+- `list_generation_config.config_type`
+- `list_generation_config.config_json`
+
+MVP の `config_type`:
+
+```txt
+bbq
+```
+
+`config_json`:
+
+```json
+{
+  "version": 1,
+  "answers": {
+    "adultCount": 6,
+    "childCount": 2,
+    "appetite": "normal",
+    "balance": "meat",
+    "seafoodLevel": "included",
+    "drinkLevel": "normal",
+    "alcoholLevel": "included",
+    "alcoholAmount": "normal",
+    "stapleLevel": "light"
+  },
+  "adjustments": {
+    "meat": "normal",
+    "seafood": "normal",
+    "vegetables": "normal",
+    "drinks": "normal",
+    "staple": "normal",
+    "overall": "normal"
+  }
+}
+```
+
+`version` は将来の config schema 変更に備えて入れる。
+
+### answers
+
+初回生成のベース条件。
+
+### adjustments
+
+生成後のカテゴリ別微調整パラメータ。ユーザーが「肉を多め」「海鮮を少なめ」「飲み物を少なめ」などを選んだ状態として扱う。
+
+`adjustments` は回答そのものを書き換えるものではなく、生成条件に重ねる UI 状態として扱う。
+
+---
+
+## Frontend 生成ロジック
+
+MVP では生成処理を frontend 側で実行する。ただし Vue component に数量計算を直接書かず、純粋関数の service / module に分離する。
+
+配置案:
+
+```txt
+frontend/src/lib/generation/
+  bbqGenerator.ts
+  bbqGenerationRules.ts
+  generationTypes.ts
+```
+
+既存の `frontend/src/lib/listGenerationConstants.ts` は、BBQ ルールの定数置き場として使える。ロジックが増えた段階で `generation/` 配下へ移す。
+
+### 入力型
+
+```ts
+export type BBQGenerationAnswers = {
+  adultCount: number;
+  childCount: number;
+  appetite: 'small' | 'normal' | 'large';
+  balance: 'vegetables' | 'balanced' | 'meat';
+  drinkLevel: 'small' | 'normal' | 'large';
+  alcoholLevel: 'none' | 'included';
+  alcoholAmount: 'small' | 'normal' | 'large';
+  seafoodLevel: 'none' | 'included';
+  stapleLevel: 'none' | 'light' | 'solid';
+};
+
+export type BBQGenerationAdjustments = {
+  meat: 'small' | 'normal' | 'large';
+  seafood: 'small' | 'normal' | 'large';
+  vegetables: 'small' | 'normal' | 'large';
+  drinks: 'small' | 'normal' | 'large';
+  staple: 'small' | 'normal' | 'large';
+  overall: 'small' | 'normal' | 'large';
+};
+```
+
+### 出力型
+
+```ts
+export type GeneratedItemCandidate = {
+  generatorKey: string;
+  name: string;
+  category: ItemCategory;
+  quantity: number;
+  baseUnit: BaseUnit;
+  displayUnit: UnitCode;
+};
+```
+
+`quantity` は必ず `baseUnit` 基準で返す。`displayUnit` は UI 表示用。
+
+### 呼び出しイメージ
+
+```ts
+const candidates = generateBBQItems({
+  answers,
+  adjustments
+});
+```
+
+### 生成ルール定数
+
+現行 frontend には以下の BBQ ルールがある。
+
+```ts
+export const BBQ_GENERATION_RULES = {
+  beef: {
+    generatorKey: 'beef',
+    category: 'meat',
+    baseUnit: 'g',
+    displayUnit: 'g'
+  },
+  pork: {
+    generatorKey: 'pork',
+    category: 'meat',
+    baseUnit: 'g',
+    displayUnit: 'g'
+  },
+  chicken: {
+    generatorKey: 'chicken',
+    category: 'meat',
+    baseUnit: 'g',
+    displayUnit: 'g'
+  },
+  sausage: {
+    generatorKey: 'sausage',
+    category: 'meat',
+    baseUnit: 'g',
+    displayUnit: 'g'
+  },
+  vegetableOnion: {
+    generatorKey: 'vegetable_onion',
+    category: 'vegetables',
+    baseUnit: 'piece',
+    displayUnit: 'piece'
+  },
+  vegetableBellPepper: {
+    generatorKey: 'vegetable_bell_pepper',
+    category: 'vegetables',
+    baseUnit: 'piece',
+    displayUnit: 'piece'
+  },
+  vegetableCorn: {
+    generatorKey: 'vegetable_corn',
+    category: 'vegetables',
+    baseUnit: 'piece',
+    displayUnit: 'piece'
+  },
+  vegetablePotato: {
+    generatorKey: 'vegetable_potato',
+    category: 'vegetables',
+    baseUnit: 'piece',
+    displayUnit: 'piece'
+  },
+  vegetableMushrooms: {
+    generatorKey: 'vegetable_mushrooms',
+    category: 'vegetables',
+    baseUnit: 'pack',
+    displayUnit: 'pack'
+  },
+  seafoodShrimp: {
+    generatorKey: 'seafood_shrimp',
+    category: 'seafood',
+    baseUnit: 'pack',
+    displayUnit: 'pack'
+  },
+  seafoodScallop: {
+    generatorKey: 'seafood_scallop',
+    category: 'seafood',
+    baseUnit: 'pack',
+    displayUnit: 'pack'
+  },
+  seafoodSquid: {
+    generatorKey: 'seafood_squid',
+    category: 'seafood',
+    baseUnit: 'pack',
+    displayUnit: 'pack'
+  },
+  softDrinks: {
+    generatorKey: 'soft_drinks',
+    category: 'drinks',
+    baseUnit: 'ml',
+    displayUnit: 'l'
+  },
+  alcohol: {
+    generatorKey: 'alcohol',
+    category: 'drinks',
+    baseUnit: 'piece',
+    displayUnit: 'piece'
+  },
+  yakisoba: {
+    generatorKey: 'yakisoba',
+    category: 'staple',
+    baseUnit: 'piece',
+    displayUnit: 'piece'
+  }
+};
+```
+
+MVP の最初の生成対象は、現行定数に合わせて以下から始める。
+
+- `beef`
+- `pork`
+- `chicken`
+- `sausage`
+- `vegetable_onion`
+- `vegetable_bell_pepper`
+- `vegetable_corn`
+- `vegetable_potato`
+- `vegetable_mushrooms`
+- `seafood_shrimp`
+- `seafood_scallop`
+- `seafood_squid`
+- `soft_drinks`
+- `alcohol`
+- `yakisoba`
+
+生成 candidate には `name` が必要になる。現行の frontend / backend 生成ルールは label を持っていないため、`generateBBQItems` 実装時に frontend の BBQ ルールへ `label` を追加するか、生成 module 内に `generatorKey -> label` の対応を持たせる。MVP では frontend 実行なので、backend の生成ルールには label を追加しなくてもよい。
+
+備品・調味料は、カテゴリと単位の定義があるため後から追加する。
+
+---
+
+## 数量計算方針
+
+MVP では、厳密なレシピ計算ではなく「一般的な目安に近い初期候補」を作る。保存数量は必ず `baseUnit` 基準にする。
+
+基本人数:
+
+```txt
+effectivePeople = adultCount + childCount * 0.6
+```
+
+子供は大人の 60% として換算する。大人 250g 前後、子供 150g 前後の肉量になるようにするための係数である。
+
+通常設定の基準量:
+
+```txt
+牛肉: effectivePeople * 110g
+豚肉: effectivePeople * 80g
+鶏肉: effectivePeople * 60g
+ソーセージ: effectivePeople * 40g
+海鮮ありの場合:
+  海鮮カテゴリ基準量: effectivePeople * 120g
+  480g あたり:
+    えび 1パック
+    ホタテ 0.75パック
+    イカ 0.75パック
+  肉類: 0.85倍
+野菜カテゴリ基準量: effectivePeople * 150g
+  600g あたり:
+    玉ねぎ 1個
+    ピーマン 2個
+    とうもろこし 1本
+    じゃがいも 2個
+    きのこ 1袋
+ソフトドリンク: effectivePeople * 500ml
+アルコール(350ml): adultCount * 500ml * alcoholAmount係数 / 350ml を切り上げ
+焼きそば:
+  なし: 0玉
+  軽め: effectivePeople * 0.65玉
+  しっかり: effectivePeople * 1玉
+```
+
+通常設定の肉量は、牛肉 110g + 豚肉 80g + 鶏肉 60g + ソーセージ 40g とする。肉・ソーセージ込みで 290g 前後になり、一般的な BBQ の大人 1 人前として説明しやすい水準に置く。ソーセージはパック購入を想定し、個数ではなく g で保存する。
+
+海鮮 120g は「海鮮メイン」ではなく追加枠の軽め想定である。生成時は `seafood` という集合 item は作らず、内部のカテゴリ基準量を `えび` / `ホタテ` / `イカ` に展開する。480g を 4人前相当の基準量として、えび 1パック、ホタテ 0.75パック、イカ 0.75パックを係数計算し、買い物しやすいようにパック単位で切り上げる。海鮮ありの場合は海鮮を追加し、肉類を 0.85 倍にして全体が過剰になりすぎないようにする。
+
+野菜 150g は、焼きやすい野菜を複数種類入れたカテゴリ基準量である。生成時は `vegetables` という集合 item は作らず、内部のカテゴリ基準量を `玉ねぎ` / `ピーマン` / `とうもろこし` / `じゃがいも` / `きのこ` に展開する。600g を 4人前相当の基準量として、玉ねぎ 1個、ピーマン 2個、とうもろこし 1本、じゃがいも 2個、きのこ 1袋を係数計算し、個数・袋単位で切り上げる。
+
+このように、カテゴリ基準量を直接 item 化せず、必要なカテゴリだけ品目レベルへ展開する。MVP では野菜と海鮮を展開対象にするが、将来的には `beef` を `牛カルビ` / `牛タン` などへ細分化する場合にも同じ breakdown rule を使う。
+
+食事量係数:
+
+```txt
+small: 0.8
+normal: 1.0
+large: 1.2
+```
+
+調整係数:
+
+```txt
+small: 0.8
+normal: 1.0
+large: 1.25
+```
+
+例:
+
+```txt
+牛肉 quantity(g)
+= effectivePeople
+  * 肉の1人あたり基準量
+  * appetite係数
+  * balance係数
+  * adjustments.meat係数
+  * adjustments.overall係数
+```
+
+海鮮・野菜・飲み物・主食も同様に、それぞれ `adjustments.seafood` / `adjustments.vegetables` / `adjustments.drinks` / `adjustments.staple` を持つ。`adjustments.overall` は全カテゴリにかかる全体補正として扱う。
+
+端数処理:
+
+- `g` は 50g または 100g 単位に丸める
+- `piece` / `pack` は整数に切り上げる
+- `ml` は 100ml または 500ml 単位に丸める
+
+---
+
+## 初回生成保存フロー
+
+初回生成は、既に存在する list に対して実行する。
+
+### Step 1: 生成開始
+
+リスト画面で「テンプレートから追加」を押し、BBQ テンプレート専用ページへ遷移する。
+
+### Step 2: BBQ 回答と preview
+
+回答フォームから `answers` と初期 `adjustments` を作り、frontend の `generateBBQItems` で candidate を計算する。
+
+### Step 3: 生成 config 保存
+
+追加 API 案:
+
+```txt
+PUT /api/lists/{listId}/generation-configs/bbq
+GET /api/lists/{listId}/generation-configs/bbq
+```
+
+`PUT` は upsert とする。`list_generation_config` には `(list_id, config_type)` の unique index があるため、同一 list / type では 1 件だけ保持する。
+
+### Step 4: item 同期
+
+生成 candidate と、そのテンプレートが管理する `generatorKeysInScope` を generated item sync API の payload に変換する。
+
+同期 API:
+
+```txt
+POST /api/lists/{listId}/generated-items/sync
+```
+
+この API は生成 candidate の同期専用とする。
+
+責務:
+
+- 既存の `generated + auto` item があれば lock せずに数量・単位・カテゴリを更新する
+- 既存の `generated + auto` item の `name` は上書きしない
+- 一致する `generated + auto` item がなければ新規 item として追加する
+- `generatorKeysInScope` に含まれるが今回 candidate に存在しない `generated + auto` item は削除する
+- `plain` / `manual + none` / `generated + locked` は更新しない
+
+通常の item 更新 API はユーザー編集として `locked` 遷移を行うため、再生成更新には使わない。
+
+```json
+{
+  "generatorKeysInScope": ["beef", "pork", "yakisoba"],
+  "items": [
+    {
+      "name": "牛肉",
+      "itemType": "quantified",
+      "category": "meat",
+      "quantified": {
+        "quantity": 1200,
+        "baseUnit": "g",
+        "origin": "generated",
+        "regenerationPolicy": "auto",
+        "generatorKey": "beef"
+      }
+    }
+  ]
+}
+```
+
+Backend では `generated + auto` の場合、`generatorKey` から category を解決する。Frontend からも category を送るが、生成ルールと矛盾する場合は backend の生成ルールが優先される。
+
+### Step 5: 既存 item がある場合
+
+初回生成時に既存 item があっても、自動生成は既存 item を変更しない。生成 candidate は新規 item として追加する。
+
+ただし、同じ list に同じ BBQ config が既にある場合は、初回生成ではなく再生成フローとして扱う。
+
+---
+
+## 再生成フロー
+
+再生成は「生成対象 item の全置換」ではなく、既存 item との突合更新として扱う。
+
+再生成 UI は、対象 list に `list_generation_config` が存在する場合に表示する。BBQ config が保存されている list では「条件を調整して再生成」を出せる。
+
+### Step 1: adjustments 更新
+
+ユーザーが必要に応じて「量の微調整」を展開し、カテゴリ別の `adjustments` を変更する。未展開のままなら既存または初期値の `normal` を使う。
+
+### Step 2: config 保存
+
+`list_generation_config.config_json` を更新する。
+
+### Step 3: 新しい生成結果を計算
+
+Frontend の `generateBBQItems` を再実行する。
+
+### Step 4: `generatorKey` で突合
+
+既存 item のうち、以下だけを更新対象にする。
+
+- `item.itemType = quantified`
+- `item.quantified.origin = generated`
+- `item.quantified.regenerationPolicy = auto`
+- `item.quantified.generatorKey` が candidate と一致
+
+更新対象外:
+
+- `plain`
+- `manual + none`
+- `generated + locked`
+- `generatorKey` が一致しない item
+
+### Step 5: 不足 candidate を追加
+
+新しい生成結果に含まれるが既存 item にない `generatorKey` は、generated item sync API が新規 item として追加する。
+
+### Step 6: 消えた candidate の扱い
+
+前回生成に存在して今回生成に存在しない item は、`generatorKeysInScope` に含まれる `generated + auto` のみ削除する。
+
+例:
+
+- 海鮮ありから海鮮なしに変更した場合、`seafood_shrimp` / `seafood_scallop` / `seafood_squid` は削除候補になる。
+- アルコールありからなしに変更した場合、`alcohol` は削除候補になる。
+- 主食ありからなしに変更した場合、`yakisoba` は削除候補になる。
+
+ただし、削除対象は `generated + auto` に限定する。`generated + locked` は candidate から外れても削除せず、preview では「変更対象外」として表示する。
 
 ---
 
 ## 表示ルール
 
-- 一覧表示では `item.name` を表示する
-- 数量・単位は `item_quantified` から取得し、バッジとして表示する
-
-例:
+一覧では `item.name` と数量バッジを分けて表示する。
 
 ```txt
-牛肉          [1kg]
-コーラ        [3本]
+牛肉           [1.2kg]
+焼きそば       [4個]
 紙皿
 ```
 
-- `item.name` に数量・単位は含めない
+重要:
+
+- `item.name` に数量・単位を含めない
+- 数量は `item.quantified.quantity` と `baseUnit` から表示変換する
+- 表示用単位は frontend の数量表示 helper で `category + unit` から解決する
+- `g` 保存 item は、1000g 未満は `g`、1000g 以上は `kg` で表示する
+- `pack` の通常表示は `袋` とし、カテゴリが `meat` / `seafood` の `pack` は買い物単位として `パック` と表示する
 
 ---
 
-## generator_key の役割
+## 編集方針
 
-- 自動生成ロジックの識別子
-- 再生成時の突合キー
-- 表示名の決定には直接使わない
-- 表示名は生成ルール定義の label を初期値として `item.name` にコピーする
+### plain item
 
----
+通常テキスト編集を維持する。
 
-## 生成ルールの拡張パターン
+### quantified item
 
-生成ルールは **Strategy を Registry で管理する構成（table-driven）** として扱う。
+詳細編集 UI で以下を編集できるようにする。
 
-- `GenerationRule` を共通インターフェースとし、各生成ルールはこの Strategy を実装する。
-- `GenerationRules` は `generator_key -> GenerationRule` の対応を一元管理する Registry とする。
-- Service 層は BBQ などの具体ルールクラスに依存せず、`GenerationRules` 経由で key 検証・カテゴリ解決を行う。
-- BBQ 以外のテンプレートを追加する場合は、具体ルール定義を追加し、Registry に集約する。
-- 生成ルールの選択は Map ベースで行い、Service 層にテンプレート別の条件分岐を増やさない。
+- `item.name`
+- `quantity`
+- `baseUnit`
+- `category`
+- `preparationType`
 
----
-
-## いまできていること
-
-- `item.item_type` による `plain` / `quantified` の区別
-- `item_quantified` による数量付き item 詳細の保存
-- `list_generation_config` による将来の生成条件保存先の確保
-- `item.category` による plain / quantified 共通カテゴリの保存
-- `item.preparationType` による持参物の保存（`null` は購入扱い、`bring` は持参）
-- `generated` item に対する `generator_key` 必須バリデーション
-- `generated + auto` のカテゴリを生成ルールから決定する処理
-- `generated + auto` item 更新時の `locked` 遷移
-- `quantified -> plain` への戻し処理
-- API レスポンスでの `itemType` / `category` / `preparationType` / `quantified` 返却
-- Frontend 型定義での `ItemType` / `BaseUnit` / `ItemCategory` / `ItemPreparationType` / `QuantifiedItem` 分離
+MVP では通常リスト体験を優先し、一覧上のクイック操作は複雑にしない。
 
 ---
 
-## これからすること
+## Backend 責務
 
-- テンプレート選択 UI を追加する
-- BBQ 生成条件入力 UI を追加する
-- `list_generation_config.config_json` に生成条件を保存する
-- 生成条件から item 候補を作成する service を追加する
-- `generated + auto` の item だけを再生成で更新する
-- `generated + locked` / `manual + none` を再生成対象外として保護する
-- Frontend の実 UI からデバッグ用表示を除き、数量・単位・カテゴリの入力体験を整える
-- 単位表示を必要に応じて `base_unit` から表示用単位へ変換する
-- DB マスタ化が必要になった段階で、コード定数から master table へ移行する
+Backend は生成エンジンではなく、永続化と整合性維持を担う。
+
+責務:
+
+- list / item / member の永続化
+- revision 管理
+- `list_generation_config` の保存・取得
+- `generated` item の generator key バリデーション
+- `generated + auto` の category 解決
+- ユーザー編集時の `locked` 遷移
+- 共有リストとしての整合性維持
+
+MVP では数量計算は frontend で行うため、backend に BBQ の人数計算ロジックは置かない。
 
 ---
 
-## 将来の拡張
+## Frontend 責務
 
-- `generator_key` 内での細分化が必要になった場合は `generator_item_key` を追加する
-- 部位分けや複数明細生成に対応する
+Frontend は生成体験と preview を担う。
 
-例:
+責務:
+
+- リスト画面上のテンプレート追加導線
+- テンプレート選択 UI
+- テンプレート専用ページ
+- BBQ 回答フォーム UI
+- 生成 candidate の計算
+- preview 表示
+- 生成 config 保存 API 呼び出し
+- item 作成 API 呼び出し
+- 再生成時の突合更新
+- 数量の表示単位変換
+
+---
+
+## 将来の Workers / Pages Functions 化
+
+以下の状態になったら、生成ロジックを Cloudflare Workers / Pages Functions へ切り出す。
+
+- テンプレート種類が増える
+- 生成ルールが複雑化する
+- frontend bundle が肥大化する
+- 複数クライアントで生成ロジックを共有したくなる
+- frontend deploy なしで生成ルールを改善したくなる
+
+Workers 化した場合の責務:
+
+- テンプレート生成
+- 数量計算
+- カテゴリ決定
+- candidate item 作成
+
+Frontend は入力 UI / preview / 保存 API 呼び出しに集中する。
+
+将来 API イメージ:
+
+```txt
+POST /api/templates/bbq/preview
+```
+
+Request:
+
+```json
+{
+  "answers": {
+    "adultCount": 6,
+    "childCount": 2,
+    "appetite": "normal",
+    "balance": "meat",
+    "seafoodLevel": "included",
+    "drinkLevel": "normal",
+    "alcoholLevel": "included",
+    "alcoholAmount": "normal",
+    "stapleLevel": "light"
+  },
+  "adjustments": {
+    "meat": "normal",
+    "seafood": "normal",
+    "vegetables": "normal",
+    "drinks": "normal",
+    "staple": "normal",
+    "overall": "normal"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "generatorKey": "beef",
+      "name": "牛肉",
+      "quantity": 1200,
+      "baseUnit": "g",
+      "displayUnit": "kg",
+      "category": "meat"
+    }
+  ]
+}
+```
+
+---
+
+## コード定数管理
+
+MVP では以下を DB マスタ化しない。
+
+- item category
+- unit
+- generation rule
+
+理由:
+
+- MVP の実装速度を優先する
+- ファイル単位で差分管理しやすい
+- 将来 master table へ移行しやすい
+
+現行の主な管理場所:
+
+- Frontend unit / origin / regeneration policy: `frontend/src/types/list-generation.ts`
+- Frontend category: `frontend/src/types/item-category.ts`
+- Frontend BBQ generation rules: `frontend/src/lib/listGenerationConstants.ts`
+- Backend generation rules: `backend/src/main/java/com/atoook/otsukailist/generation`
+- Backend model enum: `backend/src/main/java/com/atoook/otsukailist/model`
+
+Frontend と Backend の generation rule は、MVP では二重管理になる。実装時は `generatorKey` / `category` / `baseUnit` の不一致が起きないよう、テストで最低限検出する。
+
+---
+
+## 新しいテンプレートを追加する場合のガイド
+
+BBQ は最初のテンプレート実装であり、今後のテンプレート追加時も「テンプレート固有の入力・生成ロジック」と「共通の保存・同期基盤」を分ける。
+
+### 追加時の基本方針
+
+- `generated item` の永続化は既存の `POST /api/lists/{listId}/generated-items/sync` を使う。
+- `list_generation_config` の保存・取得は既存の `/generation-configs/{configType}` を使う。
+- 新テンプレート固有の数量計算は Vue component に書かず、`frontend/src/lib/generation` 配下の pure function に閉じ込める。
+- リスト画面の導線は `frontend/src/lib/listTemplateRegistry.ts` にテンプレート定義を追加して広げる。
+- `generatorKey` / `category` / `baseUnit` は frontend と backend の両方に登録する。
+- 生成 candidate は必ず `name` / `generatorKey` / `category` / `quantity` / `baseUnit` / `displayUnit` を持つ。
+- 再生成対象は `generated + auto` のみで、`generated + locked` は更新・削除しない。
+
+### Backend で追加するもの
+
+1. `GenerationConfigType` に新しい `configType` を追加する。
+2. `backend/src/main/java/com/atoook/otsukailist/generation` 配下に新テンプレート用の generation rule 定数を追加する。
+3. `GenerationRules` に新テンプレートの rule を統合する。
+4. `generatorKey` は全テンプレート横断で一意にする。
+5. `category` と `baseUnit` は frontend の定義と一致させる。
+6. 必要に応じて `ItemCategory` / `BaseUnit` を追加する。ただし DB マスタ化は MVP では行わない。
+7. `GeneratedItemCommandServiceTest` に、新テンプレートの代表 `generatorKey` が sync できること、未知 key / scope 外 key が拒否されることを追加する。
+
+Backend はテンプレート固有の回答内容を解釈しない。回答 JSON は `list_generation_config.config_json` に保存し、生成 candidate の整合性は `generatorKey` と generation rule で検証する。
+
+### Frontend で追加するもの
+
+1. `frontend/src/lib/generation/{template}Generator.ts` を追加する。
+2. `createDefault{Template}GenerationConfig` / `generate{Template}Items` / `is{Template}GenerationConfig` を用意する。
+3. `frontend/src/lib/listGenerationConstants.ts` に新テンプレートの generation rule を追加する。
+4. `GENERATION_RULES` に新テンプレートの rule を統合する。
+5. `frontend/src/lib/listTemplateRegistry.ts` にテンプレート定義を追加する。
+6. 専用ページ `frontend/src/pages/{Template}GenerationPage.vue` を追加する。
+7. 専用パネル `frontend/src/components/{Template}GenerationPanel.vue` を追加する。
+8. `frontend/src/router/index.ts` に専用ページの route を追加する。
+9. `syncGeneratedItems` に渡す `generatorKeysInScope` は、そのテンプレートが管理する全 `generatorKey` を渡す。
+10. preview では `new` / `update` / `delete` / `locked` を区別する。
+
+テンプレート専用 UI は、`BBQGenerationPanel` のようにテンプレート名を含めた component 名にする。`ListGenerationPanel` のような汎用名にすると、テンプレート固有ロジックが共通 UI に見えやすくなるため避ける。
+
+### 生成ロジック追加時の注意点
+
+- 人数や回答値から算出する基準量は、コメントまたは設計書に根拠を残す。
+- `quantity` は保存用の `baseUnit` 基準にする。
+- 表示変換は `formatQuantity` / `resolveUnitLabel` を使い、component 内で独自ラベルを持たない。
+- 集合カテゴリをそのまま item 化すると買い物チェックリストとして弱い場合は、breakdown rule で品目へ展開する。
+- 「なし」にした回答で candidate から外れる item は、sync preview で `delete` として表示し、保存時に `generated + auto` だけ削除する。
+- 既存 `generated + locked` item は、candidate から外れても削除対象にしない。
+
+### テスト追加の目安
+
+Frontend:
+
+- default config が valid と判定される
+- 代表入力から期待 candidate が出る
+- optional 回答を `none` にすると candidate が出ない
+- adjustments が対象カテゴリにだけ効く
+- `baseUnit` と `displayUnit` が期待どおりになる
+- breakdown 対象カテゴリが品目単位に展開される
+
+Backend:
+
+- 新 `generatorKey` の `category` / `baseUnit` が受け入れられる
+- scope 内の `generated + auto` は更新される
+- scope 内で candidate から外れた `generated + auto` は削除される
+- `generated + locked` は更新・削除されない
+- scope 外 key / unknown key / baseUnit 不一致は reject される
+
+### 追加前チェックリスト
+
+- `configType` が route / registry / API 呼び出し / backend enum で一致している
+- `generatorKey` が全体で一意
+- frontend/backend の `category` と `baseUnit` が一致
+- `generatorKeysInScope` にテンプレート管理下の全 key が含まれている
+- 保存済み config がある場合、ボタン文言が「生成条件を調整」になる
+- `generated + locked` の preview が「変更対象外」として見える
+- 新テンプレートの pure function に unit test がある
+
+---
+
+## テスト方針
+
+### Frontend
+
+生成ロジックは pure function として unit test を書く。
+
+確認対象:
+
+- 人数・食事量から期待数量が出る
+- `adjustments` が数量に反映される
+- `baseUnit` 基準で quantity が返る
+- `displayUnit` が表示用に保持される
+- `stapleLevel = none` で主食 candidate が出ない
+
+### Backend
+
+追加する `list_generation_config` API の service / controller test を書く。
+
+確認対象:
+
+- config を保存できる
+- 同じ list / config type で upsert される
+- list が存在しない場合は 404
+- 他 list の config を誤って取得しない
+
+既存 item 更新テストでは以下を維持する。
+
+- `generated + auto` の数量・単位・カテゴリ変更で `locked` になる
+- `manual + none` は再生成対象にならない
+- 未知の `generatorKey` は reject される
+
+---
+
+## 実装順序
+
+1. Frontend に BBQ answers / adjustments / candidate の型を追加する。
+2. `generateBBQItems` を pure function として実装する。
+3. 生成ロジックの unit test を追加する。
+4. `ItemListPage.vue` に「テンプレートから追加」導線を追加する。
+5. BBQ テンプレート専用ページに回答フォームと preview UI を追加する。
+6. generated item sync API を使って生成候補を保存する。
+7. Backend に `list_generation_config` 保存・取得 API を追加する。
+8. 保存済み config がある list 向けに再生成 UI と突合更新処理を追加する。
+9. 必要に応じて備品・調味料の generation rule を増やす。
+
+---
+
+## 将来拡張
+
+### generator_item_key
+
+将来的に 1 つの `generator_key` をさらに細分化したくなった場合は `generator_item_key` を追加する。
 
 ```txt
 generator_key = beef
 generator_item_key = beef_karubi
-item.name = 牛肉カルビ
+item.name = 牛カルビ
 ```
 
----
+MVP では追加しない。
 
-## 将来のマスタ化候補
+### マスタ化候補
 
 - `item_category_master`
 - `unit_master`
@@ -193,12 +1035,15 @@ item.name = 牛肉カルビ
 
 ---
 
-## 最終方針まとめ
+## 最終方針
 
-- 名称は `item.name` に一本化する
-- `item_quantified` は数量・単位・生成制御のみを持つ
-- 表示は「名称 + 数量バッジ」で構成する
-- `generator_key` は表示ではなくロジック用途
-- ユーザー編集は常に `item.name` に対して行う
-- 自動生成後の数量・単位・生成ルール・カテゴリ編集は `locked` として保護する
-- 将来の細分化は `generator_item_key` で拡張する
+- 自動生成は「初期候補生成」として扱う。
+- 通常の自由入力リスト体験を壊さない。
+- 名称は `item.name` に一本化する。
+- `item_quantified` は数量・単位・生成制御のみ持つ。
+- `generated + auto` のみ再生成対象にする。
+- ユーザー編集された生成 item は `locked` として保護する。
+- `category` は item の分類、`generator_key` は生成ロジック識別子として分ける。
+- 数量は必ず `baseUnit` 基準で保存する。
+- MVP では生成ロジックを frontend の pure function として実装する。
+- Vue component に数量計算を書かず、将来 API 化しやすい module 境界にする。

--- a/docs/list-generation-automation.md
+++ b/docs/list-generation-automation.md
@@ -133,7 +133,8 @@ OtsukaiList の基本体験は「自由入力できる軽い買い物リスト�
 - `quantity`
 - `base_unit`
 - `generator_key`
-- `category`
+
+`category` は `generator_key` に紐づく属性として扱うため、generated item では `auto` / `locked` に関係なく編集不可とする。カテゴリを変えたい場合は別 item として扱うべきなので、既存 generated item を削除して手動追加または別生成候補で対応する。
 
 現行 backend 実装では、名称変更だけでは locked にしない。`item.name` は通常の自由編集体験に寄せるため、生成 item でも編集しやすくしている。
 
@@ -648,7 +649,7 @@ POST /api/lists/{listId}/generated-items/sync
 }
 ```
 
-Backend では `generated + auto` の場合、`generatorKey` から category を解決する。Frontend からも category を送るが、生成ルールと矛盾する場合は backend の生成ルールが優先される。
+Backend では `generated` item の場合、`auto` / `locked` に関係なく `generatorKey` から category を解決する。Frontend からも category を送るが、生成ルールと矛盾する場合は backend の生成ルールが優先される。
 
 ### Step 5: 既存 item がある場合
 
@@ -746,6 +747,8 @@ Frontend の `generateBBQItems` を再実行する。
 - `category`
 - `preparationType`
 
+ただし generated item の `category` は `generatorKey` 由来で固定し、詳細編集 UI でも編集不可にする。
+
 MVP では通常リスト体験を優先し、一覧上のクイック操作は複雑にしない。
 
 ---
@@ -760,7 +763,7 @@ Backend は生成エンジンではなく、永続化と整合性維持を担う
 - revision 管理
 - `list_generation_config` の保存・取得
 - `generated` item の generator key バリデーション
-- `generated + auto` の category 解決
+- `generated` item の category 解決
 - ユーザー編集時の `locked` 遷移
 - 共有リストとしての整合性維持
 
@@ -991,7 +994,7 @@ Backend:
 
 既存 item 更新テストでは以下を維持する。
 
-- `generated + auto` の数量・単位・カテゴリ変更で `locked` になる
+- `generated + auto` の数量・単位変更で `locked` になる
 - `manual + none` は再生成対象にならない
 - 未知の `generatorKey` は reject される
 

--- a/frontend/src/api/item.ts
+++ b/frontend/src/api/item.ts
@@ -34,6 +34,16 @@ type CreateQuantifiedItemPayload = CreateItemPayloadBase & {
 
 export type CreateItemPayload = CreatePlainItemPayload | CreateQuantifiedItemPayload;
 
+export type SyncGeneratedItemsPayload = {
+  generatorKeysInScope: string[];
+  items: CreateQuantifiedItemPayload[];
+};
+
+export type SyncGeneratedItemsResponse = {
+  items: Item[];
+  deletedItemIds: UUID[];
+};
+
 export async function createItem(listId: UUID, payload: CreateItemPayload) {
   const res = await http.post<MutationResponse<Item>>(`/lists/${listId}/items`, payload);
   return res.data;
@@ -46,5 +56,13 @@ export async function updateItem(listId: UUID, itemId: UUID, payload: UpdateItem
 
 export async function deleteItem(listId: UUID, itemId: UUID) {
   const res = await http.delete<MutationResponse<DeleteResponse>>(`/lists/${listId}/items/${itemId}`);
+  return res.data;
+}
+
+export async function syncGeneratedItems(listId: UUID, payload: SyncGeneratedItemsPayload) {
+  const res = await http.post<MutationResponse<SyncGeneratedItemsResponse>>(
+    `/lists/${listId}/generated-items/sync`,
+    payload
+  );
   return res.data;
 }

--- a/frontend/src/api/listGenerationConfig.ts
+++ b/frontend/src/api/listGenerationConfig.ts
@@ -1,0 +1,37 @@
+import { http } from '@/lib/http';
+import type { MutationResponse, UUID } from '@/types/api';
+
+export type ListGenerationConfigType = 'bbq';
+
+export type ListGenerationConfigResponse<TConfig = unknown> = {
+  id: UUID;
+  listId: UUID;
+  configType: ListGenerationConfigType;
+  configJson: TConfig;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export async function fetchListGenerationConfig<TConfig = unknown>(
+  listId: UUID,
+  configType: ListGenerationConfigType
+) {
+  const res = await http.get<ListGenerationConfigResponse<TConfig>>(
+    `/lists/${listId}/generation-configs/${configType}`
+  );
+  return res.data;
+}
+
+export async function saveListGenerationConfig<TConfig>(
+  listId: UUID,
+  configType: ListGenerationConfigType,
+  configJson: TConfig
+) {
+  const res = await http.put<MutationResponse<ListGenerationConfigResponse<TConfig>>>(
+    `/lists/${listId}/generation-configs/${configType}`,
+    {
+      configJson
+    }
+  );
+  return res.data;
+}

--- a/frontend/src/components/BBQGenerationPanel.vue
+++ b/frontend/src/components/BBQGenerationPanel.vue
@@ -1,0 +1,688 @@
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import CheckBox from './CheckBox.vue';
+import IconChevronDown from './icons/IconChevronDown.vue';
+import InlineSpinner from './InlineSpinner.vue';
+import MainButton from './MainButton.vue';
+import {
+  createDefaultBBQGenerationConfig,
+  generateBBQItems,
+  type BBQGenerationConfig,
+  type BBQGenerationLevel,
+  type BBQGenerationBalance,
+  type BBQStapleLevel,
+  type BBQAlcoholLevel,
+  type BBQSeafoodLevel,
+  type GeneratedItemCandidate
+} from '@/lib/generation/bbqGenerator';
+import { saveListGenerationConfig } from '@/api/listGenerationConfig';
+import { syncGeneratedItems } from '@/api/item';
+import { useListStore } from '@/stores/list';
+import { useMutation } from '@/composables/useMutation';
+import { getErrorMessage } from '@/lib/http';
+import { BBQ_GENERATOR_KEYS } from '@/lib/listGenerationConstants';
+import { formatQuantity } from '@/lib/quantityDisplay';
+import type { Item } from '@/types/api';
+
+const LEVEL_OPTIONS: Array<{ value: BBQGenerationLevel; label: string }> = [
+  { value: 'small', label: '少なめ' },
+  { value: 'normal', label: '普通' },
+  { value: 'large', label: '多め' }
+];
+
+const BALANCE_OPTIONS: Array<{ value: BBQGenerationBalance; label: string }> = [
+  { value: 'vegetables', label: '野菜多め' },
+  { value: 'balanced', label: 'バランス' },
+  { value: 'meat', label: '肉中心' }
+];
+
+const STAPLE_OPTIONS: Array<{ value: BBQStapleLevel; label: string }> = [
+  { value: 'none', label: 'なし' },
+  { value: 'light', label: '軽め' },
+  { value: 'solid', label: 'しっかり' }
+];
+
+const ALCOHOL_OPTIONS: Array<{ value: BBQAlcoholLevel; label: string }> = [
+  { value: 'none', label: 'なし' },
+  { value: 'included', label: 'あり' }
+];
+
+const SEAFOOD_OPTIONS: Array<{ value: BBQSeafoodLevel; label: string }> = [
+  { value: 'none', label: 'なし' },
+  { value: 'included', label: 'あり' }
+];
+
+const ADJUSTMENT_TARGETS: Array<{ key: keyof BBQGenerationConfig['adjustments']; label: string }> = [
+  { key: 'meat', label: '肉' },
+  { key: 'seafood', label: '海鮮' },
+  { key: 'vegetables', label: '野菜' },
+  { key: 'drinks', label: '飲み物' },
+  { key: 'staple', label: '主食' },
+  { key: 'overall', label: '全体' }
+];
+
+type GenerationPreviewRow = {
+  key: string;
+  name: string;
+  status: 'new' | 'update' | 'delete' | 'unchanged' | 'locked';
+  beforeQuantity: string | null;
+  afterQuantity: string | null;
+  beforeRawQuantity: number | null;
+  afterRawQuantity: number | null;
+};
+
+type GeneratedItemWithKey = Item & {
+  quantified: NonNullable<Item['quantified']> & { generatorKey: string };
+};
+
+function isGeneratedItemWithKey(item: Item): item is GeneratedItemWithKey {
+  return (
+    item.itemType === 'quantified' &&
+    item.quantified != null &&
+    item.quantified.origin === 'generated' &&
+    item.quantified.generatorKey != null
+  );
+}
+
+function cloneBBQGenerationConfig(config: BBQGenerationConfig): BBQGenerationConfig {
+  const defaults = createDefaultBBQGenerationConfig();
+  const rawBalance = (config.answers as { balance?: string }).balance;
+  const balance = rawBalance === 'seafood' ? defaults.answers.balance : config.answers.balance;
+  return {
+    version: 1,
+    answers: {
+      ...defaults.answers,
+      ...config.answers,
+      balance,
+      alcoholLevel: config.answers.alcoholLevel,
+      seafoodLevel: config.answers.seafoodLevel
+    },
+    adjustments: { ...defaults.adjustments, ...config.adjustments }
+  };
+}
+
+export default defineComponent({
+  name: 'BBQGenerationPanel',
+  components: { CheckBox, IconChevronDown, InlineSpinner, MainButton },
+  props: {
+    initialConfig: {
+      type: Object as PropType<BBQGenerationConfig | null>,
+      default: null
+    },
+    hasExistingConfig: {
+      type: Boolean,
+      default: false
+    },
+    showHeader: {
+      type: Boolean,
+      default: true
+    }
+  },
+  emits: ['completed', 'cancel', 'error'],
+  setup() {
+    const listStore = useListStore();
+    const { run, loading } = useMutation();
+    return { listStore, mutationRun: run, mutationLoading: loading };
+  },
+  data(): {
+    config: BBQGenerationConfig;
+    showAdjustmentPanel: boolean;
+    showOnlyChangedRows: boolean;
+  } {
+    return {
+      config: cloneBBQGenerationConfig(this.initialConfig ?? createDefaultBBQGenerationConfig()),
+      showAdjustmentPanel: false,
+      showOnlyChangedRows: true
+    };
+  },
+  computed: {
+    levelOptions(): typeof LEVEL_OPTIONS {
+      return LEVEL_OPTIONS;
+    },
+    balanceOptions(): typeof BALANCE_OPTIONS {
+      return BALANCE_OPTIONS;
+    },
+    stapleOptions(): typeof STAPLE_OPTIONS {
+      return STAPLE_OPTIONS;
+    },
+    alcoholOptions(): typeof ALCOHOL_OPTIONS {
+      return ALCOHOL_OPTIONS;
+    },
+    seafoodOptions(): typeof SEAFOOD_OPTIONS {
+      return SEAFOOD_OPTIONS;
+    },
+    adjustmentTargets(): typeof ADJUSTMENT_TARGETS {
+      return ADJUSTMENT_TARGETS;
+    },
+    templateGeneratorKeys(): string[] {
+      return BBQ_GENERATOR_KEYS;
+    },
+    candidates(): GeneratedItemCandidate[] {
+      return generateBBQItems({
+        answers: this.config.answers,
+        adjustments: this.config.adjustments
+      });
+    },
+    existingGeneratedItemsByGeneratorKey(): Map<string, GeneratedItemWithKey> {
+      return new Map(
+        this.listStore.items.filter(isGeneratedItemWithKey).map((item) => [item.quantified.generatorKey, item])
+      );
+    },
+    applicableCandidates(): GeneratedItemCandidate[] {
+      return this.candidates.filter((candidate) => {
+        const existingItem = this.existingGeneratedItemsByGeneratorKey.get(candidate.generatorKey);
+        return existingItem?.quantified?.regenerationPolicy !== 'locked';
+      });
+    },
+    previewRows(): GenerationPreviewRow[] {
+      if (!this.hasExistingConfig) {
+        return this.candidates.map((candidate) => ({
+          key: candidate.generatorKey,
+          name: candidate.name,
+          status: 'new',
+          beforeQuantity: null,
+          afterQuantity: this.displayQuantity(candidate),
+          beforeRawQuantity: null,
+          afterRawQuantity: candidate.quantity
+        }));
+      }
+
+      const candidateKeys = new Set(this.candidates.map((candidate) => candidate.generatorKey));
+      const candidateRows = this.candidates.map((candidate): GenerationPreviewRow => {
+        const existingItem = this.existingGeneratedItemsByGeneratorKey.get(candidate.generatorKey);
+        if (!existingItem?.quantified) {
+          return {
+            key: candidate.generatorKey,
+            name: candidate.name,
+            status: 'new',
+            beforeQuantity: null,
+            afterQuantity: this.displayQuantity(candidate),
+            beforeRawQuantity: null,
+            afterRawQuantity: candidate.quantity
+          };
+        }
+
+        if (existingItem.quantified.regenerationPolicy === 'locked') {
+          return {
+            key: candidate.generatorKey,
+            name: existingItem.name,
+            status: 'locked',
+            beforeQuantity: this.displayExistingQuantity(existingItem),
+            afterQuantity: null,
+            beforeRawQuantity: existingItem.quantified.quantity,
+            afterRawQuantity: null
+          };
+        }
+
+        const beforeQuantity = this.displayExistingQuantity(existingItem);
+        const afterQuantity = this.displayQuantity(candidate);
+        return {
+          key: candidate.generatorKey,
+          name: existingItem.name,
+          status: beforeQuantity === afterQuantity ? 'unchanged' : 'update',
+          beforeQuantity,
+          afterQuantity,
+          beforeRawQuantity: existingItem.quantified.quantity,
+          afterRawQuantity: candidate.quantity
+        };
+      });
+
+      const templateGeneratorKeys = new Set(this.templateGeneratorKeys);
+      const staleGeneratedRows = Array.from(this.existingGeneratedItemsByGeneratorKey.entries())
+        .filter((entry): entry is [string, GeneratedItemWithKey] => {
+          const [generatorKey] = entry;
+          return !candidateKeys.has(generatorKey) && templateGeneratorKeys.has(generatorKey);
+        })
+        .map(([generatorKey, item]): GenerationPreviewRow => ({
+          key: generatorKey,
+          name: item.name,
+          status: item.quantified.regenerationPolicy === 'locked' ? 'locked' : 'delete',
+          beforeQuantity: this.displayExistingQuantity(item),
+          afterQuantity: null,
+          beforeRawQuantity: item.quantified.quantity,
+          afterRawQuantity: null
+        }));
+
+      return [...candidateRows, ...staleGeneratedRows];
+    },
+    visiblePreviewRows(): GenerationPreviewRow[] {
+      if (!this.hasExistingConfig || !this.showOnlyChangedRows) {
+        return this.previewRows;
+      }
+      return this.previewRows.filter((row) => row.status === 'update' || row.status === 'new' || row.status === 'delete');
+    },
+    canApply(): boolean {
+      return (
+        this.config.answers.adultCount + this.config.answers.childCount > 0 &&
+        (this.candidates.length > 0 || this.previewRows.some((row) => row.status === 'delete')) &&
+        !this.mutationLoading
+      );
+    },
+    primaryButtonLabel(): string {
+      return this.hasExistingConfig ? '再生成する' : 'リストに追加';
+    },
+    previewTitle(): string {
+      return this.hasExistingConfig ? '変更されるアイテム' : '追加されるアイテム';
+    },
+    emptyPreviewMessage(): string {
+      if (this.hasExistingConfig && this.showOnlyChangedRows && this.previewRows.length > 0) {
+        return '変更があるアイテムはありません';
+      }
+      return '人数を入力すると候補が表示されます';
+    },
+    panelClass(): string {
+      return this.showHeader ? 'mb-6 rounded-lg border border-wood-300 bg-wood-50 p-4 shadow-sm' : 'mb-6';
+    }
+  },
+  watch: {
+    initialConfig: {
+      handler(value: BBQGenerationConfig | null) {
+        this.config = cloneBBQGenerationConfig(value ?? createDefaultBBQGenerationConfig());
+      },
+      deep: true
+    }
+  },
+  methods: {
+    setLevel(target: 'appetite' | 'drinkLevel' | 'alcoholAmount', value: BBQGenerationLevel): void {
+      this.config.answers[target] = value;
+    },
+    setBalance(value: BBQGenerationBalance): void {
+      this.config.answers.balance = value;
+    },
+    setStapleLevel(value: BBQStapleLevel): void {
+      this.config.answers.stapleLevel = value;
+    },
+    setAlcoholLevel(value: BBQAlcoholLevel): void {
+      this.config.answers.alcoholLevel = value;
+    },
+    setSeafoodLevel(value: BBQSeafoodLevel): void {
+      this.config.answers.seafoodLevel = value;
+    },
+    setAdjustment(target: keyof BBQGenerationConfig['adjustments'], value: BBQGenerationLevel): void {
+      this.config.adjustments[target] = value;
+    },
+    toggleAdjustmentPanel(): void {
+      this.showAdjustmentPanel = !this.showAdjustmentPanel;
+    },
+    toggleShowOnlyChangedRows(): void {
+      this.showOnlyChangedRows = !this.showOnlyChangedRows;
+    },
+    displayQuantity(item: GeneratedItemCandidate): string {
+      return formatQuantity(item);
+    },
+    displayExistingQuantity(item: GeneratedItemWithKey): string {
+      return formatQuantity({
+        quantity: item.quantified.quantity,
+        baseUnit: item.quantified.baseUnit,
+        category: item.category
+      });
+    },
+    previewStatusLabel(status: GenerationPreviewRow['status']): string {
+      if (status === 'new') {
+        return '追加';
+      }
+      if (status === 'update') {
+        return '変更';
+      }
+      if (status === 'delete') {
+        return '削除';
+      }
+      if (status === 'locked') {
+        return '変更対象外';
+      }
+      return '変更なし';
+    },
+    previewStatusClass(status: GenerationPreviewRow['status']): string {
+      if (status === 'new') {
+        return 'bg-amber-100 text-amber-800';
+      }
+      if (status === 'update') {
+        return 'bg-wood-100 text-charcoal-800';
+      }
+      if (status === 'delete') {
+        return 'border border-red-200 bg-white text-red-700';
+      }
+      if (status === 'locked') {
+        return 'bg-charcoal-100 text-charcoal-600';
+      }
+      return 'bg-transparent text-charcoal-500';
+    },
+    quantityBadgeClass(row: GenerationPreviewRow, position: 'before' | 'after'): string[] {
+      const baseClass = ['rounded px-2 py-0.5'];
+      if (row.status === 'delete' && position === 'before') {
+        return [...baseClass, 'bg-red-50 text-red-700'];
+      }
+      if (row.status !== 'update' || position !== 'after') {
+        return [...baseClass, position === 'after' ? 'bg-wood-100' : 'bg-charcoal-50'];
+      }
+      if (row.beforeRawQuantity != null && row.afterRawQuantity != null && row.afterRawQuantity > row.beforeRawQuantity) {
+        return [...baseClass, 'bg-amber-100 text-amber-800'];
+      }
+      if (row.beforeRawQuantity != null && row.afterRawQuantity != null && row.afterRawQuantity < row.beforeRawQuantity) {
+        return [...baseClass, 'bg-charcoal-100 text-charcoal-700'];
+      }
+      return [...baseClass, 'bg-wood-100'];
+    },
+    optionButtonClass(isActive: boolean, size: 'default' | 'compact' = 'default'): string[] {
+      const sizeClass = size === 'compact' ? 'px-2 py-2 text-sm' : 'px-3 py-2.5 text-sm';
+      return [
+        'rounded-full border font-medium transition-[background-color,border-color,color,box-shadow]',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-wood-300',
+        sizeClass,
+        isActive
+          ? 'border-wood-500 bg-wood-100 text-charcoal-800 shadow-sm'
+          : 'border-wood-200 bg-white text-charcoal-600 hover:border-wood-300 hover:bg-wood-50'
+      ];
+    },
+    async applyTemplate(): Promise<void> {
+      const listId = this.listStore.listId;
+      if (!listId) {
+        this.$emit('error', 'リストが初期化されていません。');
+        return;
+      }
+      if (!this.canApply) {
+        return;
+      }
+
+      try {
+        const normalizedConfig = cloneBBQGenerationConfig(this.config);
+        await this.mutationRun(() => saveListGenerationConfig(listId, 'bbq', normalizedConfig));
+        const result = await this.mutationRun(() =>
+          syncGeneratedItems(listId, {
+            generatorKeysInScope: this.templateGeneratorKeys,
+            items: this.applicableCandidates.map((candidate) => ({
+              name: candidate.name,
+              itemType: 'quantified' as const,
+              category: candidate.category,
+              quantified: {
+                quantity: candidate.quantity,
+                baseUnit: candidate.baseUnit,
+                origin: 'generated' as const,
+                regenerationPolicy: 'auto' as const,
+                generatorKey: candidate.generatorKey
+              }
+            }))
+          })
+        );
+        if (result.applied) {
+          for (const itemId of result.data.deletedItemIds) {
+            this.listStore.removeItem(itemId);
+          }
+          for (const item of result.data.items) {
+            this.listStore.upsertItem(item);
+          }
+        }
+        this.$emit('completed', normalizedConfig);
+      } catch (err: unknown) {
+        console.error('Failed to apply list generation template', err);
+        this.$emit('error', getErrorMessage(err) ?? 'テンプレートからの生成に失敗しました。');
+      }
+    }
+  }
+});
+</script>
+
+<template>
+  <section :class="panelClass">
+    <div v-if="showHeader" class="mb-4 flex items-start justify-between gap-3">
+      <div>
+        <h3 class="text-lg font-bold text-charcoal-800">BBQ テンプレート</h3>
+        <p class="mt-1 text-sm text-charcoal-600">人数と好みに合わせて買い物候補を作ります</p>
+      </div>
+      <button
+        type="button"
+        class="shrink-0 rounded px-2 py-1 text-sm text-charcoal-500 hover:bg-wood-100 hover:text-charcoal-700"
+        :disabled="mutationLoading"
+        @click="$emit('cancel')"
+      >
+        閉じる
+      </button>
+    </div>
+
+    <div class="space-y-4">
+      <div class="rounded-lg border border-wood-100 bg-white p-4">
+        <p class="mb-3 text-sm font-semibold text-charcoal-800">何人で食べますか？</p>
+        <div class="grid grid-cols-2 gap-3">
+          <label class="block">
+            <span class="mb-1 block text-xs font-medium text-charcoal-500">大人</span>
+            <input
+              v-model.number="config.answers.adultCount"
+              type="number"
+              min="0"
+              inputmode="numeric"
+              class="w-full rounded-lg border border-wood-200 bg-wood-50 px-3 py-2 text-base text-charcoal-800 focus:border-wood-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-wood-100"
+            />
+          </label>
+          <label class="block">
+            <span class="mb-1 block text-xs font-medium text-charcoal-500">子供</span>
+            <input
+              v-model.number="config.answers.childCount"
+              type="number"
+              min="0"
+              inputmode="numeric"
+              class="w-full rounded-lg border border-wood-200 bg-wood-50 px-3 py-2 text-base text-charcoal-800 focus:border-wood-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-wood-100"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div class="rounded-lg border border-wood-100 bg-white p-4">
+        <p class="mb-3 text-sm font-semibold text-charcoal-800">食べる量はどれくらいですか？</p>
+        <div class="grid grid-cols-3 gap-2">
+          <button
+            v-for="option in levelOptions"
+            :key="option.value"
+            type="button"
+            :class="optionButtonClass(config.answers.appetite === option.value)"
+            @click="setLevel('appetite', option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
+
+      <div class="rounded-lg border border-wood-100 bg-white p-4">
+        <p class="mb-3 text-sm font-semibold text-charcoal-800">肉と野菜のバランスは？</p>
+        <div class="grid grid-cols-3 gap-2">
+          <button
+            v-for="option in balanceOptions"
+            :key="option.value"
+            type="button"
+            :class="optionButtonClass(config.answers.balance === option.value)"
+            @click="setBalance(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
+
+      <div class="rounded-lg border border-wood-100 bg-white p-4">
+        <p class="mb-3 text-sm font-semibold text-charcoal-800">海鮮も用意しますか？</p>
+        <div class="grid grid-cols-2 gap-2">
+          <button
+            v-for="option in seafoodOptions"
+            :key="option.value"
+            type="button"
+            :class="optionButtonClass(config.answers.seafoodLevel === option.value)"
+            @click="setSeafoodLevel(option.value)"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div class="rounded-lg border border-wood-100 bg-white p-4">
+          <p class="mb-3 text-sm font-semibold text-charcoal-800">飲み物はどれくらいですか？</p>
+          <div class="grid grid-cols-3 gap-2">
+            <button
+              v-for="option in levelOptions"
+              :key="option.value"
+              type="button"
+              :class="optionButtonClass(config.answers.drinkLevel === option.value, 'compact')"
+              @click="setLevel('drinkLevel', option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+
+        <div class="rounded-lg border border-wood-100 bg-white p-4">
+          <p class="mb-3 text-sm font-semibold text-charcoal-800">アルコールは用意しますか？</p>
+          <div class="grid grid-cols-2 gap-2">
+            <button
+              v-for="option in alcoholOptions"
+              :key="option.value"
+              type="button"
+              :class="optionButtonClass(config.answers.alcoholLevel === option.value, 'compact')"
+              @click="setAlcoholLevel(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+          <div v-if="config.answers.alcoholLevel === 'included'" class="mt-3">
+            <p class="mb-2 text-xs font-medium text-charcoal-500">アルコールの量</p>
+            <div class="grid grid-cols-3 gap-2">
+              <button
+                v-for="option in levelOptions"
+                :key="option.value"
+                type="button"
+                :class="optionButtonClass(config.answers.alcoholAmount === option.value, 'compact')"
+                @click="setLevel('alcoholAmount', option.value)"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-lg border border-wood-100 bg-white p-4">
+          <p class="mb-3 text-sm font-semibold text-charcoal-800">焼きそばなどの主食は？</p>
+          <div class="grid grid-cols-3 gap-2">
+            <button
+              v-for="option in stapleOptions"
+              :key="option.value"
+              type="button"
+              :class="optionButtonClass(config.answers.stapleLevel === option.value, 'compact')"
+              @click="setStapleLevel(option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="hasExistingConfig" class="rounded-lg border border-wood-100 bg-white">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left hover:bg-wood-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-wood-300"
+          :aria-expanded="showAdjustmentPanel"
+          aria-controls="bbq-adjustment-panel"
+          @click="toggleAdjustmentPanel"
+        >
+          <span>
+            <span class="block text-sm font-medium text-charcoal-700">量の微調整</span>
+            <span class="mt-0.5 block text-xs text-charcoal-500">必要に応じてカテゴリ別に増減できます</span>
+          </span>
+          <span
+            class="flex shrink-0 items-center text-charcoal-500 transition-transform duration-200"
+            :class="{ '-rotate-90': !showAdjustmentPanel }"
+            aria-hidden="true"
+          >
+            <IconChevronDown />
+          </span>
+        </button>
+        <div
+          v-if="showAdjustmentPanel"
+          id="bbq-adjustment-panel"
+          class="grid gap-3 border-t border-wood-100 p-4"
+        >
+          <div v-for="target in adjustmentTargets" :key="target.key">
+            <p class="mb-1 text-xs font-medium text-charcoal-600">
+              {{ target.label }}
+            </p>
+            <div class="grid grid-cols-3 gap-1">
+              <button
+                v-for="option in levelOptions"
+                :key="option.value"
+                type="button"
+                :class="optionButtonClass(config.adjustments[target.key] === option.value, 'compact')"
+                @click="setAdjustment(target.key, option.value)"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-lg border border-wood-100 bg-white p-4">
+        <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
+          <p class="text-sm font-semibold text-charcoal-800">{{ previewTitle }}</p>
+          <div v-if="hasExistingConfig" class="flex items-center gap-2 text-xs font-medium text-charcoal-600">
+            <CheckBox
+              :checked="showOnlyChangedRows"
+              aria-label="変更ありだけ表示"
+              @toggle="toggleShowOnlyChangedRows"
+            />
+            <button type="button" class="text-left hover:text-charcoal-800" @click="toggleShowOnlyChangedRows">
+              変更ありだけ表示
+            </button>
+          </div>
+        </div>
+        <div class="divide-y divide-wood-100 rounded-lg border border-wood-100 bg-white">
+          <div
+            v-for="row in visiblePreviewRows"
+            :key="row.key"
+            class="grid gap-2 px-3 py-2 sm:grid-cols-[minmax(0,1fr)_auto]"
+            :class="{ 'bg-charcoal-50/50': row.status === 'unchanged' }"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <span
+                class="min-w-0 truncate text-sm"
+                :class="row.status === 'unchanged' ? 'text-charcoal-500' : 'text-charcoal-800'"
+              >
+                {{ row.name }}
+              </span>
+              <span
+                class="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium"
+                :class="previewStatusClass(row.status)"
+              >
+                {{ previewStatusLabel(row.status) }}
+              </span>
+            </div>
+            <div class="flex flex-wrap items-center gap-1 text-xs font-medium text-charcoal-700 sm:justify-end">
+              <span v-if="row.status === 'unchanged'" class="text-charcoal-500">
+                {{ row.beforeQuantity }}
+              </span>
+              <template v-else-if="row.beforeQuantity && row.afterQuantity">
+                <span :class="quantityBadgeClass(row, 'before')">{{ row.beforeQuantity }}</span>
+                <span class="text-charcoal-400">→</span>
+                <span :class="quantityBadgeClass(row, 'after')">{{ row.afterQuantity }}</span>
+              </template>
+              <span v-else-if="row.afterQuantity" :class="quantityBadgeClass(row, 'after')">
+                {{ row.afterQuantity }}
+              </span>
+              <span v-else-if="row.beforeQuantity" :class="quantityBadgeClass(row, 'before')">
+                {{ row.beforeQuantity }}
+              </span>
+            </div>
+          </div>
+          <p v-if="visiblePreviewRows.length === 0" class="px-3 py-3 text-sm text-charcoal-600">
+            {{ emptyPreviewMessage }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-5 flex flex-col-reverse gap-2">
+      <MainButton variant="cancel" :disabled="mutationLoading" @click="$emit('cancel')">キャンセル</MainButton>
+      <MainButton :disabled="!canApply" :aria-busy="mutationLoading" @click="applyTemplate">
+        <span class="relative inline-grid min-w-[6em] place-items-center">
+          <span :class="{ 'opacity-0': mutationLoading }">{{ primaryButtonLabel }}</span>
+          <InlineSpinner v-if="mutationLoading" class="absolute inset-0 m-auto" size="md" tone="primary" />
+        </span>
+      </MainButton>
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/ItemBox.vue
+++ b/frontend/src/components/ItemBox.vue
@@ -164,7 +164,7 @@ import IconTrash from './icons/IconTrash.vue';
 import type { Item, ItemId } from '../types/item';
 import { isItem, isItemCompleted } from '../types/item';
 import { normalizeText } from '../utils/text-normalization';
-import { UNIT_DEFINITIONS } from '@/types/list-generation';
+import { formatQuantity } from '@/lib/quantityDisplay';
 import { ITEM_CATEGORIES, type ItemCategory } from '@/types/item-category';
 import { ITEM_PREPARATION_TYPES, type ItemPreparationType } from '@/types/item-preparation-type';
 
@@ -272,9 +272,11 @@ export default {
       if (this.item.itemType !== 'quantified' || !this.item.quantified) {
         return '';
       }
-      const unitDefinition = UNIT_DEFINITIONS[this.item.quantified.baseUnit];
-      const unitLabel = unitDefinition?.label ?? this.item.quantified.baseUnit ?? '';
-      return `${this.item.quantified.quantity}${unitLabel}`;
+      return formatQuantity({
+        quantity: this.item.quantified.quantity,
+        baseUnit: this.item.quantified.baseUnit,
+        category: this.item.category
+      });
     },
     categoryLabel() {
       if (!this.item.category) {

--- a/frontend/src/components/icons/IconSparkles.vue
+++ b/frontend/src/components/icons/IconSparkles.vue
@@ -1,0 +1,12 @@
+<template>
+  <SparklesIcon class="w-[1.25em] h-[1.25em] inline align-middle" aria-hidden="true" />
+</template>
+
+<script>
+import { SparklesIcon } from '@heroicons/vue/24/solid';
+
+export default {
+  name: 'IconSparkles',
+  components: { SparklesIcon }
+};
+</script>

--- a/frontend/src/lib/generation/bbqGenerator.test.ts
+++ b/frontend/src/lib/generation/bbqGenerator.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultBBQGenerationConfig,
+  generateBBQItems,
+  isBBQGenerationConfig,
+  type BBQGenerationAnswers,
+  type BBQGenerationAdjustments
+} from './bbqGenerator';
+
+const answers: BBQGenerationAnswers = {
+  adultCount: 6,
+  childCount: 2,
+  appetite: 'normal',
+  balance: 'balanced',
+  drinkLevel: 'normal',
+  alcoholLevel: 'none',
+  alcoholAmount: 'normal',
+  seafoodLevel: 'none',
+  stapleLevel: 'light'
+};
+
+const adjustments: BBQGenerationAdjustments = {
+  meat: 'normal',
+  seafood: 'normal',
+  vegetables: 'normal',
+  drinks: 'normal',
+  staple: 'normal',
+  overall: 'normal'
+};
+
+describe('generateBBQItems', () => {
+  it('人数から baseUnit 基準の候補を生成する', () => {
+    const items = generateBBQItems({ answers, adjustments });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ generatorKey: 'beef', quantity: 800, baseUnit: 'g', displayUnit: 'g' }),
+        expect.objectContaining({ generatorKey: 'pork', quantity: 600, baseUnit: 'g', displayUnit: 'g' }),
+        expect.objectContaining({ generatorKey: 'chicken', quantity: 450, baseUnit: 'g', displayUnit: 'g' }),
+        expect.objectContaining({ generatorKey: 'sausage', quantity: 300, baseUnit: 'g', displayUnit: 'g' }),
+        expect.objectContaining({ generatorKey: 'vegetable_onion', quantity: 2, baseUnit: 'piece' }),
+        expect.objectContaining({ generatorKey: 'vegetable_bell_pepper', quantity: 4, baseUnit: 'piece' }),
+        expect.objectContaining({ generatorKey: 'vegetable_corn', quantity: 2, baseUnit: 'piece' }),
+        expect.objectContaining({ generatorKey: 'vegetable_potato', quantity: 4, baseUnit: 'piece' }),
+        expect.objectContaining({ generatorKey: 'vegetable_mushrooms', quantity: 2, baseUnit: 'pack' }),
+        expect.objectContaining({ generatorKey: 'soft_drinks', quantity: 4000, baseUnit: 'ml', displayUnit: 'l' }),
+        expect.objectContaining({ generatorKey: 'yakisoba', quantity: 5, baseUnit: 'piece' })
+      ])
+    );
+  });
+
+  it('g数量は1000g以上の場合だけ kg 表示にする', () => {
+    const items = generateBBQItems({
+      answers: { ...answers, adultCount: 10, childCount: 0 },
+      adjustments
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ generatorKey: 'beef', quantity: 1100, baseUnit: 'g', displayUnit: 'kg' }),
+        expect.objectContaining({ generatorKey: 'pork', quantity: 800, baseUnit: 'g', displayUnit: 'g' })
+      ])
+    );
+  });
+
+  it('adjustments を数量に反映する', () => {
+    const normalItems = generateBBQItems({ answers, adjustments });
+    const largeMeatItems = generateBBQItems({
+      answers,
+      adjustments: { ...adjustments, meat: 'large' }
+    });
+
+    const normalBeef = normalItems.find((item) => item.generatorKey === 'beef');
+    const largeBeef = largeMeatItems.find((item) => item.generatorKey === 'beef');
+    const normalVegetables = normalItems.find((item) => item.generatorKey === 'vegetable_bell_pepper');
+    const largeVegetables = largeMeatItems.find((item) => item.generatorKey === 'vegetable_bell_pepper');
+
+    expect(largeBeef?.quantity).toBeGreaterThan(normalBeef?.quantity ?? 0);
+    expect(largeVegetables?.quantity).toBe(normalVegetables?.quantity);
+  });
+
+  it('主食なしの場合は焼きそば候補を出さない', () => {
+    const items = generateBBQItems({
+      answers: { ...answers, stapleLevel: 'none' },
+      adjustments
+    });
+
+    expect(items.some((item) => item.generatorKey === 'yakisoba')).toBe(false);
+  });
+
+  it('アルコールありの場合だけアルコール候補を出す', () => {
+    const withoutAlcohol = generateBBQItems({ answers, adjustments });
+    const withAlcohol = generateBBQItems({
+      answers: { ...answers, alcoholLevel: 'included' },
+      adjustments
+    });
+
+    expect(withoutAlcohol.some((item) => item.generatorKey === 'alcohol')).toBe(false);
+    expect(withAlcohol).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          generatorKey: 'alcohol',
+          name: 'アルコール(350ml)',
+          quantity: 9,
+          baseUnit: 'piece',
+          displayUnit: 'piece'
+        })
+      ])
+    );
+  });
+
+  it('アルコール普通は大人1人あたり500ml相当を350ml缶の本数で生成する', () => {
+    const items = generateBBQItems({
+      answers: { ...answers, adultCount: 4, childCount: 0, alcoholLevel: 'included', alcoholAmount: 'normal' },
+      adjustments
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ generatorKey: 'alcohol', quantity: 6, baseUnit: 'piece', displayUnit: 'piece' })
+      ])
+    );
+  });
+
+  it('アルコール量の回答をアルコール候補に反映する', () => {
+    const normalAlcoholItems = generateBBQItems({
+      answers: { ...answers, alcoholLevel: 'included', alcoholAmount: 'normal' },
+      adjustments
+    });
+    const largeAlcoholItems = generateBBQItems({
+      answers: { ...answers, alcoholLevel: 'included', alcoholAmount: 'large' },
+      adjustments
+    });
+    const normalAlcohol = normalAlcoholItems.find((item) => item.generatorKey === 'alcohol');
+    const largeAlcohol = largeAlcoholItems.find((item) => item.generatorKey === 'alcohol');
+
+    expect(largeAlcohol?.quantity).toBeGreaterThan(normalAlcohol?.quantity ?? 0);
+  });
+
+  it('飲み物の調整をソフトドリンク数量に反映する', () => {
+    const normalItems = generateBBQItems({ answers, adjustments });
+    const largeDrinkItems = generateBBQItems({
+      answers,
+      adjustments: { ...adjustments, drinks: 'large' }
+    });
+
+    const normalDrinks = normalItems.find((item) => item.generatorKey === 'soft_drinks');
+    const largeDrinks = largeDrinkItems.find((item) => item.generatorKey === 'soft_drinks');
+
+    expect(largeDrinks?.quantity).toBeGreaterThan(normalDrinks?.quantity ?? 0);
+  });
+
+  it('海鮮の調整を海鮮数量に反映する', () => {
+    const normalItems = generateBBQItems({
+      answers: { ...answers, seafoodLevel: 'included' },
+      adjustments
+    });
+    const largeSeafoodItems = generateBBQItems({
+      answers: { ...answers, seafoodLevel: 'included' },
+      adjustments: { ...adjustments, seafood: 'large' }
+    });
+
+    const normalShrimp = normalItems.find((item) => item.generatorKey === 'seafood_shrimp');
+    const largeShrimp = largeSeafoodItems.find((item) => item.generatorKey === 'seafood_shrimp');
+
+    expect(largeShrimp?.quantity).toBeGreaterThan(normalShrimp?.quantity ?? 0);
+  });
+
+  it('主食の調整を焼きそば数量に反映する', () => {
+    const normalItems = generateBBQItems({ answers, adjustments });
+    const largeStapleItems = generateBBQItems({
+      answers,
+      adjustments: { ...adjustments, staple: 'large' }
+    });
+
+    const normalYakisoba = normalItems.find((item) => item.generatorKey === 'yakisoba');
+    const largeYakisoba = largeStapleItems.find((item) => item.generatorKey === 'yakisoba');
+
+    expect(largeYakisoba?.quantity).toBeGreaterThan(normalYakisoba?.quantity ?? 0);
+  });
+
+  it('海鮮ありの場合は海鮮候補を出し肉量を少し抑える', () => {
+    const withoutSeafood = generateBBQItems({ answers, adjustments });
+    const withSeafood = generateBBQItems({
+      answers: { ...answers, seafoodLevel: 'included' },
+      adjustments
+    });
+
+    const normalBeef = withoutSeafood.find((item) => item.generatorKey === 'beef');
+    const seafoodBeef = withSeafood.find((item) => item.generatorKey === 'beef');
+
+    expect(withSeafood).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ generatorKey: 'seafood_shrimp', quantity: 2, baseUnit: 'pack' }),
+        expect.objectContaining({ generatorKey: 'seafood_scallop', quantity: 2, baseUnit: 'pack' }),
+        expect.objectContaining({ generatorKey: 'seafood_squid', quantity: 2, baseUnit: 'pack' })
+      ])
+    );
+    expect(seafoodBeef?.quantity).toBeLessThan(normalBeef?.quantity ?? 0);
+  });
+});
+
+describe('isBBQGenerationConfig', () => {
+  it('デフォルト config を有効な config として判定する', () => {
+    expect(isBBQGenerationConfig(createDefaultBBQGenerationConfig())).toBe(true);
+  });
+});

--- a/frontend/src/lib/generation/bbqGenerator.ts
+++ b/frontend/src/lib/generation/bbqGenerator.ts
@@ -1,0 +1,387 @@
+import { BBQ_GENERATION_RULES } from '@/lib/listGenerationConstants';
+import type { ItemCategory } from '@/types/item-category';
+import type { BaseUnit, UnitCode } from '@/types/list-generation';
+
+export type BBQGenerationLevel = 'small' | 'normal' | 'large';
+export type BBQGenerationBalance = 'vegetables' | 'balanced' | 'meat';
+export type BBQStapleLevel = 'none' | 'light' | 'solid';
+export type BBQAlcoholLevel = 'none' | 'included';
+export type BBQSeafoodLevel = 'none' | 'included';
+
+export type BBQGenerationAnswers = {
+  adultCount: number;
+  childCount: number;
+  appetite: BBQGenerationLevel;
+  balance: BBQGenerationBalance;
+  drinkLevel: BBQGenerationLevel;
+  alcoholLevel: BBQAlcoholLevel;
+  alcoholAmount: BBQGenerationLevel;
+  seafoodLevel: BBQSeafoodLevel;
+  stapleLevel: BBQStapleLevel;
+};
+
+export type BBQGenerationAdjustments = {
+  meat: BBQGenerationLevel;
+  seafood: BBQGenerationLevel;
+  vegetables: BBQGenerationLevel;
+  drinks: BBQGenerationLevel;
+  staple: BBQGenerationLevel;
+  overall: BBQGenerationLevel;
+};
+
+export type BBQGenerationConfig = {
+  version: 1;
+  answers: BBQGenerationAnswers;
+  adjustments: BBQGenerationAdjustments;
+};
+
+export type GeneratedItemCandidate = {
+  generatorKey: string;
+  name: string;
+  category: ItemCategory;
+  quantity: number;
+  baseUnit: BaseUnit;
+  displayUnit: UnitCode;
+};
+
+type GenerateBBQItemsInput = {
+  answers: BBQGenerationAnswers;
+  adjustments: BBQGenerationAdjustments;
+};
+
+type BBQGeneratorKey = keyof typeof BBQ_GENERATION_RULES;
+
+type BreakdownRule = {
+  generatorKey: BBQGeneratorKey;
+  amountPerBaseQuantity: number;
+};
+
+const LEVEL_FACTORS: Record<BBQGenerationLevel, number> = {
+  small: 0.8,
+  normal: 1,
+  large: 1.25
+};
+
+const APPETITE_FACTORS: Record<BBQGenerationLevel, number> = {
+  small: 0.8,
+  normal: 1,
+  large: 1.2
+};
+
+const BALANCE_FACTORS: Record<
+  BBQGenerationBalance,
+  { beef: number; pork: number; chicken: number; sausage: number; vegetables: number }
+> = {
+  vegetables: { beef: 0.85, pork: 0.85, chicken: 0.85, sausage: 0.8, vegetables: 1.35 },
+  balanced: { beef: 1, pork: 1, chicken: 1, sausage: 1, vegetables: 1 },
+  meat: { beef: 1.15, pork: 1.1, chicken: 1.1, sausage: 1.15, vegetables: 0.9 }
+};
+
+const CHILD_TO_ADULT_FACTOR = 0.6;
+const BEEF_GRAMS_PER_PERSON = 110;
+const PORK_GRAMS_PER_PERSON = 80;
+const CHICKEN_GRAMS_PER_PERSON = 60;
+const SAUSAGE_GRAMS_PER_PERSON = 40;
+const SEAFOOD_GRAMS_PER_PERSON = 120;
+const SEAFOOD_MEAT_REDUCTION_FACTOR = 0.85;
+// Assumes a grill-friendly mix such as onion, bell pepper, corn, potato, and mushrooms.
+const VEGETABLE_GRAMS_PER_PERSON = 150;
+const SOFT_DRINK_ML_PER_PERSON = 500;
+const ALCOHOL_ML_PER_ADULT = 500;
+const ALCOHOL_CAN_ML = 350;
+
+const VEGETABLE_BREAKDOWN_BASE_GRAMS = 600;
+const VEGETABLE_BREAKDOWN_RULES: BreakdownRule[] = [
+  { generatorKey: 'vegetableOnion', amountPerBaseQuantity: 1 },
+  { generatorKey: 'vegetableBellPepper', amountPerBaseQuantity: 2 },
+  { generatorKey: 'vegetableCorn', amountPerBaseQuantity: 1 },
+  { generatorKey: 'vegetablePotato', amountPerBaseQuantity: 2 },
+  { generatorKey: 'vegetableMushrooms', amountPerBaseQuantity: 1 }
+];
+
+const SEAFOOD_BREAKDOWN_BASE_GRAMS = 480;
+const SEAFOOD_BREAKDOWN_RULES: BreakdownRule[] = [
+  { generatorKey: 'seafoodShrimp', amountPerBaseQuantity: 1 },
+  { generatorKey: 'seafoodScallop', amountPerBaseQuantity: 0.75 },
+  { generatorKey: 'seafoodSquid', amountPerBaseQuantity: 0.75 }
+];
+
+const DEFAULT_BBQ_ANSWERS: BBQGenerationAnswers = {
+  adultCount: 4,
+  childCount: 0,
+  appetite: 'normal',
+  balance: 'balanced',
+  drinkLevel: 'normal',
+  alcoholLevel: 'none',
+  alcoholAmount: 'normal',
+  seafoodLevel: 'none',
+  stapleLevel: 'light'
+};
+
+export const DEFAULT_BBQ_ADJUSTMENTS: BBQGenerationAdjustments = {
+  meat: 'normal',
+  seafood: 'normal',
+  vegetables: 'normal',
+  drinks: 'normal',
+  staple: 'normal',
+  overall: 'normal'
+};
+
+export function createDefaultBBQGenerationConfig(): BBQGenerationConfig {
+  return {
+    version: 1,
+    answers: { ...DEFAULT_BBQ_ANSWERS },
+    adjustments: { ...DEFAULT_BBQ_ADJUSTMENTS }
+  };
+}
+
+export function generateBBQItems({ answers, adjustments }: GenerateBBQItemsInput): GeneratedItemCandidate[] {
+  const people = Math.max(0, answers.adultCount) + Math.max(0, answers.childCount) * CHILD_TO_ADULT_FACTOR;
+  if (people <= 0) {
+    return [];
+  }
+
+  const appetiteFactor = APPETITE_FACTORS[answers.appetite];
+  const overallFactor = LEVEL_FACTORS[adjustments.overall];
+  const balanceFactors = BALANCE_FACTORS[answers.balance] ?? BALANCE_FACTORS.balanced;
+  const meatFactor = LEVEL_FACTORS[adjustments.meat];
+  const seafoodFactor = LEVEL_FACTORS[adjustments.seafood];
+  const stapleAdjustmentFactor = LEVEL_FACTORS[adjustments.staple];
+  const seafoodIncluded = answers.seafoodLevel === 'included';
+  const seafoodMeatFactor = seafoodIncluded ? SEAFOOD_MEAT_REDUCTION_FACTOR : 1;
+  const vegetableQuantity = roundTo(
+    people *
+      VEGETABLE_GRAMS_PER_PERSON *
+      appetiteFactor *
+      overallFactor *
+      LEVEL_FACTORS[adjustments.vegetables] *
+      balanceFactors.vegetables,
+    50
+  );
+
+  const candidates: GeneratedItemCandidate[] = [
+    candidate(
+      'beef',
+      roundTo(
+        people *
+          BEEF_GRAMS_PER_PERSON *
+          appetiteFactor *
+          overallFactor *
+          meatFactor *
+          balanceFactors.beef *
+          seafoodMeatFactor,
+        50
+      )
+    ),
+    candidate(
+      'pork',
+      roundTo(
+        people *
+          PORK_GRAMS_PER_PERSON *
+          appetiteFactor *
+          overallFactor *
+          meatFactor *
+          balanceFactors.pork *
+          seafoodMeatFactor,
+        50
+      )
+    ),
+    candidate(
+      'chicken',
+      roundTo(
+        people *
+          CHICKEN_GRAMS_PER_PERSON *
+          appetiteFactor *
+          overallFactor *
+          meatFactor *
+          balanceFactors.chicken *
+          seafoodMeatFactor,
+        50
+      )
+    ),
+    candidate(
+      'sausage',
+      roundTo(
+        people *
+          SAUSAGE_GRAMS_PER_PERSON *
+          appetiteFactor *
+          overallFactor *
+          meatFactor *
+          balanceFactors.sausage *
+          seafoodMeatFactor,
+        50
+      )
+    ),
+    ...expandBreakdown(VEGETABLE_BREAKDOWN_RULES, vegetableQuantity, VEGETABLE_BREAKDOWN_BASE_GRAMS),
+    candidate(
+      'softDrinks',
+      roundTo(
+        people *
+          SOFT_DRINK_ML_PER_PERSON *
+          LEVEL_FACTORS[answers.drinkLevel] *
+          LEVEL_FACTORS[adjustments.drinks] *
+          overallFactor,
+        500
+      )
+    )
+  ];
+
+  if (seafoodIncluded) {
+    const seafoodQuantity = roundTo(
+      people * SEAFOOD_GRAMS_PER_PERSON * appetiteFactor * overallFactor * seafoodFactor,
+      50
+    );
+    candidates.push(...expandBreakdown(SEAFOOD_BREAKDOWN_RULES, seafoodQuantity, SEAFOOD_BREAKDOWN_BASE_GRAMS));
+  }
+
+  const alcoholQuantity = calculateAlcoholQuantity(answers, adjustments, overallFactor);
+  if (alcoholQuantity > 0) {
+    candidates.push(candidate('alcohol', alcoholQuantity));
+  }
+
+  const yakisobaQuantity = calculateYakisobaQuantity(
+    people,
+    answers.stapleLevel,
+    appetiteFactor,
+    overallFactor,
+    stapleAdjustmentFactor
+  );
+  if (yakisobaQuantity > 0) {
+    candidates.push(candidate('yakisoba', yakisobaQuantity));
+  }
+
+  return candidates.filter((item) => item.quantity > 0);
+}
+
+export function isBBQGenerationConfig(value: unknown): value is BBQGenerationConfig {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as BBQGenerationConfig;
+  return (
+    candidate.version === 1 &&
+    isBBQGenerationAnswers(candidate.answers) &&
+    isBBQGenerationAdjustments(candidate.adjustments)
+  );
+}
+
+function isBBQGenerationAnswers(value: unknown): value is BBQGenerationAnswers {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as BBQGenerationAnswers;
+  return (
+    isNonNegativeNumber(candidate.adultCount) &&
+    isNonNegativeNumber(candidate.childCount) &&
+    isLevel(candidate.appetite) &&
+    isBalance(candidate.balance) &&
+    isLevel(candidate.drinkLevel) &&
+    isAlcoholLevel(candidate.alcoholLevel) &&
+    isLevel(candidate.alcoholAmount) &&
+    isSeafoodLevel(candidate.seafoodLevel) &&
+    isStapleLevel(candidate.stapleLevel)
+  );
+}
+
+function isBBQGenerationAdjustments(value: unknown): value is BBQGenerationAdjustments {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as BBQGenerationAdjustments;
+  return (
+    isLevel(candidate.meat) &&
+    isLevel(candidate.seafood) &&
+    isLevel(candidate.vegetables) &&
+    isLevel(candidate.drinks) &&
+    isLevel(candidate.staple) &&
+    isLevel(candidate.overall)
+  );
+}
+
+function candidate(generatorKey: BBQGeneratorKey, quantity: number): GeneratedItemCandidate {
+  const rule = BBQ_GENERATION_RULES[generatorKey];
+  return {
+    generatorKey: rule.generatorKey,
+    name: rule.label,
+    category: rule.category,
+    quantity,
+    baseUnit: rule.baseUnit,
+    displayUnit: resolveDisplayUnit(rule.displayUnit, rule.baseUnit, quantity)
+  };
+}
+
+function resolveDisplayUnit(defaultDisplayUnit: UnitCode, baseUnit: BaseUnit, quantity: number): UnitCode {
+  if (baseUnit === 'g' && quantity >= 1000) {
+    return 'kg';
+  }
+  return defaultDisplayUnit;
+}
+
+function expandBreakdown(
+  rules: BreakdownRule[],
+  aggregateQuantity: number,
+  baseQuantity: number
+): GeneratedItemCandidate[] {
+  const scale = aggregateQuantity / baseQuantity;
+  return rules.map((rule) => candidate(rule.generatorKey, Math.max(1, Math.ceil(scale * rule.amountPerBaseQuantity))));
+}
+
+function calculateYakisobaQuantity(
+  people: number,
+  stapleLevel: BBQStapleLevel,
+  appetiteFactor: number,
+  overallFactor: number,
+  stapleAdjustmentFactor: number
+): number {
+  if (stapleLevel === 'none') {
+    return 0;
+  }
+  const stapleFactor = stapleLevel === 'light' ? 0.65 : 1;
+  return Math.ceil(people * stapleFactor * appetiteFactor * overallFactor * stapleAdjustmentFactor);
+}
+
+function calculateAlcoholQuantity(
+  answers: BBQGenerationAnswers,
+  adjustments: BBQGenerationAdjustments,
+  overallFactor: number
+): number {
+  if (answers.alcoholLevel !== 'included' || answers.adultCount <= 0) {
+    return 0;
+  }
+  return Math.ceil(
+    (answers.adultCount *
+      ALCOHOL_ML_PER_ADULT *
+      LEVEL_FACTORS[answers.alcoholAmount] *
+      LEVEL_FACTORS[adjustments.drinks] *
+      overallFactor) /
+      ALCOHOL_CAN_ML
+  );
+}
+
+function roundTo(value: number, unit: number): number {
+  return Math.ceil(value / unit) * unit;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isLevel(value: unknown): value is BBQGenerationLevel {
+  return value === 'small' || value === 'normal' || value === 'large';
+}
+
+function isBalance(value: unknown): value is BBQGenerationBalance {
+  return value === 'vegetables' || value === 'balanced' || value === 'meat' || value === 'seafood';
+}
+
+function isStapleLevel(value: unknown): value is BBQStapleLevel {
+  return value === 'none' || value === 'light' || value === 'solid';
+}
+
+function isAlcoholLevel(value: unknown): value is BBQAlcoholLevel {
+  return value === 'none' || value === 'included';
+}
+
+function isSeafoodLevel(value: unknown): value is BBQSeafoodLevel {
+  return value === 'none' || value === 'included';
+}

--- a/frontend/src/lib/listGenerationConstants.ts
+++ b/frontend/src/lib/listGenerationConstants.ts
@@ -4,26 +4,113 @@ import type { BaseUnit, UnitCode } from '@/types/list-generation';
 export const BBQ_GENERATION_RULES = {
   beef: {
     generatorKey: 'beef',
+    label: '牛肉',
     category: 'meat' satisfies ItemCategory,
-    baseUnit: 'g' satisfies BaseUnit,
-    displayUnit: 'kg' satisfies UnitCode
-  },
-  pork: {
-    generatorKey: 'pork',
-    category: 'meat' satisfies ItemCategory,
-    baseUnit: 'g' satisfies BaseUnit,
-    displayUnit: 'kg' satisfies UnitCode
-  },
-  vegetables: {
-    generatorKey: 'vegetables',
-    category: 'vegetables' satisfies ItemCategory,
     baseUnit: 'g' satisfies BaseUnit,
     displayUnit: 'g' satisfies UnitCode
   },
+  pork: {
+    generatorKey: 'pork',
+    label: '豚肉',
+    category: 'meat' satisfies ItemCategory,
+    baseUnit: 'g' satisfies BaseUnit,
+    displayUnit: 'g' satisfies UnitCode
+  },
+  chicken: {
+    generatorKey: 'chicken',
+    label: '鶏肉',
+    category: 'meat' satisfies ItemCategory,
+    baseUnit: 'g' satisfies BaseUnit,
+    displayUnit: 'g' satisfies UnitCode
+  },
+  sausage: {
+    generatorKey: 'sausage',
+    label: 'ソーセージ',
+    category: 'meat' satisfies ItemCategory,
+    baseUnit: 'g' satisfies BaseUnit,
+    displayUnit: 'g' satisfies UnitCode
+  },
+  vegetableOnion: {
+    generatorKey: 'vegetable_onion',
+    label: '玉ねぎ',
+    category: 'vegetables' satisfies ItemCategory,
+    baseUnit: 'piece' satisfies BaseUnit,
+    displayUnit: 'piece' satisfies UnitCode
+  },
+  vegetableBellPepper: {
+    generatorKey: 'vegetable_bell_pepper',
+    label: 'ピーマン',
+    category: 'vegetables' satisfies ItemCategory,
+    baseUnit: 'piece' satisfies BaseUnit,
+    displayUnit: 'piece' satisfies UnitCode
+  },
+  vegetableCorn: {
+    generatorKey: 'vegetable_corn',
+    label: 'とうもろこし',
+    category: 'vegetables' satisfies ItemCategory,
+    baseUnit: 'piece' satisfies BaseUnit,
+    displayUnit: 'piece' satisfies UnitCode
+  },
+  vegetablePotato: {
+    generatorKey: 'vegetable_potato',
+    label: 'じゃがいも',
+    category: 'vegetables' satisfies ItemCategory,
+    baseUnit: 'piece' satisfies BaseUnit,
+    displayUnit: 'piece' satisfies UnitCode
+  },
+  vegetableMushrooms: {
+    generatorKey: 'vegetable_mushrooms',
+    label: 'きのこ',
+    category: 'vegetables' satisfies ItemCategory,
+    baseUnit: 'pack' satisfies BaseUnit,
+    displayUnit: 'pack' satisfies UnitCode
+  },
+  seafoodShrimp: {
+    generatorKey: 'seafood_shrimp',
+    label: 'えび',
+    category: 'seafood' satisfies ItemCategory,
+    baseUnit: 'pack' satisfies BaseUnit,
+    displayUnit: 'pack' satisfies UnitCode
+  },
+  seafoodScallop: {
+    generatorKey: 'seafood_scallop',
+    label: 'ホタテ',
+    category: 'seafood' satisfies ItemCategory,
+    baseUnit: 'pack' satisfies BaseUnit,
+    displayUnit: 'pack' satisfies UnitCode
+  },
+  seafoodSquid: {
+    generatorKey: 'seafood_squid',
+    label: 'イカ',
+    category: 'seafood' satisfies ItemCategory,
+    baseUnit: 'pack' satisfies BaseUnit,
+    displayUnit: 'pack' satisfies UnitCode
+  },
+  softDrinks: {
+    generatorKey: 'soft_drinks',
+    label: 'ソフトドリンク',
+    category: 'drinks' satisfies ItemCategory,
+    baseUnit: 'ml' satisfies BaseUnit,
+    displayUnit: 'l' satisfies UnitCode
+  },
+  alcohol: {
+    generatorKey: 'alcohol',
+    label: 'アルコール(350ml)',
+    category: 'drinks' satisfies ItemCategory,
+    baseUnit: 'piece' satisfies BaseUnit,
+    displayUnit: 'piece' satisfies UnitCode
+  },
   yakisoba: {
     generatorKey: 'yakisoba',
+    label: '焼きそば',
     category: 'staple' satisfies ItemCategory,
     baseUnit: 'piece' satisfies BaseUnit,
     displayUnit: 'piece' satisfies UnitCode
   }
+} as const;
+
+export const BBQ_GENERATOR_KEYS = Object.values(BBQ_GENERATION_RULES).map((rule) => rule.generatorKey);
+
+export const GENERATION_RULES = {
+  ...BBQ_GENERATION_RULES
 } as const;

--- a/frontend/src/lib/listTemplateRegistry.ts
+++ b/frontend/src/lib/listTemplateRegistry.ts
@@ -1,0 +1,39 @@
+import { fetchListGenerationConfig, type ListGenerationConfigType } from '@/api/listGenerationConfig';
+import { isBBQGenerationConfig } from '@/lib/generation/bbqGenerator';
+import type { ApiError, UUID } from '@/types/api';
+
+export type ListTemplateDefinition = {
+  id: ListGenerationConfigType;
+  routeName: string;
+  createLabel: string;
+  updateLabel: string;
+  description: string;
+  hasConfig(listId: UUID): Promise<boolean>;
+};
+
+function isNotFoundError(err: unknown): boolean {
+  return err !== null && typeof err === 'object' && 'error' in err && (err as ApiError).error === 'not_found';
+}
+
+const BBQ_LIST_TEMPLATE: ListTemplateDefinition = {
+  id: 'bbq',
+  routeName: 'BBQGeneration',
+  createLabel: 'テンプレートから追加',
+  updateLabel: '生成条件を調整',
+  description: 'BBQなどの条件からまとめて候補を作成',
+  async hasConfig(listId: UUID): Promise<boolean> {
+    try {
+      const res = await fetchListGenerationConfig<unknown>(listId, 'bbq');
+      return isBBQGenerationConfig(res.configJson);
+    } catch (err: unknown) {
+      if (isNotFoundError(err)) {
+        return false;
+      }
+      throw err;
+    }
+  }
+};
+
+export const LIST_TEMPLATES: readonly ListTemplateDefinition[] = [BBQ_LIST_TEMPLATE];
+
+export const PRIMARY_LIST_TEMPLATE: ListTemplateDefinition = BBQ_LIST_TEMPLATE;

--- a/frontend/src/lib/quantityDisplay.test.ts
+++ b/frontend/src/lib/quantityDisplay.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { formatQuantity, resolveUnitLabel } from './quantityDisplay';
+
+describe('formatQuantity', () => {
+  it('g数量はカテゴリに関係なく1000g以上の場合だけkg表示にする', () => {
+    expect(formatQuantity({ quantity: 800, baseUnit: 'g', category: 'meat' })).toBe('800g');
+    expect(formatQuantity({ quantity: 1100, baseUnit: 'g', category: 'meat' })).toBe('1.1kg');
+    expect(formatQuantity({ quantity: 1200, baseUnit: 'g', category: 'seafood' })).toBe('1.2kg');
+  });
+
+  it('ml数量は1000ml以上の場合だけL表示にする', () => {
+    expect(formatQuantity({ quantity: 500, baseUnit: 'ml', category: 'drinks' })).toBe('500ml');
+    expect(formatQuantity({ quantity: 4000, baseUnit: 'ml', category: 'drinks' })).toBe('4L');
+    expect(formatQuantity({ quantity: 3150, baseUnit: 'ml', category: 'drinks' })).toBe('3.2L');
+  });
+
+  it('packはカテゴリに応じて表示ラベルを変える', () => {
+    expect(formatQuantity({ quantity: 2, baseUnit: 'pack', category: 'vegetables' })).toBe('2袋');
+    expect(formatQuantity({ quantity: 2, baseUnit: 'pack', category: 'seafood' })).toBe('2パック');
+    expect(formatQuantity({ quantity: 2, baseUnit: 'pack', category: 'meat' })).toBe('2パック');
+  });
+
+  it('単位ラベルをカテゴリと単位から解決する', () => {
+    expect(resolveUnitLabel('pack', 'vegetables')).toBe('袋');
+    expect(resolveUnitLabel('pack', 'seafood')).toBe('パック');
+    expect(resolveUnitLabel('pack', 'meat')).toBe('パック');
+    expect(resolveUnitLabel('piece', 'drinks')).toBe('本');
+    expect(resolveUnitLabel('piece', 'seafood')).toBe('個');
+  });
+});

--- a/frontend/src/lib/quantityDisplay.ts
+++ b/frontend/src/lib/quantityDisplay.ts
@@ -1,0 +1,58 @@
+import type { ItemCategory } from '@/types/item-category';
+import { UNIT_DEFINITIONS, type BaseUnit, type UnitCode } from '@/types/list-generation';
+
+type FormatQuantityInput = {
+  quantity: number;
+  baseUnit: BaseUnit;
+  category: ItemCategory | null;
+  displayUnit?: UnitCode;
+};
+
+export function formatQuantity({ quantity, baseUnit, category, displayUnit }: FormatQuantityInput): string {
+  const resolvedDisplayUnit = resolveDisplayUnit({ quantity, baseUnit, displayUnit });
+  const unitDefinition = UNIT_DEFINITIONS[resolvedDisplayUnit];
+
+  if (!unitDefinition || unitDefinition.baseUnit !== baseUnit) {
+    return `${quantity}${resolveUnitLabel(baseUnit, category)}`;
+  }
+
+  const value = quantity / unitDefinition.factor;
+  const roundedValue = Math.round(value * 10) / 10;
+  const formattedValue = Number.isInteger(roundedValue) ? String(roundedValue) : roundedValue.toFixed(1);
+  return `${formattedValue}${resolveUnitLabel(resolvedDisplayUnit, category)}`;
+}
+
+function resolveDisplayUnit({ quantity, baseUnit, displayUnit }: Omit<FormatQuantityInput, 'category'>): UnitCode {
+  if (baseUnit === 'g' && quantity >= 1000) {
+    return 'kg';
+  }
+  if (baseUnit === 'ml' && quantity >= 1000) {
+    return 'l';
+  }
+  return displayUnit ?? baseUnit;
+}
+
+export function resolveUnitLabel(unitCode: UnitCode, category: ItemCategory | null): string {
+  if (unitCode === 'g') {
+    return 'g';
+  }
+  if (unitCode === 'kg') {
+    return 'kg';
+  }
+  if (unitCode === 'ml') {
+    return 'ml';
+  }
+  if (unitCode === 'l') {
+    return 'L';
+  }
+  if (unitCode === 'piece') {
+    if (category === 'drinks') {
+      return '本';
+    }
+    return '個';
+  }
+  if (unitCode === 'pack' && (category === 'meat' || category === 'seafood')) {
+    return 'パック';
+  }
+  return '袋';
+}

--- a/frontend/src/pages/BBQGenerationPage.vue
+++ b/frontend/src/pages/BBQGenerationPage.vue
@@ -1,0 +1,142 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import BBQGenerationPanel from '../components/BBQGenerationPanel.vue';
+import ContentArea from '../components/ContentArea.vue';
+import LoadingSpinner from '../components/LoadingSpinner.vue';
+import MainButton from '../components/MainButton.vue';
+import { fetchSnapshot } from '@/api/list';
+import { fetchListGenerationConfig } from '@/api/listGenerationConfig';
+import { isBBQGenerationConfig, type BBQGenerationConfig } from '@/lib/generation/bbqGenerator';
+import { getErrorMessage } from '@/lib/http';
+import { addOrUpdateListHistory } from '@/lib/userCache';
+import { useListStore } from '@/stores/list';
+import type { ApiError } from '@/types/api';
+
+export default defineComponent({
+  name: 'BBQGenerationPage',
+  components: {
+    ContentArea,
+    BBQGenerationPanel,
+    LoadingSpinner,
+    MainButton
+  },
+  setup() {
+    const listStore = useListStore();
+    return { listStore };
+  },
+  data(): {
+    currentListId: string | null;
+    generationConfig: BBQGenerationConfig | null;
+    loading: boolean;
+    errorMessage: string;
+  } {
+    return {
+      currentListId: null,
+      generationConfig: null,
+      loading: false,
+      errorMessage: ''
+    };
+  },
+  async created() {
+    const listId = this.$route.params.id as string | undefined;
+    this.currentListId = listId ?? null;
+
+    if (!listId) {
+      this.errorMessage = 'リストIDが指定されていません。';
+      return;
+    }
+
+    await this.loadPageData(listId);
+  },
+  computed: {
+    listName(): string {
+      return this.listStore.name || '買い物リスト';
+    },
+    hasExistingConfig(): boolean {
+      return this.generationConfig !== null;
+    }
+  },
+  methods: {
+    async loadPageData(listId: string): Promise<void> {
+      this.loading = true;
+      this.errorMessage = '';
+
+      try {
+        const snapshot = await fetchSnapshot(listId);
+        this.listStore.applySnapshot(snapshot);
+        addOrUpdateListHistory({ listId, name: snapshot.name });
+        await this.loadGenerationConfig(listId);
+      } catch (err: unknown) {
+        console.error('Failed to load BBQ generation page', err);
+        this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';
+      } finally {
+        this.loading = false;
+      }
+    },
+    async loadGenerationConfig(listId: string): Promise<void> {
+      try {
+        const res = await fetchListGenerationConfig<unknown>(listId, 'bbq');
+        this.generationConfig = isBBQGenerationConfig(res.configJson) ? res.configJson : null;
+      } catch (err: unknown) {
+        if (this.isNotFoundError(err)) {
+          this.generationConfig = null;
+          return;
+        }
+        throw err;
+      }
+    },
+    isNotFoundError(err: unknown): boolean {
+      return err !== null && typeof err === 'object' && 'error' in err && (err as ApiError).error === 'not_found';
+    },
+    navigateToList(): void {
+      if (!this.currentListId) {
+        this.$router.push({ name: 'Welcome' });
+        return;
+      }
+      this.$router.push({
+        name: 'ItemList',
+        params: { id: this.currentListId }
+      });
+    },
+    handleGenerationCompleted(config: BBQGenerationConfig): void {
+      this.generationConfig = config;
+      this.navigateToList();
+    }
+  }
+});
+</script>
+
+<template>
+  <ContentArea v-if="loading" layout="center">
+    <LoadingSpinner message="BBQ テンプレートを読み込み中..." />
+  </ContentArea>
+  <ContentArea v-else>
+    <div class="mx-auto w-full max-w-3xl">
+      <div class="mb-5">
+        <button type="button" class="mb-3 text-sm font-medium text-charcoal-500 hover:text-charcoal-800" @click="navigateToList">
+          ← リストに戻る
+        </button>
+        <h2 class="text-2xl font-black text-charcoal-800">BBQ テンプレート</h2>
+        <p class="mt-1 text-sm text-charcoal-600">{{ listName }} に追加する買い物候補を作ります</p>
+      </div>
+
+      <div v-if="errorMessage" class="mb-4 rounded-lg border border-ember-300 bg-ember-100 p-3 text-sm text-ember-700">
+        {{ errorMessage }}
+      </div>
+
+      <BBQGenerationPanel
+        v-if="!errorMessage"
+        :initial-config="generationConfig"
+        :has-existing-config="hasExistingConfig"
+        :show-header="false"
+        @completed="handleGenerationCompleted"
+        @cancel="navigateToList"
+        @error="errorMessage = $event"
+      />
+
+      <div v-else class="mt-5">
+        <MainButton variant="secondary" @click="navigateToList">リストに戻る</MainButton>
+      </div>
+    </div>
+  </ContentArea>
+</template>

--- a/frontend/src/pages/ItemEditPage.test.ts
+++ b/frontend/src/pages/ItemEditPage.test.ts
@@ -147,7 +147,7 @@ describe('ItemEditPage', () => {
       });
     });
 
-    it('generated_locked は既存の選択カテゴリを保持して送信する', () => {
+    it('generated_locked も生成ルール由来カテゴリを送信する', () => {
       const vm = createVm({
         itemName: '牛肉',
         selectedCategory: 'sweets',
@@ -159,7 +159,7 @@ describe('ItemEditPage', () => {
 
       const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
 
-      expect(payload.category).toBe('sweets');
+      expect(payload.category).toBe('meat');
       expect(payload.itemType).toBe('quantified');
       expect(payload.quantified).toMatchObject({
         quantity: 1000,
@@ -185,7 +185,7 @@ describe('ItemEditPage', () => {
       expect(payload.preparationType).toBeNull();
     });
 
-    it('持参物はカテゴリと数量を送信しない', () => {
+    it('持参物でもカテゴリと数量があれば保持して送信する', () => {
       const vm = createVm({
         itemName: '包丁',
         selectedCategory: 'daily_goods',
@@ -199,16 +199,64 @@ describe('ItemEditPage', () => {
 
       expect(payload).toMatchObject({
         name: '包丁',
-        category: null,
+        category: 'daily_goods',
         preparationType: 'bring',
-        itemType: 'plain'
+        itemType: 'quantified',
+        quantified: {
+          quantity: 1,
+          baseUnit: 'piece',
+          origin: 'manual',
+          regenerationPolicy: 'none',
+          generatorKey: null
+        }
       });
-      expect(payload.quantified).toBeUndefined();
+    });
+
+    it('generated_auto の持参物は自動生成情報を保持して送信する', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        selectedCategory: 'meat',
+        selectedPreparationType: 'bring',
+        itemEditMode: 'generated_auto',
+        quantifiedQuantity: '1000',
+        quantifiedBaseUnit: 'g',
+        quantifiedGeneratorKey: 'beef'
+      });
+
+      const payload = (vm.buildUpdatePayload as (name: string) => Record<string, unknown>)('牛肉');
+
+      expect(payload).toMatchObject({
+        name: '牛肉',
+        category: 'meat',
+        preparationType: 'bring',
+        itemType: 'quantified',
+        quantified: {
+          quantity: 1000,
+          baseUnit: 'g',
+          origin: 'generated',
+          regenerationPolicy: 'auto',
+          generatorKey: 'beef'
+        }
+      });
+    });
+
+    it('generated_auto は数量と単位を空にすると更新不可にする', () => {
+      const vm = createVm({
+        itemName: '牛肉',
+        itemEditMode: 'generated_auto',
+        quantifiedQuantity: '',
+        quantifiedBaseUnit: '',
+        quantifiedGeneratorKey: 'beef'
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(true);
+      expect(vm.hasValidQuantifiedInput).toBe(false);
+      expect(vm.hasRequiredInput).toBe(false);
     });
   });
 
   describe('持参物チェックボックス', () => {
-    it('オンにするとカテゴリと数量入力状態をクリアする', () => {
+    it('オンにしてもカテゴリと数量入力状態を保持する', () => {
       const vm = createVm({
         selectedCategory: 'daily_goods',
         selectedPreparationType: '',
@@ -221,23 +269,35 @@ describe('ItemEditPage', () => {
       (vm.setBringItem as (value: boolean) => void)(true);
 
       expect(vm.selectedPreparationType).toBe('bring');
-      expect(vm.selectedCategory).toBe('');
-      expect(vm.itemEditMode).toBe('plain');
-      expect(vm.quantifiedQuantity).toBe('');
-      expect(vm.quantifiedBaseUnit).toBe('');
-      expect(vm.quantifiedGeneratorKey).toBe('');
+      expect(vm.selectedCategory).toBe('daily_goods');
+      expect(vm.itemEditMode).toBe('manual_none');
+      expect(vm.quantifiedQuantity).toBe('1');
+      expect(vm.quantifiedBaseUnit).toBe('piece');
+      expect(vm.quantifiedGeneratorKey).toBe('beef');
     });
 
-    it('オンの間は数量入力をバリデーション対象にしない', () => {
+    it('オンの間も数量入力があればバリデーション対象にする', () => {
       const vm = createVm({
         itemName: '包丁',
         selectedPreparationType: 'bring',
         quantifiedQuantity: 'abc',
+        quantifiedBaseUnit: 'g'
+      });
+
+      expect(vm.hasQuantifiedDraftInput).toBe(true);
+      expect(vm.hasValidQuantifiedInput).toBe(false);
+      expect(vm.hasRequiredInput).toBe(false);
+    });
+
+    it('オンでも数量入力がなければ通常アイテムとして更新可能にする', () => {
+      const vm = createVm({
+        itemName: '包丁',
+        selectedPreparationType: 'bring',
+        quantifiedQuantity: '',
         quantifiedBaseUnit: ''
       });
 
       expect(vm.hasQuantifiedDraftInput).toBe(false);
-      expect(vm.hasValidQuantifiedInput).toBe(true);
       expect(vm.hasRequiredInput).toBe(true);
     });
   });

--- a/frontend/src/pages/ItemEditPage.vue
+++ b/frontend/src/pages/ItemEditPage.vue
@@ -19,7 +19,8 @@ import { useMutation } from '@/composables/useMutation';
 import { updateItem, type UpdateItemPayload } from '@/api/item';
 import { fetchSnapshot } from '@/api/list';
 import { getErrorMessage } from '@/lib/http';
-import { BBQ_GENERATION_RULES } from '@/lib/listGenerationConstants';
+import { GENERATION_RULES } from '@/lib/listGenerationConstants';
+import { resolveUnitLabel } from '@/lib/quantityDisplay';
 
 const UNASSIGNED_MEMBER_VALUE = '';
 const UNCATEGORIZED_VALUE = '';
@@ -168,7 +169,7 @@ export default defineComponent({
       return this.selectedMemberId || null;
     },
     getSelectedCategory(): ItemCategory | null {
-      if (this.hasSelectedBaseUnit && this.usesGeneratedCategory && this.selectedGeneratorRule) {
+      if (this.usesGeneratedCategory && this.selectedGeneratorRule) {
         return this.selectedGeneratorRule.category;
       }
       return this.selectedCategory || null;
@@ -181,19 +182,9 @@ export default defineComponent({
     },
     setBringItem(value: boolean): void {
       this.selectedPreparationType = value ? 'bring' : UNSET_PREPARATION_TYPE_VALUE;
-      if (value) {
-        this.clearPurchaseDetails();
-      }
     },
     handleBringItemChange(event: Event): void {
       this.setBringItem((event.target as HTMLInputElement).checked);
-    },
-    clearPurchaseDetails(): void {
-      this.selectedCategory = UNCATEGORIZED_VALUE;
-      this.itemEditMode = 'plain';
-      this.quantifiedQuantity = '';
-      this.quantifiedBaseUnit = UNSELECTED_BASE_UNIT_VALUE;
-      this.quantifiedGeneratorKey = UNSET_GENERATOR_KEY_VALUE;
     },
     setQuantifiedBaseUnit(value: string): void {
       this.quantifiedBaseUnit = value as BaseUnit | typeof UNSELECTED_BASE_UNIT_VALUE;
@@ -204,11 +195,11 @@ export default defineComponent({
     buildUpdatePayload(normalizedName: string): UpdateItemPayload {
       const payload: UpdateItemPayload = {
         name: normalizedName,
-        category: this.isBringItem ? null : this.getSelectedCategory(),
+        category: this.getSelectedCategory(),
         preparationType: this.getSelectedPreparationType()
       };
 
-      if (!this.isBringItem && this.hasSelectedBaseUnit) {
+      if (this.hasSelectedBaseUnit) {
         payload.itemType = 'quantified';
         payload.quantified = {
           quantity: this.parsedQuantifiedQuantity,
@@ -319,16 +310,13 @@ export default defineComponent({
       return (
         !!this.normalizedItemName &&
         (!this.isCompleted || !!this.getCurrentSelectedMemberId()) &&
-        (this.isBringItem || !this.hasQuantifiedDraftInput || this.hasValidQuantifiedInput)
+        (!this.hasQuantifiedDraftInput || this.hasValidQuantifiedInput)
       );
     },
     hasQuantifiedDraftInput(): boolean {
-      return !this.isBringItem && (this.hasSelectedBaseUnit || !!this.normalizedQuantifiedQuantity);
+      return this.isGeneratedMode || this.hasSelectedBaseUnit || !!this.normalizedQuantifiedQuantity;
     },
     hasValidQuantifiedInput(): boolean {
-      if (this.isBringItem) {
-        return true;
-      }
       return (
         !!this.normalizedItemName &&
         !!this.normalizedQuantifiedQuantity &&
@@ -346,7 +334,7 @@ export default defineComponent({
       return this.itemEditMode === 'generated_auto' || this.itemEditMode === 'generated_locked';
     },
     usesGeneratedCategory(): boolean {
-      return this.itemEditMode === 'generated_auto';
+      return this.isGeneratedMode;
     },
     requiresGeneratorKey(): boolean {
       return this.isGeneratedMode;
@@ -370,11 +358,20 @@ export default defineComponent({
       }
       return Object.values(ITEM_CATEGORIES).find((itemCategory) => itemCategory.code === category)?.label ?? category;
     },
-    selectedGeneratorRule(): (typeof BBQ_GENERATION_RULES)[keyof typeof BBQ_GENERATION_RULES] | undefined {
+    generatedItemNotice(): string | null {
+      if (this.itemEditMode === 'generated_auto') {
+        return '自動生成アイテムです。数量・単位を変更すると、次回の再生成では更新されなくなります。持参するだけなら自動生成情報は保持されます。';
+      }
+      if (this.itemEditMode === 'generated_locked') {
+        return '手動編集済みの自動生成アイテムです。次回の再生成では変更されません。';
+      }
+      return null;
+    },
+    selectedGeneratorRule(): (typeof GENERATION_RULES)[keyof typeof GENERATION_RULES] | undefined {
       if (!this.quantifiedGeneratorKey) {
         return undefined;
       }
-      return Object.values(BBQ_GENERATION_RULES).find((rule) => rule.generatorKey === this.quantifiedGeneratorKey);
+      return Object.values(GENERATION_RULES).find((rule) => rule.generatorKey === this.quantifiedGeneratorKey);
     },
     isLoading(): boolean {
       return this.mutationLoading || this.snapshotLoading;
@@ -394,11 +391,12 @@ export default defineComponent({
       return this.selectedPreparationType === 'bring';
     },
     baseUnitOptions(): Array<{ id: string; name: string }> {
+      const category = this.getSelectedCategory();
       return [
         { id: UNSELECTED_BASE_UNIT_VALUE, name: '未選択' },
         ...Object.values(UNIT_DEFINITIONS)
           .filter((definition) => definition.code === definition.baseUnit)
-          .map((definition) => ({ id: definition.baseUnit, name: definition.label }))
+          .map((definition) => ({ id: definition.baseUnit, name: resolveUnitLabel(definition.baseUnit, category) }))
       ];
     }
   }
@@ -445,14 +443,21 @@ export default defineComponent({
           <span class="min-w-0 truncate">持参する</span>
         </label>
 
-        <div v-if="!isBringItem">
+        <p
+          v-if="generatedItemNotice"
+          class="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm leading-relaxed text-charcoal-700"
+        >
+          {{ generatedItemNotice }}
+        </p>
+
+        <div>
           <label for="itemCategory" class="mb-2 block text-sm font-medium text-charcoal-700">
             カテゴリ
-            <span v-if="hasSelectedBaseUnit && usesGeneratedCategory" class="text-xs font-normal text-charcoal-500">
+            <span v-if="usesGeneratedCategory" class="text-xs font-normal text-charcoal-500">
               （自動設定）
             </span>
           </label>
-          <template v-if="hasSelectedBaseUnit && usesGeneratedCategory">
+          <template v-if="usesGeneratedCategory">
             <p class="rounded-lg border border-wood-200 bg-white px-3 py-2 text-sm font-semibold text-charcoal-700">
               {{ currentCategoryLabel }}
             </p>
@@ -467,7 +472,7 @@ export default defineComponent({
           />
         </div>
 
-        <div v-if="!isBringItem">
+        <div>
           <label for="quantifiedQuantity" class="mb-2 block text-sm font-medium text-charcoal-700"> 数量(単位) </label>
           <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
             <TextInput

--- a/frontend/src/pages/ItemListPage.vue
+++ b/frontend/src/pages/ItemListPage.vue
@@ -10,6 +10,7 @@ import IconButton from '../components/IconButton.vue';
 import IconEdit from '../components/icons/IconEdit.vue';
 import IconRefresh from '../components/icons/IconRefresh.vue';
 import IconCelebration from '../components/icons/IconCelebration.vue';
+import IconSparkles from '../components/icons/IconSparkles.vue';
 import type { Item } from '../types/item';
 import type { ItemCategory } from '../types/item-category';
 import type { ItemPreparationType } from '../types/item-preparation-type';
@@ -21,6 +22,7 @@ import { useListStore } from '@/stores/list';
 import { getErrorMessage } from '@/lib/http';
 import { getSelectedMemberId, setSelectedMemberId, addOrUpdateListHistory } from '@/lib/userCache';
 import { filterItems } from '@/utils/item-filtering';
+import { PRIMARY_LIST_TEMPLATE } from '@/lib/listTemplateRegistry';
 
 export default defineComponent({
   name: 'ItemListPage',
@@ -34,7 +36,8 @@ export default defineComponent({
     IconButton,
     IconEdit,
     IconRefresh,
-    IconCelebration
+    IconCelebration,
+    IconSparkles
   },
   data(): {
     currentListId: string | null;
@@ -46,6 +49,8 @@ export default defineComponent({
     errorMessage: string;
     fallbackListName: string;
     snapshotLoading: boolean;
+    hasGenerationConfig: boolean;
+    generationConfigLoading: boolean;
   } {
     return {
       currentListId: null,
@@ -56,7 +61,9 @@ export default defineComponent({
       preparationTypeFilter: null,
       errorMessage: '',
       fallbackListName: '',
-      snapshotLoading: false
+      snapshotLoading: false,
+      hasGenerationConfig: false,
+      generationConfigLoading: false
     };
   },
   setup() {
@@ -126,6 +133,12 @@ export default defineComponent({
     },
     formattedLastItemActivityAt(): string | null {
       return formatActivityAt(this.listStore.lastItemActivityAt);
+    },
+    generationButtonLabel(): string {
+      return this.hasGenerationConfig ? PRIMARY_LIST_TEMPLATE.updateLabel : PRIMARY_LIST_TEMPLATE.createLabel;
+    },
+    generationButtonDescription(): string {
+      return this.hasGenerationConfig ? '条件を見直して再生成できます' : PRIMARY_LIST_TEMPLATE.description;
     }
   },
   watch: {
@@ -157,12 +170,32 @@ export default defineComponent({
         }
 
         addOrUpdateListHistory({ listId, name: snapshot.name });
+        await this.loadGenerationConfig(listId);
       } catch (err: unknown) {
         console.error('Failed to load snapshot', err);
         this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';
       } finally {
         this.snapshotLoading = false;
       }
+    },
+    async loadGenerationConfig(listId: string) {
+      this.generationConfigLoading = true;
+
+      try {
+        this.hasGenerationConfig = await PRIMARY_LIST_TEMPLATE.hasConfig(listId);
+      } catch (err: unknown) {
+        console.error('Failed to load generation config', err);
+        this.errorMessage = getErrorMessage(err) ?? '生成設定の取得に失敗しました。';
+      } finally {
+        this.generationConfigLoading = false;
+      }
+    },
+    openGenerationPage(): void {
+      this.errorMessage = '';
+      this.$router.push({
+        name: PRIMARY_LIST_TEMPLATE.routeName,
+        params: { id: this.currentListId ?? this.$route.params.id }
+      });
     },
     handleMemberSelect(selectedId: string) {
       this.selectedMemberId = selectedId;
@@ -208,7 +241,7 @@ export default defineComponent({
   <ContentArea v-else>
     <div class="w-full">
       <!-- リストタイトル -->
-      <div class="mb-8">
+      <div :class="items.length > 0 ? 'mb-4' : 'mb-8'">
         <div class="flex flex-row justify-center space-x-2 items-center mb-1">
           <h2 class="text-2xl font-black text-charcoal-800 text-center">
             {{ listName }}
@@ -218,6 +251,19 @@ export default defineComponent({
           </IconButton>
         </div>
         <p class="text-sm text-charcoal-600 text-center">{{ memberNames }}</p>
+        <div v-if="items.length > 0" class="mt-2 flex justify-end">
+          <button
+            type="button"
+            class="inline-flex items-center gap-0.5 rounded-md px-1.5 py-2 text-xs font-medium text-charcoal-500 transition-colors hover:bg-charcoal-100 hover:text-charcoal-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-charcoal-300 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="generationConfigLoading"
+            :aria-label="generationConfigLoading ? '生成設定を確認中' : generationButtonLabel"
+            :title="generationConfigLoading ? '生成設定を確認中' : generationButtonLabel"
+            @click="openGenerationPage"
+          >
+            <IconSparkles />
+            <span>{{ generationConfigLoading ? '確認中...' : generationButtonLabel }}</span>
+          </button>
+        </div>
       </div>
 
       <!-- エラーメッセージ -->
@@ -233,6 +279,29 @@ export default defineComponent({
         @error="errorMessage = $event"
       />
 
+      <div v-if="items.length === 0" class="-mt-3 mb-4">
+        <button
+          type="button"
+          class="group flex w-full items-center gap-3 rounded-lg border border-wood-200 bg-white px-3 py-2 text-left shadow-sm transition-[background-color,border-color,box-shadow] hover:border-wood-300 hover:bg-wood-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-wood-300 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="generationConfigLoading"
+          @click="openGenerationPage"
+        >
+          <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-wood-100 text-ember-700">
+            <IconSparkles />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="block truncate text-sm font-semibold text-charcoal-800">
+              {{ generationConfigLoading ? '確認中...' : generationButtonLabel }}
+            </span>
+            <span class="mt-0.5 block truncate text-xs text-charcoal-500">
+              {{ generationConfigLoading ? '生成設定を確認しています' : generationButtonDescription }}
+            </span>
+          </span>
+          <span class="shrink-0 text-lg leading-none text-charcoal-400 transition-transform group-hover:translate-x-0.5">
+            &gt;
+          </span>
+        </button>
+      </div>
       <!-- 検索ボックス -->
       <div v-if="items.length > 0" class="mb-4">
         <div class="flex px-2 py-2 border border-charcoal-200 bg-charcoal-100 rounded-md">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,6 +5,7 @@ const WelcomePage = () => import('../pages/WelcomePage.vue');
 const CreateListPage = () => import('../pages/CreateListPage.vue');
 const ShareListPage = () => import('../pages/ShareListPage.vue');
 const ItemListPage = () => import('../pages/ItemListPage.vue');
+const BBQGenerationPage = () => import('../pages/BBQGenerationPage.vue');
 const ListEditPage = () => import('../pages/ListEditPage.vue');
 const ItemEditPage = () => import('../pages/ItemEditPage.vue');
 const TermsPage = () => import('../pages/TermsPage.vue');
@@ -30,6 +31,11 @@ const routes: RouteRecordRaw[] = [
     path: '/lists/:id',
     name: 'ItemList',
     component: ItemListPage
+  },
+  {
+    path: '/lists/:id/templates/bbq',
+    name: 'BBQGeneration',
+    component: BBQGenerationPage
   },
   {
     path: '/lists/:id/edit',

--- a/frontend/src/types/list-generation.ts
+++ b/frontend/src/types/list-generation.ts
@@ -3,12 +3,12 @@ export const ITEM_TYPE_VALUES = ['plain', 'quantified'] as const;
 export type ItemType = (typeof ITEM_TYPE_VALUES)[number];
 
 export const UNIT_DEFINITIONS = {
-  g: { code: 'g', label: 'g', baseUnit: 'g', factor: 1 },
-  kg: { code: 'kg', label: 'kg', baseUnit: 'g', factor: 1000 },
-  ml: { code: 'ml', label: 'ml', baseUnit: 'ml', factor: 1 },
-  l: { code: 'l', label: 'L', baseUnit: 'ml', factor: 1000 },
-  piece: { code: 'piece', label: '個', baseUnit: 'piece', factor: 1 },
-  pack: { code: 'pack', label: '袋', baseUnit: 'pack', factor: 1 }
+  g: { code: 'g', baseUnit: 'g', factor: 1 },
+  kg: { code: 'kg', baseUnit: 'g', factor: 1000 },
+  ml: { code: 'ml', baseUnit: 'ml', factor: 1 },
+  l: { code: 'l', baseUnit: 'ml', factor: 1000 },
+  piece: { code: 'piece', baseUnit: 'piece', factor: 1 },
+  pack: { code: 'pack', baseUnit: 'pack', factor: 1 }
 } as const;
 
 export type UnitCode = keyof typeof UNIT_DEFINITIONS;


### PR DESCRIPTION
This pull request introduces a new API for managing list generation configurations and syncing generated items, along with several supporting DTOs and service implementations. It also expands and refines the BBQ generation rules and unit definitions, and adds a repository method for fetching generated items by generator keys.

**API and Service Layer Additions:**

* Introduced `GeneratedItemCommandController` and `GeneratedItemCommandService` to handle validation and syncing of generated items to a list, including comprehensive error handling and normalization of input. [[1]](diffhunk://#diff-2775df9bf36817ade8d104f6a4a993729432542b64fb3a73d950785f91c0ce63R1-R40) [[2]](diffhunk://#diff-4621889381c02c5d6917ed0fc471977292cee3a4dec1b6a748b8ee9d638d9f55R1-R163)
* Added `ListGenerationConfigController` for getting and upserting generation configurations per list and type, using new request/response DTOs. [[1]](diffhunk://#diff-53870ddcedf4b67e9db41f5fd3b8616999cf5dfb0e1448806667c85a41ac0c39R1-R57) [[2]](diffhunk://#diff-2d5c64e2738fff324c3f3957a0f6f0482491cecd047b5aef636a20cf3f33744bR1-R21) [[3]](diffhunk://#diff-6ce41e4ad53ba3cb082134e606a379bb1dd4ecab0473269442c11de8993058e5R1-R23)
* Added DTOs for syncing generated items: `SyncGeneratedItemsRequest` (validates input structure), and `SyncGeneratedItemsResponse` (returns synced items and deleted item IDs). [[1]](diffhunk://#diff-99a31cade5888fd31382ba2241b6af24ed3385650ca67539de90e61c8cf8e8fbR1-R29) [[2]](diffhunk://#diff-5c109ffa6a72a012879437ab8906f3a74809371bd85e6228b45a7239832858a2R1-R16)

**Domain and Repository Enhancements:**

* Expanded BBQ generation rules in `BBQGenerationRules` to cover more generator keys (e.g., chicken, sausage, various vegetables, seafood, drinks), and standardized units for meat to grams.
* Refined unit definitions in `UnitDefinitions`, simplifying the `UnitDefinition` record and removing the unused `label` field.
* Added a repository method `findGeneratedItemsByGeneratorKeys` in `ItemRepository` to efficiently fetch generated items by their generator keys for a given list.