### PR TITLE
Implement and refactor exclusion logic for BBQ configuration

### DIFF
--- a/frontend/src/components/BBQGenerationPanel.vue
+++ b/frontend/src/components/BBQGenerationPanel.vue
@@ -7,6 +7,7 @@ import MainButton from './MainButton.vue';
 import {
   createDefaultBBQGenerationConfig,
   generateBBQItems,
+  normalizeBBQGenerationConfig,
   type BBQGenerationConfig,
   type BBQGenerationLevel,
   type BBQGenerationBalance,
@@ -15,6 +16,7 @@ import {
   type BBQSeafoodLevel,
   type GeneratedItemCandidate
 } from '@/lib/generation/bbqGenerator';
+import { isGeneratorKeyExcluded, setGeneratorKeyExcluded } from '@/lib/generation/generationConfig';
 import { saveListGenerationConfig } from '@/api/listGenerationConfig';
 import { syncGeneratedItems } from '@/api/item';
 import { useListStore } from '@/stores/list';
@@ -64,7 +66,7 @@ const ADJUSTMENT_TARGETS: Array<{ key: keyof BBQGenerationConfig['adjustments'];
 type GenerationPreviewRow = {
   key: string;
   name: string;
-  status: 'new' | 'update' | 'delete' | 'unchanged' | 'locked' | 'completed';
+  status: 'new' | 'update' | 'delete' | 'excluded' | 'unchanged' | 'locked' | 'completed';
   beforeQuantity: string | null;
   afterQuantity: string | null;
   beforeRawQuantity: number | null;
@@ -95,20 +97,7 @@ function getStaleGeneratedRowStatus(item: GeneratedItemWithKey): GenerationPrevi
 }
 
 function cloneBBQGenerationConfig(config: BBQGenerationConfig): BBQGenerationConfig {
-  const defaults = createDefaultBBQGenerationConfig();
-  const rawBalance = (config.answers as { balance?: string }).balance;
-  const balance = rawBalance === 'seafood' ? defaults.answers.balance : config.answers.balance;
-  return {
-    version: 1,
-    answers: {
-      ...defaults.answers,
-      ...config.answers,
-      balance,
-      alcoholLevel: config.answers.alcoholLevel,
-      seafoodLevel: config.answers.seafoodLevel
-    },
-    adjustments: { ...defaults.adjustments, ...config.adjustments }
-  };
+  return normalizeBBQGenerationConfig(config);
 }
 
 export default defineComponent({
@@ -180,6 +169,9 @@ export default defineComponent({
     },
     applicableCandidates(): GeneratedItemCandidate[] {
       return this.candidates.filter((candidate) => {
+        if (isGeneratorKeyExcluded(this.config, candidate.generatorKey)) {
+          return false;
+        }
         const existingItem = this.existingGeneratedItemsByGeneratorKey.get(candidate.generatorKey);
         return !existingItem?.completed && existingItem?.quantified?.regenerationPolicy !== 'locked';
       });
@@ -189,7 +181,7 @@ export default defineComponent({
         return this.candidates.map((candidate) => ({
           key: candidate.generatorKey,
           name: candidate.name,
-          status: 'new',
+          status: isGeneratorKeyExcluded(this.config, candidate.generatorKey) ? 'excluded' : 'new',
           beforeQuantity: null,
           afterQuantity: this.displayQuantity(candidate),
           beforeRawQuantity: null,
@@ -200,6 +192,18 @@ export default defineComponent({
       const candidateKeys = new Set(this.candidates.map((candidate) => candidate.generatorKey));
       const candidateRows = this.candidates.map((candidate): GenerationPreviewRow => {
         const existingItem = this.existingGeneratedItemsByGeneratorKey.get(candidate.generatorKey);
+        if (isGeneratorKeyExcluded(this.config, candidate.generatorKey)) {
+          return {
+            key: candidate.generatorKey,
+            name: existingItem?.name ?? candidate.name,
+            status: 'excluded',
+            beforeQuantity: existingItem ? this.displayExistingQuantity(existingItem) : null,
+            afterQuantity: existingItem ? null : this.displayQuantity(candidate),
+            beforeRawQuantity: existingItem?.quantified.quantity ?? null,
+            afterRawQuantity: existingItem ? null : candidate.quantity
+          };
+        }
+
         if (!existingItem?.quantified) {
           return {
             key: candidate.generatorKey,
@@ -243,15 +247,17 @@ export default defineComponent({
           const [generatorKey] = entry;
           return !candidateKeys.has(generatorKey) && templateGeneratorKeys.has(generatorKey);
         })
-        .map(([generatorKey, item]): GenerationPreviewRow => ({
-          key: generatorKey,
-          name: item.name,
-          status: getStaleGeneratedRowStatus(item),
-          beforeQuantity: this.displayExistingQuantity(item),
-          afterQuantity: null,
-          beforeRawQuantity: item.quantified.quantity,
-          afterRawQuantity: null
-        }));
+        .map(
+          ([generatorKey, item]): GenerationPreviewRow => ({
+            key: generatorKey,
+            name: item.name,
+            status: getStaleGeneratedRowStatus(item),
+            beforeQuantity: this.displayExistingQuantity(item),
+            afterQuantity: null,
+            beforeRawQuantity: item.quantified.quantity,
+            afterRawQuantity: null
+          })
+        );
 
       return [...candidateRows, ...staleGeneratedRows];
     },
@@ -259,15 +265,19 @@ export default defineComponent({
       if (!this.hasExistingConfig || !this.showOnlyChangedRows) {
         return this.previewRows;
       }
-      return this.previewRows.filter((row) => row.status === 'update' || row.status === 'new' || row.status === 'delete');
+      return this.previewRows.filter(
+        (row) => row.status === 'update' || row.status === 'new' || row.status === 'delete' || row.status === 'excluded'
+      );
     },
     hasApplicablePreviewChanges(): boolean {
-      return this.previewRows.some((row) => row.status === 'update' || row.status === 'new' || row.status === 'delete');
+      return this.previewRows.some(
+        (row) => row.status === 'update' || row.status === 'new' || row.status === 'delete' || row.status === 'excluded'
+      );
     },
     canApply(): boolean {
       return (
         this.config.answers.adultCount + this.config.answers.childCount > 0 &&
-        (this.hasExistingConfig ? this.hasApplicablePreviewChanges : this.candidates.length > 0) &&
+        (this.hasExistingConfig ? this.hasApplicablePreviewChanges : this.applicableCandidates.length > 0) &&
         !this.mutationLoading
       );
     },
@@ -320,6 +330,19 @@ export default defineComponent({
     toggleShowOnlyChangedRows(): void {
       this.showOnlyChangedRows = !this.showOnlyChangedRows;
     },
+    setCandidateExcluded(generatorKey: string, excluded: boolean): void {
+      this.config = setGeneratorKeyExcluded(this.config, generatorKey, excluded);
+    },
+    shouldShowTargetToggle(row: GenerationPreviewRow): boolean {
+      return row.status === 'new' || row.status === 'update' || row.status === 'excluded';
+    },
+    targetToggleButtonClass(isActive: boolean): string[] {
+      return [
+        'min-w-12 rounded-full px-2 py-1 text-xs font-medium transition-colors',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-wood-300',
+        isActive ? 'bg-wood-200 text-charcoal-800 shadow-sm' : 'bg-charcoal-50 text-charcoal-600 hover:bg-wood-50'
+      ];
+    },
     displayQuantity(item: GeneratedItemCandidate): string {
       return formatQuantity(item);
     },
@@ -340,6 +363,9 @@ export default defineComponent({
       if (status === 'delete') {
         return '削除';
       }
+      if (status === 'excluded') {
+        return '対象外';
+      }
       if (status === 'locked') {
         return '変更対象外';
       }
@@ -358,6 +384,9 @@ export default defineComponent({
       if (status === 'delete') {
         return 'border border-red-200 bg-white text-red-700';
       }
+      if (status === 'excluded') {
+        return 'border border-charcoal-200 bg-charcoal-50 text-charcoal-600';
+      }
       if (status === 'locked' || status === 'completed') {
         return 'bg-charcoal-100 text-charcoal-600';
       }
@@ -368,13 +397,24 @@ export default defineComponent({
       if (row.status === 'delete' && position === 'before') {
         return [...baseClass, 'bg-red-50 text-red-700'];
       }
+      if (row.status === 'excluded' && position === 'before') {
+        return [...baseClass, 'bg-charcoal-100 text-charcoal-600'];
+      }
       if (row.status !== 'update' || position !== 'after') {
         return [...baseClass, position === 'after' ? 'bg-wood-100' : 'bg-charcoal-50'];
       }
-      if (row.beforeRawQuantity != null && row.afterRawQuantity != null && row.afterRawQuantity > row.beforeRawQuantity) {
+      if (
+        row.beforeRawQuantity != null &&
+        row.afterRawQuantity != null &&
+        row.afterRawQuantity > row.beforeRawQuantity
+      ) {
         return [...baseClass, 'bg-amber-100 text-amber-800'];
       }
-      if (row.beforeRawQuantity != null && row.afterRawQuantity != null && row.afterRawQuantity < row.beforeRawQuantity) {
+      if (
+        row.beforeRawQuantity != null &&
+        row.afterRawQuantity != null &&
+        row.afterRawQuantity < row.beforeRawQuantity
+      ) {
         return [...baseClass, 'bg-charcoal-100 text-charcoal-700'];
       }
       return [...baseClass, 'bg-wood-100'];
@@ -608,11 +648,7 @@ export default defineComponent({
             <IconChevronDown />
           </span>
         </button>
-        <div
-          v-if="showAdjustmentPanel"
-          id="bbq-adjustment-panel"
-          class="grid gap-3 border-t border-wood-100 p-4"
-        >
+        <div v-if="showAdjustmentPanel" id="bbq-adjustment-panel" class="grid gap-3 border-t border-wood-100 p-4">
           <div v-for="target in adjustmentTargets" :key="target.key">
             <p class="mb-1 text-xs font-medium text-charcoal-600">
               {{ target.label }}
@@ -650,24 +686,50 @@ export default defineComponent({
           <div
             v-for="row in visiblePreviewRows"
             :key="row.key"
-            class="grid gap-2 px-3 py-2 sm:grid-cols-[minmax(0,1fr)_auto]"
+            class="px-3 py-2"
             :class="{ 'bg-charcoal-50/50': row.status === 'unchanged' }"
           >
-            <div class="flex min-w-0 items-center gap-2">
-              <span
-                class="min-w-0 truncate text-sm"
-                :class="row.status === 'unchanged' ? 'text-charcoal-500' : 'text-charcoal-800'"
+            <div class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+              <div class="flex min-w-0 items-center gap-2">
+                <span
+                  class="min-w-0 truncate text-sm"
+                  :class="row.status === 'unchanged' ? 'text-charcoal-500' : 'text-charcoal-800'"
+                >
+                  {{ row.name }}
+                </span>
+                <span
+                  v-if="row.status !== 'excluded'"
+                  class="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium"
+                  :class="previewStatusClass(row.status)"
+                >
+                  {{ previewStatusLabel(row.status) }}
+                </span>
+              </div>
+              <div
+                v-if="shouldShowTargetToggle(row)"
+                class="inline-flex shrink-0 rounded-full border border-wood-200 bg-charcoal-50 p-0.5"
+                role="group"
+                :aria-label="`${row.name}の生成対象を切り替え`"
               >
-                {{ row.name }}
-              </span>
-              <span
-                class="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium"
-                :class="previewStatusClass(row.status)"
-              >
-                {{ previewStatusLabel(row.status) }}
-              </span>
+                <button
+                  type="button"
+                  :class="targetToggleButtonClass(row.status !== 'excluded')"
+                  :aria-pressed="row.status !== 'excluded'"
+                  @click="setCandidateExcluded(row.key, false)"
+                >
+                  対象
+                </button>
+                <button
+                  type="button"
+                  :class="targetToggleButtonClass(row.status === 'excluded')"
+                  :aria-pressed="row.status === 'excluded'"
+                  @click="setCandidateExcluded(row.key, true)"
+                >
+                  対象外
+                </button>
+              </div>
             </div>
-            <div class="flex flex-wrap items-center gap-1 text-xs font-medium text-charcoal-700 sm:justify-end">
+            <div class="mt-1 flex flex-wrap items-center gap-1 text-xs font-medium text-charcoal-700">
               <span v-if="row.status === 'unchanged'" class="text-charcoal-500">
                 {{ row.beforeQuantity }}
               </span>

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -15,7 +15,7 @@ import { useMutation } from '@/composables/useMutation';
 import { groupItems } from '@/utils/item-grouping';
 import type { GroupDefinition, ItemGroup } from '@/utils/item-grouping';
 import { getErrorMessage } from '@/lib/http';
-import { markGeneratedItemExcludedFromBBQConfig } from '@/lib/listTemplateExclusions';
+import { buildGeneratedItemExclusionConfigMutation } from '@/lib/listTemplateExclusions';
 
 const ITEM_GROUP_DEFINITIONS: GroupDefinition<Item>[] = [
   {
@@ -201,9 +201,9 @@ export default defineComponent({
         }
         if (item) {
           try {
-            const configResult = await markGeneratedItemExcludedFromBBQConfig(listId, item);
-            if (configResult && configResult.revision > this.listStore.revision) {
-              this.listStore.setRevision(configResult.revision);
+            const configMutation = await buildGeneratedItemExclusionConfigMutation(listId, item);
+            if (configMutation) {
+              await this.mutationRun(configMutation);
             }
           } catch (err: unknown) {
             console.error('Failed to update generated item exclusion config', err);

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -15,6 +15,7 @@ import { useMutation } from '@/composables/useMutation';
 import { groupItems } from '@/utils/item-grouping';
 import type { GroupDefinition, ItemGroup } from '@/utils/item-grouping';
 import { getErrorMessage } from '@/lib/http';
+import { markGeneratedItemExcludedFromBBQConfig } from '@/lib/listTemplateExclusions';
 
 const ITEM_GROUP_DEFINITIONS: GroupDefinition<Item>[] = [
   {
@@ -192,10 +193,24 @@ export default defineComponent({
         return;
       }
       try {
+        const item = this.listStore.items.find((candidate) => candidate.id === itemId) ?? null;
         this.deleteLoading = { ...this.deleteLoading, [itemId]: true };
         const result = await this.mutationRun(() => deleteItemApi(listId, itemId));
         if (result.applied) {
           this.listStore.removeItem(itemId);
+        }
+        if (item) {
+          try {
+            const configResult = await markGeneratedItemExcludedFromBBQConfig(listId, item);
+            if (configResult && configResult.revision > this.listStore.revision) {
+              this.listStore.setRevision(configResult.revision);
+            }
+          } catch (err: unknown) {
+            console.error('Failed to update generated item exclusion config', err);
+            this.errorMessage =
+              getErrorMessage(err) ?? 'アイテムは削除されましたが、次回の再生成対象外設定に失敗しました。';
+            this.showErrorFeedback();
+          }
         }
       } catch (err: unknown) {
         console.error('Failed to delete item', err);

--- a/frontend/src/lib/generation/bbqGenerator.test.ts
+++ b/frontend/src/lib/generation/bbqGenerator.test.ts
@@ -3,6 +3,7 @@ import {
   createDefaultBBQGenerationConfig,
   generateBBQItems,
   isBBQGenerationConfig,
+  normalizeBBQGenerationConfig,
   type BBQGenerationAnswers,
   type BBQGenerationAdjustments
 } from './bbqGenerator';
@@ -203,5 +204,34 @@ describe('generateBBQItems', () => {
 describe('isBBQGenerationConfig', () => {
   it('デフォルト config を有効な config として判定する', () => {
     expect(isBBQGenerationConfig(createDefaultBBQGenerationConfig())).toBe(true);
+  });
+
+  it('excludedGeneratorKeys がない既存 config も有効な config として判定する', () => {
+    const legacyConfig: Partial<ReturnType<typeof createDefaultBBQGenerationConfig>> = {
+      ...createDefaultBBQGenerationConfig()
+    };
+    delete legacyConfig.excludedGeneratorKeys;
+
+    expect(isBBQGenerationConfig(legacyConfig)).toBe(true);
+  });
+
+  it('excludedGeneratorKeys が文字列配列でない場合は不正な config として判定する', () => {
+    expect(
+      isBBQGenerationConfig({
+        ...createDefaultBBQGenerationConfig(),
+        excludedGeneratorKeys: ['beef', 1]
+      })
+    ).toBe(false);
+  });
+});
+
+describe('normalizeBBQGenerationConfig', () => {
+  it('excludedGeneratorKeys を重複なしの文字列配列に正規化する', () => {
+    const normalized = normalizeBBQGenerationConfig({
+      ...createDefaultBBQGenerationConfig(),
+      excludedGeneratorKeys: ['beef', ' beef ', '', 'pork']
+    });
+
+    expect(normalized.excludedGeneratorKeys).toEqual(['beef', 'pork']);
   });
 });

--- a/frontend/src/lib/generation/bbqGenerator.ts
+++ b/frontend/src/lib/generation/bbqGenerator.ts
@@ -1,4 +1,9 @@
 import { BBQ_GENERATION_RULES } from '@/lib/listGenerationConstants';
+import {
+  isExcludedGeneratorKeys,
+  normalizeExcludedGeneratorKeys,
+  type ListGenerationConfigBase
+} from '@/lib/generation/generationConfig';
 import type { ItemCategory } from '@/types/item-category';
 import type { BaseUnit, UnitCode } from '@/types/list-generation';
 
@@ -29,10 +34,11 @@ export type BBQGenerationAdjustments = {
   overall: BBQGenerationLevel;
 };
 
-export type BBQGenerationConfig = {
+export type BBQGenerationConfig = ListGenerationConfigBase & {
   version: 1;
   answers: BBQGenerationAnswers;
   adjustments: BBQGenerationAdjustments;
+  excludedGeneratorKeys: string[];
 };
 
 export type GeneratedItemCandidate = {
@@ -131,7 +137,8 @@ export function createDefaultBBQGenerationConfig(): BBQGenerationConfig {
   return {
     version: 1,
     answers: { ...DEFAULT_BBQ_ANSWERS },
-    adjustments: { ...DEFAULT_BBQ_ADJUSTMENTS }
+    adjustments: { ...DEFAULT_BBQ_ADJUSTMENTS },
+    excludedGeneratorKeys: []
   };
 }
 
@@ -261,8 +268,27 @@ export function isBBQGenerationConfig(value: unknown): value is BBQGenerationCon
   return (
     candidate.version === 1 &&
     isBBQGenerationAnswers(candidate.answers) &&
-    isBBQGenerationAdjustments(candidate.adjustments)
+    isBBQGenerationAdjustments(candidate.adjustments) &&
+    isExcludedGeneratorKeys(candidate.excludedGeneratorKeys)
   );
+}
+
+export function normalizeBBQGenerationConfig(config: BBQGenerationConfig): BBQGenerationConfig {
+  const defaults = createDefaultBBQGenerationConfig();
+  const rawBalance = (config.answers as { balance?: string }).balance;
+  const balance = rawBalance === 'seafood' ? defaults.answers.balance : config.answers.balance;
+  return {
+    version: 1,
+    answers: {
+      ...defaults.answers,
+      ...config.answers,
+      balance,
+      alcoholLevel: config.answers.alcoholLevel,
+      seafoodLevel: config.answers.seafoodLevel
+    },
+    adjustments: { ...defaults.adjustments, ...config.adjustments },
+    excludedGeneratorKeys: normalizeExcludedGeneratorKeys(config.excludedGeneratorKeys)
+  };
 }
 
 function isBBQGenerationAnswers(value: unknown): value is BBQGenerationAnswers {

--- a/frontend/src/lib/generation/generationConfig.ts
+++ b/frontend/src/lib/generation/generationConfig.ts
@@ -1,0 +1,44 @@
+export type ListGenerationConfigBase = {
+  version: number;
+  excludedGeneratorKeys?: string[];
+};
+
+export function normalizeExcludedGeneratorKeys(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      value
+        .filter((key): key is string => typeof key === 'string')
+        .map((key) => key.trim())
+        .filter((key) => key.length > 0)
+    )
+  ];
+}
+
+export function isExcludedGeneratorKeys(value: unknown): value is string[] | undefined {
+  return value === undefined || (Array.isArray(value) && value.every((key) => typeof key === 'string'));
+}
+
+export function isGeneratorKeyExcluded(config: ListGenerationConfigBase, generatorKey: string): boolean {
+  return normalizeExcludedGeneratorKeys(config.excludedGeneratorKeys).includes(generatorKey);
+}
+
+export function setGeneratorKeyExcluded<T extends ListGenerationConfigBase>(
+  config: T,
+  generatorKey: string,
+  excluded: boolean
+): T {
+  const keys = new Set(normalizeExcludedGeneratorKeys(config.excludedGeneratorKeys));
+  if (excluded) {
+    keys.add(generatorKey);
+  } else {
+    keys.delete(generatorKey);
+  }
+
+  return {
+    ...config,
+    excludedGeneratorKeys: [...keys]
+  };
+}

--- a/frontend/src/lib/listTemplateConfigRegistry.ts
+++ b/frontend/src/lib/listTemplateConfigRegistry.ts
@@ -1,0 +1,28 @@
+import type { ListGenerationConfigType } from '@/api/listGenerationConfig';
+import {
+  isBBQGenerationConfig,
+  normalizeBBQGenerationConfig,
+  type BBQGenerationConfig
+} from '@/lib/generation/bbqGenerator';
+import type { ListGenerationConfigBase } from '@/lib/generation/generationConfig';
+import { BBQ_GENERATOR_KEYS } from '@/lib/listGenerationConstants';
+
+export type ListTemplateConfigAdapter<TConfig extends ListGenerationConfigBase = ListGenerationConfigBase> = {
+  id: ListGenerationConfigType;
+  generatorKeys: readonly string[];
+  isConfig(value: unknown): value is TConfig;
+  normalizeConfig(config: TConfig): TConfig;
+};
+
+const BBQ_TEMPLATE_CONFIG_ADAPTER: ListTemplateConfigAdapter<BBQGenerationConfig> = {
+  id: 'bbq',
+  generatorKeys: BBQ_GENERATOR_KEYS,
+  isConfig: isBBQGenerationConfig,
+  normalizeConfig: normalizeBBQGenerationConfig
+};
+
+export const LIST_TEMPLATE_CONFIG_ADAPTERS: readonly ListTemplateConfigAdapter[] = [BBQ_TEMPLATE_CONFIG_ADAPTER];
+
+export function findListTemplateConfigAdapterByGeneratorKey(generatorKey: string): ListTemplateConfigAdapter | null {
+  return LIST_TEMPLATE_CONFIG_ADAPTERS.find((adapter) => adapter.generatorKeys.includes(generatorKey)) ?? null;
+}

--- a/frontend/src/lib/listTemplateExclusions.test.ts
+++ b/frontend/src/lib/listTemplateExclusions.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchListGenerationConfig, saveListGenerationConfig } from '@/api/listGenerationConfig';
+import { createDefaultBBQGenerationConfig } from '@/lib/generation/bbqGenerator';
+import { buildGeneratedItemExclusionConfigMutation } from '@/lib/listTemplateExclusions';
+import type { Item } from '@/types/api';
+
+vi.mock('@/api/listGenerationConfig', () => ({
+  fetchListGenerationConfig: vi.fn(),
+  saveListGenerationConfig: vi.fn()
+}));
+
+const mockedFetchListGenerationConfig = vi.mocked(fetchListGenerationConfig);
+const mockedSaveListGenerationConfig = vi.mocked(saveListGenerationConfig);
+
+function generatedItem(generatorKey: string): Item {
+  return {
+    id: `item-${generatorKey}`,
+    name: generatorKey,
+    itemType: 'quantified',
+    category: 'meat',
+    preparationType: null,
+    quantified: {
+      quantity: 100,
+      baseUnit: 'g',
+      origin: 'generated',
+      regenerationPolicy: 'auto',
+      generatorKey
+    },
+    completed: false,
+    assignedMemberId: null,
+    completedByMemberId: null,
+    completedAt: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z'
+  };
+}
+
+function plainItem(): Item {
+  return {
+    ...generatedItem('beef'),
+    itemType: 'plain',
+    quantified: null
+  };
+}
+
+describe('buildGeneratedItemExclusionConfigMutation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('generated item の generatorKey を除外した config 保存 mutation を作る', async () => {
+    const config = createDefaultBBQGenerationConfig();
+    mockedFetchListGenerationConfig.mockResolvedValue({
+      id: 'config-id',
+      listId: 'list-id',
+      configType: 'bbq',
+      configJson: config,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z'
+    });
+    mockedSaveListGenerationConfig.mockResolvedValue({
+      revision: 3,
+      data: {
+        id: 'config-id',
+        listId: 'list-id',
+        configType: 'bbq',
+        configJson: { ...config, excludedGeneratorKeys: ['beef'] },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z'
+      }
+    });
+
+    const mutation = await buildGeneratedItemExclusionConfigMutation('list-id', generatedItem('beef'));
+
+    expect(mockedFetchListGenerationConfig).toHaveBeenCalledWith('list-id', 'bbq');
+    expect(mutation).not.toBeNull();
+
+    const result = await mutation?.();
+
+    expect(mockedSaveListGenerationConfig).toHaveBeenCalledWith(
+      'list-id',
+      'bbq',
+      expect.objectContaining({
+        excludedGeneratorKeys: ['beef']
+      })
+    );
+    expect(result?.revision).toBe(3);
+  });
+
+  it('既存の excludedGeneratorKeys を保持して追加する', async () => {
+    const config = { ...createDefaultBBQGenerationConfig(), excludedGeneratorKeys: ['pork'] };
+    mockedFetchListGenerationConfig.mockResolvedValue({
+      id: 'config-id',
+      listId: 'list-id',
+      configType: 'bbq',
+      configJson: config,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z'
+    });
+    mockedSaveListGenerationConfig.mockResolvedValue({
+      revision: 4,
+      data: {
+        id: 'config-id',
+        listId: 'list-id',
+        configType: 'bbq',
+        configJson: { ...config, excludedGeneratorKeys: ['pork', 'beef'] },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z'
+      }
+    });
+
+    const mutation = await buildGeneratedItemExclusionConfigMutation('list-id', generatedItem('beef'));
+    await mutation?.();
+
+    expect(mockedSaveListGenerationConfig).toHaveBeenCalledWith(
+      'list-id',
+      'bbq',
+      expect.objectContaining({
+        excludedGeneratorKeys: ['pork', 'beef']
+      })
+    );
+  });
+
+  it('generated item でない場合は mutation を作らない', async () => {
+    const mutation = await buildGeneratedItemExclusionConfigMutation('list-id', plainItem());
+
+    expect(mutation).toBeNull();
+    expect(mockedFetchListGenerationConfig).not.toHaveBeenCalled();
+    expect(mockedSaveListGenerationConfig).not.toHaveBeenCalled();
+  });
+
+  it('対応するテンプレートがない generatorKey の場合は mutation を作らない', async () => {
+    const mutation = await buildGeneratedItemExclusionConfigMutation('list-id', generatedItem('unknown'));
+
+    expect(mutation).toBeNull();
+    expect(mockedFetchListGenerationConfig).not.toHaveBeenCalled();
+    expect(mockedSaveListGenerationConfig).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/listTemplateExclusions.ts
+++ b/frontend/src/lib/listTemplateExclusions.ts
@@ -1,12 +1,12 @@
 import { fetchListGenerationConfig, saveListGenerationConfig } from '@/api/listGenerationConfig';
 import type { ListGenerationConfigResponse } from '@/api/listGenerationConfig';
-import {
-  isBBQGenerationConfig,
-  normalizeBBQGenerationConfig,
-  type BBQGenerationConfig
-} from '@/lib/generation/bbqGenerator';
-import { setGeneratorKeyExcluded } from '@/lib/generation/generationConfig';
+import { setGeneratorKeyExcluded, type ListGenerationConfigBase } from '@/lib/generation/generationConfig';
+import { findListTemplateConfigAdapterByGeneratorKey } from '@/lib/listTemplateConfigRegistry';
 import type { ApiError, Item, MutationResponse, UUID } from '@/types/api';
+
+export type TemplateConfigExclusionMutation = () => Promise<
+  MutationResponse<ListGenerationConfigResponse<ListGenerationConfigBase>>
+>;
 
 type GeneratedItemWithKey = Item & {
   quantified: NonNullable<Item['quantified']> & { generatorKey: string };
@@ -22,21 +22,26 @@ export function isGeneratedItemWithKey(item: Item): item is GeneratedItemWithKey
   );
 }
 
-export async function markGeneratedItemExcludedFromBBQConfig(
+export async function buildGeneratedItemExclusionConfigMutation(
   listId: UUID,
   item: Item
-): Promise<MutationResponse<ListGenerationConfigResponse<BBQGenerationConfig>> | null> {
+): Promise<TemplateConfigExclusionMutation | null> {
   if (!isGeneratedItemWithKey(item)) {
     return null;
   }
 
-  let config: BBQGenerationConfig;
+  const adapter = findListTemplateConfigAdapterByGeneratorKey(item.quantified.generatorKey);
+  if (adapter == null) {
+    return null;
+  }
+
+  let config: ListGenerationConfigBase;
   try {
-    const res = await fetchListGenerationConfig<unknown>(listId, 'bbq');
-    if (!isBBQGenerationConfig(res.configJson)) {
+    const res = await fetchListGenerationConfig<unknown>(listId, adapter.id);
+    if (!adapter.isConfig(res.configJson)) {
       return null;
     }
-    config = normalizeBBQGenerationConfig(res.configJson);
+    config = adapter.normalizeConfig(res.configJson);
   } catch (err: unknown) {
     if (isNotFoundError(err)) {
       return null;
@@ -45,7 +50,7 @@ export async function markGeneratedItemExcludedFromBBQConfig(
   }
 
   const nextConfig = setGeneratorKeyExcluded(config, item.quantified.generatorKey, true);
-  return saveListGenerationConfig(listId, 'bbq', nextConfig);
+  return () => saveListGenerationConfig(listId, adapter.id, nextConfig);
 }
 
 function isNotFoundError(err: unknown): boolean {

--- a/frontend/src/lib/listTemplateExclusions.ts
+++ b/frontend/src/lib/listTemplateExclusions.ts
@@ -1,0 +1,53 @@
+import { fetchListGenerationConfig, saveListGenerationConfig } from '@/api/listGenerationConfig';
+import type { ListGenerationConfigResponse } from '@/api/listGenerationConfig';
+import {
+  isBBQGenerationConfig,
+  normalizeBBQGenerationConfig,
+  type BBQGenerationConfig
+} from '@/lib/generation/bbqGenerator';
+import { setGeneratorKeyExcluded } from '@/lib/generation/generationConfig';
+import type { ApiError, Item, MutationResponse, UUID } from '@/types/api';
+
+type GeneratedItemWithKey = Item & {
+  quantified: NonNullable<Item['quantified']> & { generatorKey: string };
+};
+
+export function isGeneratedItemWithKey(item: Item): item is GeneratedItemWithKey {
+  return (
+    item.itemType === 'quantified' &&
+    item.quantified != null &&
+    item.quantified.origin === 'generated' &&
+    typeof item.quantified.generatorKey === 'string' &&
+    item.quantified.generatorKey.length > 0
+  );
+}
+
+export async function markGeneratedItemExcludedFromBBQConfig(
+  listId: UUID,
+  item: Item
+): Promise<MutationResponse<ListGenerationConfigResponse<BBQGenerationConfig>> | null> {
+  if (!isGeneratedItemWithKey(item)) {
+    return null;
+  }
+
+  let config: BBQGenerationConfig;
+  try {
+    const res = await fetchListGenerationConfig<unknown>(listId, 'bbq');
+    if (!isBBQGenerationConfig(res.configJson)) {
+      return null;
+    }
+    config = normalizeBBQGenerationConfig(res.configJson);
+  } catch (err: unknown) {
+    if (isNotFoundError(err)) {
+      return null;
+    }
+    throw err;
+  }
+
+  const nextConfig = setGeneratorKeyExcluded(config, item.quantified.generatorKey, true);
+  return saveListGenerationConfig(listId, 'bbq', nextConfig);
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return err !== null && typeof err === 'object' && 'error' in err && (err as ApiError).error === 'not_found';
+}


### PR DESCRIPTION
This pull request adds support for excluding specific generator keys from BBQ item generation, allowing users to toggle whether certain items are included or not in the generation process. It introduces a new `excludedGeneratorKeys` field to the `BBQGenerationConfig`, updates the UI to allow toggling inclusion/exclusion for each candidate, and ensures that excluded items are handled correctly throughout the codebase. Additionally, when an item is deleted from the list, it will now also be excluded from future generations.

**Config and Data Model Updates:**

* Added `excludedGeneratorKeys` to `BBQGenerationConfig`, updated its creation, validation, and normalization logic, and ensured backward compatibility for configs without this field. [[1]](diffhunk://#diff-f89a2fb9047330ae1f72dd7cc8c9b02b530082a1e8452a6209bebfed4daffa9fL32-R41) [[2]](diffhunk://#diff-f89a2fb9047330ae1f72dd7cc8c9b02b530082a1e8452a6209bebfed4daffa9fL134-R141) [[3]](diffhunk://#diff-f89a2fb9047330ae1f72dd7cc8c9b02b530082a1e8452a6209bebfed4daffa9fL264-R293) [[4]](diffhunk://#diff-30b91676071de36169ba330cf176604ab31120bd00a9beb3b3e558ae4b7500c5R208-R236)

**UI/UX Improvements in `BBQGenerationPanel.vue`:**

* Added UI controls to toggle inclusion/exclusion of each candidate item, updated preview row statuses to reflect exclusions, and adjusted filtering and display logic to account for excluded items. [[1]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L67-R69) [[2]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R172-R174) [[3]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L192-R184) [[4]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R195-R206) [[5]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L246-R280) [[6]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R333-R345) [[7]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R366-R368) [[8]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R387-R389) [[9]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R400-R417) [[10]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L653-R692) [[11]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R701-R732)

**Logic and Helper Functions:**

* Refactored config cloning to use normalization, and added utility imports for handling generator key exclusion logic. [[1]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R10) [[2]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1R19) [[3]](diffhunk://#diff-77f3820eabbbebd97325d70199c6204e048d642904b251710cf50ab56c353af1L98-R100) [[4]](diffhunk://#diff-f89a2fb9047330ae1f72dd7cc8c9b02b530082a1e8452a6209bebfed4daffa9fR2-R6)

**Integration with Item Deletion:**

* When an item is deleted via `ItemGroupList.vue`, it is now also added to the exclusion config to prevent regeneration, with error handling for failed exclusion updates. [[1]](diffhunk://#diff-a0099766d39b48ce3d664d702c4ea0a0a57e32a3901cf7fdaa0225e571752f90R18) [[2]](diffhunk://#diff-a0099766d39b48ce3d664d702c4ea0a0a57e32a3901cf7fdaa0225e571752f90R196-R214)

**Testing:**

* Added tests for config validation and normalization, especially around the new `excludedGeneratorKeys` field and its edge cases.

These changes improve user control over generated items and ensure that exclusions persist across generations and deletions.