### PR TITLE
Enhance item handling with completed status and improved filtering

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
@@ -98,6 +98,7 @@ public class GeneratedItemSyncCommandService {
     List<Item> deletedItems =
         existingItems.values().stream()
             .filter(item -> !generatedKeys.contains(item.getQuantified().getGeneratorKey()))
+            .filter(item -> !item.isCompleted())
             .filter(item -> item.getQuantified().getRegenerationPolicy() == RegenerationPolicy.AUTO)
             .toList();
 
@@ -121,7 +122,8 @@ public class GeneratedItemSyncCommandService {
       ItemList list, GeneratedItemUpdateCommand command, Map<String, Item> existingItems) {
     Item existingItem = existingItems.get(command.generatorKey());
     if (existingItem != null) {
-      if (existingItem.getQuantified().getRegenerationPolicy() == RegenerationPolicy.LOCKED) {
+      if (existingItem.isCompleted()
+          || existingItem.getQuantified().getRegenerationPolicy() == RegenerationPolicy.LOCKED) {
         return null;
       }
       updateExistingGeneratedAutoItem(existingItem, command);

--- a/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
@@ -135,6 +135,34 @@ class GeneratedItemCommandServiceTest {
   }
 
   @Test
+  @DisplayName("既存の完了済みgenerated+auto itemは更新も重複追加もしないこと")
+  void syncGeneratedItemsSkipsExistingCompletedAutoItem() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item existingItem = generatedCompletedAutoItem(list, "牛肉カスタム", 1000L, "beef");
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
+        .thenReturn(List.of(existingItem));
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(existingItem.getQuantified().getQuantity()).isEqualTo(1000L);
+    assertThat(existingItem.getQuantified().getRegenerationPolicy())
+        .isEqualTo(RegenerationPolicy.AUTO);
+    assertThat(existingItem.isCompleted()).isTrue();
+    assertThat(result.getData().getItems()).isEmpty();
+    assertThat(result.getData().getDeletedItemIds()).isEmpty();
+  }
+
+  @Test
   @DisplayName("生成候補から外れた既存generated+auto itemは削除すること")
   void syncGeneratedItemsDeletesExistingAutoItemMissingFromCandidates() {
     UUID listId = UUID.randomUUID();
@@ -168,6 +196,33 @@ class GeneratedItemCommandServiceTest {
     UUID listId = UUID.randomUUID();
     ItemList list = itemList(listId);
     Item seafood = generatedLockedItem(list, "えび", 1L, "seafood_shrimp");
+    seafood.setId(UUID.randomUUID());
+    seafood.setCategory(ItemCategory.SEAFOOD);
+    seafood.getQuantified().setBaseUnit(BaseUnit.PACK);
+    SyncGeneratedItemsRequest request =
+        SyncGeneratedItemsRequest.builder()
+            .generatorKeysInScope(List.of("beef", "seafood_shrimp"))
+            .items(List.of(generatedItemRequest("牛肉", 1500L, "beef")))
+            .build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+    when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
+        .thenReturn(List.of(seafood));
+    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(4L);
+
+    var result = service.syncGeneratedItems(listId, request);
+
+    assertThat(result.getData().getItems()).hasSize(1);
+    assertThat(result.getData().getDeletedItemIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("生成候補から外れた既存の完了済みgenerated+auto itemは削除しないこと")
+  void syncGeneratedItemsKeepsExistingCompletedAutoItemMissingFromCandidates() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId);
+    Item seafood = generatedCompletedAutoItem(list, "えび", 1L, "seafood_shrimp");
     seafood.setId(UUID.randomUUID());
     seafood.setCategory(ItemCategory.SEAFOOD);
     seafood.getQuantified().setBaseUnit(BaseUnit.PACK);
@@ -268,6 +323,14 @@ class GeneratedItemCommandServiceTest {
       ItemList list, String name, long quantity, String generatorKey) {
     Item item = generatedAutoItem(list, name, quantity, generatorKey);
     item.getQuantified().setRegenerationPolicy(RegenerationPolicy.LOCKED);
+    return item;
+  }
+
+  private static Item generatedCompletedAutoItem(
+      ItemList list, String name, long quantity, String generatorKey) {
+    Item item = generatedAutoItem(list, name, quantity, generatorKey);
+    item.setCompleted(true);
+    item.setCompletedAt(java.time.Instant.parse("2024-01-01T00:00:00Z"));
     return item;
   }
 

--- a/frontend/src/components/BBQGenerationPanel.vue
+++ b/frontend/src/components/BBQGenerationPanel.vue
@@ -64,7 +64,7 @@ const ADJUSTMENT_TARGETS: Array<{ key: keyof BBQGenerationConfig['adjustments'];
 type GenerationPreviewRow = {
   key: string;
   name: string;
-  status: 'new' | 'update' | 'delete' | 'unchanged' | 'locked';
+  status: 'new' | 'update' | 'delete' | 'unchanged' | 'locked' | 'completed';
   beforeQuantity: string | null;
   afterQuantity: string | null;
   beforeRawQuantity: number | null;
@@ -171,7 +171,7 @@ export default defineComponent({
     applicableCandidates(): GeneratedItemCandidate[] {
       return this.candidates.filter((candidate) => {
         const existingItem = this.existingGeneratedItemsByGeneratorKey.get(candidate.generatorKey);
-        return existingItem?.quantified?.regenerationPolicy !== 'locked';
+        return !existingItem?.completed && existingItem?.quantified?.regenerationPolicy !== 'locked';
       });
     },
     previewRows(): GenerationPreviewRow[] {
@@ -202,11 +202,11 @@ export default defineComponent({
           };
         }
 
-        if (existingItem.quantified.regenerationPolicy === 'locked') {
+        if (existingItem.completed || existingItem.quantified.regenerationPolicy === 'locked') {
           return {
             key: candidate.generatorKey,
             name: existingItem.name,
-            status: 'locked',
+            status: existingItem.completed ? 'completed' : 'locked',
             beforeQuantity: this.displayExistingQuantity(existingItem),
             afterQuantity: null,
             beforeRawQuantity: existingItem.quantified.quantity,
@@ -236,7 +236,7 @@ export default defineComponent({
         .map(([generatorKey, item]): GenerationPreviewRow => ({
           key: generatorKey,
           name: item.name,
-          status: item.quantified.regenerationPolicy === 'locked' ? 'locked' : 'delete',
+          status: item.completed ? 'completed' : item.quantified.regenerationPolicy === 'locked' ? 'locked' : 'delete',
           beforeQuantity: this.displayExistingQuantity(item),
           afterQuantity: null,
           beforeRawQuantity: item.quantified.quantity,
@@ -330,6 +330,9 @@ export default defineComponent({
       if (status === 'locked') {
         return '変更対象外';
       }
+      if (status === 'completed') {
+        return '完了済';
+      }
       return '変更なし';
     },
     previewStatusClass(status: GenerationPreviewRow['status']): string {
@@ -343,6 +346,9 @@ export default defineComponent({
         return 'border border-red-200 bg-white text-red-700';
       }
       if (status === 'locked') {
+        return 'bg-charcoal-100 text-charcoal-600';
+      }
+      if (status === 'completed') {
         return 'bg-charcoal-100 text-charcoal-600';
       }
       return 'bg-transparent text-charcoal-500';

--- a/frontend/src/components/BBQGenerationPanel.vue
+++ b/frontend/src/components/BBQGenerationPanel.vue
@@ -84,6 +84,16 @@ function isGeneratedItemWithKey(item: Item): item is GeneratedItemWithKey {
   );
 }
 
+function getStaleGeneratedRowStatus(item: GeneratedItemWithKey): GenerationPreviewRow['status'] {
+  if (item.completed) {
+    return 'completed';
+  }
+  if (item.quantified.regenerationPolicy === 'locked') {
+    return 'locked';
+  }
+  return 'delete';
+}
+
 function cloneBBQGenerationConfig(config: BBQGenerationConfig): BBQGenerationConfig {
   const defaults = createDefaultBBQGenerationConfig();
   const rawBalance = (config.answers as { balance?: string }).balance;
@@ -236,7 +246,7 @@ export default defineComponent({
         .map(([generatorKey, item]): GenerationPreviewRow => ({
           key: generatorKey,
           name: item.name,
-          status: item.completed ? 'completed' : item.quantified.regenerationPolicy === 'locked' ? 'locked' : 'delete',
+          status: getStaleGeneratedRowStatus(item),
           beforeQuantity: this.displayExistingQuantity(item),
           afterQuantity: null,
           beforeRawQuantity: item.quantified.quantity,
@@ -345,10 +355,7 @@ export default defineComponent({
       if (status === 'delete') {
         return 'border border-red-200 bg-white text-red-700';
       }
-      if (status === 'locked') {
-        return 'bg-charcoal-100 text-charcoal-600';
-      }
-      if (status === 'completed') {
+      if (status === 'locked' || status === 'completed') {
         return 'bg-charcoal-100 text-charcoal-600';
       }
       return 'bg-transparent text-charcoal-500';


### PR DESCRIPTION
This pull request updates both the backend and frontend to properly handle "completed" auto-generated items, ensuring they are not updated, duplicated, or deleted during synchronization, and are clearly indicated in the UI. The main changes add logic to treat completed items as immutable, extend test coverage for these scenarios, and adjust the generation panel to display and style completed items distinctly.

**Backend logic changes:**

* Prevent updating or duplicating completed auto-generated items in `GeneratedItemSyncCommandService` by treating them similarly to locked items (`upsertGeneratedItem` and filtering in `syncGeneratedItems`). [[1]](diffhunk://#diff-21158eb46e078a39975d60840d2cc7e31491e1b9a4c3820c2ac40771d35fc064R101) [[2]](diffhunk://#diff-21158eb46e078a39975d60840d2cc7e31491e1b9a4c3820c2ac40771d35fc064L124-R126)

**Test coverage:**

* Add tests to verify that completed auto-generated items are neither updated nor deleted, even when missing from candidates, in `GeneratedItemCommandServiceTest`. [[1]](diffhunk://#diff-24ab7b67a883d4e8a1ff973990e8c5f7aa1858c8dfbc90a0aa3a8d014a104369R137-R164) [[2]](diffhunk://#diff-24ab7b67a883d4e8a1ff973990e8c5f7aa1858c8dfbc90a0aa3a8d014a104369R220-R246)
* Add helper method `generatedCompletedAutoItem` for test setup.

**Frontend/UI changes (`BBQGenerationPanel.vue`):**

* Add a new `completed` status to the preview row type and logic, ensuring completed items are displayed as "完了済" and styled like locked items. [[1]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L67-R67) [[2]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L205-R209) [[3]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L239-R239) [[4]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R333-R335) [[5]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R351-R353)
* Exclude completed items from applicable candidates for updates.

These changes ensure completed auto-generated items are consistently protected from modification and clearly communicated to users in the UI.