### PR TITLE
Add member limit configuration and validation for item lists

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/config/AppMemberProperties.java
+++ b/backend/src/main/java/com/atoook/otsukailist/config/AppMemberProperties.java
@@ -1,0 +1,20 @@
+package com.atoook.otsukailist.config;
+
+import jakarta.validation.constraints.Min;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "app.member")
+public class AppMemberProperties {
+
+  /** Maximum number of members that can belong to one list. */
+  @Min(1)
+  private int maxMembersPerList = 20;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/config/AppMemberProperties.java
+++ b/backend/src/main/java/com/atoook/otsukailist/config/AppMemberProperties.java
@@ -1,5 +1,6 @@
 package com.atoook.otsukailist.config;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -13,8 +14,10 @@ import lombok.Setter;
 @Validated
 @ConfigurationProperties(prefix = "app.member")
 public class AppMemberProperties {
+  public static final int ABSOLUTE_MAX_MEMBERS_PER_LIST = 1000;
 
   /** Maximum number of members that can belong to one list. */
   @Min(1)
+  @Max(ABSOLUTE_MAX_MEMBERS_PER_LIST)
   private int maxMembersPerList = 20;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequest.java
@@ -1,5 +1,7 @@
 package com.atoook.otsukailist.dto;
 
+import static com.atoook.otsukailist.config.AppMemberProperties.ABSOLUTE_MAX_MEMBERS_PER_LIST;
+
 import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
@@ -24,7 +26,7 @@ public class CreateItemListWithMembersRequest {
   private String name;
 
   @NotNull(message = "メンバー一覧は必須です")
-  @Size(min = 1, message = "メンバーは1名以上で指定してください")
+  @Size(min = 1, max = ABSOLUTE_MAX_MEMBERS_PER_LIST, message = "メンバーは1〜{max}名で指定してください")
   private List<
           @NotBlank(message = "メンバー名は必須です") @Size(max = 80, message = "メンバー名は80文字以下にしてください") String>
       memberNames;

--- a/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequest.java
@@ -23,9 +23,8 @@ public class CreateItemListWithMembersRequest {
   @Size(max = 100, message = "リスト名は100文字以下にしてください")
   private String name;
 
-  /** 初期メンバー名一覧 - UI側で 1人以上を想定するなら min=1 - 上限は適当（例: 20） */
   @NotNull(message = "メンバー一覧は必須です")
-  @Size(min = 1, max = 20, message = "メンバーは1〜20名で指定してください")
+  @Size(min = 1, message = "メンバーは1名以上で指定してください")
   private List<
           @NotBlank(message = "メンバー名は必須です") @Size(max = 80, message = "メンバー名は80文字以下にしてください") String>
       memberNames;

--- a/backend/src/main/java/com/atoook/otsukailist/repository/MemberRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/MemberRepository.java
@@ -11,6 +11,8 @@ import com.atoook.otsukailist.model.Member;
 public interface MemberRepository extends JpaRepository<Member, UUID> {
   List<Member> findByItemListId(UUID listId);
 
+  long countByItemListId(UUID listId);
+
   Optional<Member> findByIdAndItemListId(UUID id, UUID listId);
 
   boolean existsByIdAndItemListId(UUID id, UUID listId);

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
@@ -34,6 +34,7 @@ public class ListCommandService {
   private final MemberRepository memberRepo;
 
   private final ListRevisionService listRevisionService;
+  private final ListMemberLimitService listMemberLimitService;
 
   /**
    * Create a list with its initial member set.
@@ -46,13 +47,12 @@ public class ListCommandService {
       CreateItemListWithMembersRequest req) {
     String listName = req.getName().trim();
 
-    ItemList list = new ItemList();
-    list.setName(listName);
-    ItemList savedList = itemListRepo.saveAndFlush(list);
-
     // 正規化 + 重複チェック（アプリ側で早期に分かりやすく）
     List<String> names =
         req.getMemberNames().stream().map(String::trim).filter(s -> !s.isBlank()).toList();
+    if (names.isEmpty()) {
+      throw new BadRequestException("メンバーは1人以上必要です");
+    }
 
     Set<String> seen = new HashSet<>();
     for (String n : names) {
@@ -60,6 +60,11 @@ public class ListCommandService {
         throw new BadRequestException(String.format(ErrorMessages.MEMBER_DUPLICATED, n));
       }
     }
+    listMemberLimitService.validateInitialMemberCount(names.size());
+
+    ItemList list = new ItemList();
+    list.setName(listName);
+    ItemList savedList = itemListRepo.saveAndFlush(list);
 
     List<Member> members = new ArrayList<>();
     for (String n : names) {

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListMemberLimitService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListMemberLimitService.java
@@ -1,0 +1,46 @@
+package com.atoook.otsukailist.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.atoook.otsukailist.config.AppMemberProperties;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ListMemberLimitService {
+  private static final String MSG_MEMBER_LIMIT_EXCEEDED = "リストに追加できるメンバーは%d人までです";
+
+  private final MemberRepository memberRepo;
+  private final AppMemberProperties memberProperties;
+
+  /**
+   * Validate that one more member can be added to the list.
+   *
+   * @param listId target list ID
+   */
+  public void validateCanAddOne(UUID listId) {
+    long currentMemberCount = memberRepo.countByItemListId(listId);
+    validateMemberCount(currentMemberCount + 1L);
+  }
+
+  /**
+   * Validate the initial member count for a newly created list.
+   *
+   * @param memberCount normalized initial member count
+   */
+  public void validateInitialMemberCount(long memberCount) {
+    validateMemberCount(memberCount);
+  }
+
+  private void validateMemberCount(long memberCount) {
+    int maxMembersPerList = memberProperties.getMaxMembersPerList();
+    if (memberCount > maxMembersPerList) {
+      throw new BadRequestException(String.format(MSG_MEMBER_LIMIT_EXCEEDED, maxMembersPerList));
+    }
+  }
+}

--- a/backend/src/main/java/com/atoook/otsukailist/service/MemberCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/MemberCommandService.java
@@ -25,6 +25,7 @@ public class MemberCommandService {
 
   private final ItemListRepository itemListRepo;
   private final MemberRepository memberRepo;
+  private final ListMemberLimitService listMemberLimitService;
 
   /**
    * Add a member to the specified list.
@@ -37,9 +38,11 @@ public class MemberCommandService {
   public MutationResponse<MemberResponse> addMember(UUID listId, CreateMemberRequest req) {
     ItemList list =
         itemListRepo
-            .findById(listId)
+            .findByIdForUpdate(listId)
             .orElseThrow(
                 () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+
+    listMemberLimitService.validateCanAddOne(listId);
 
     Member member = new Member();
     member.setDisplayName(req.getDisplayName().trim());

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,6 +11,11 @@
       "description": "Maximum number of items that can belong to one list."
     },
     {
+      "name": "app.member.max-members-per-list",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of members that can belong to one list."
+    },
+    {
       "name": "app.rate-limit.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether API rate limiting is enabled."

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -26,6 +26,8 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
   item:
     max-items-per-list: ${APP_ITEM_MAX_ITEMS_PER_LIST:100}
+  member:
+    max-members-per-list: ${APP_MEMBER_MAX_MEMBERS_PER_LIST:20}
   rate-limit:
     enabled: ${APP_RATE_LIMIT_ENABLED:true}
     capacity: ${APP_RATE_LIMIT_CAPACITY:120}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,6 +41,8 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:5173}
   item:
     max-items-per-list: ${APP_ITEM_MAX_ITEMS_PER_LIST:100}
+  member:
+    max-members-per-list: ${APP_MEMBER_MAX_MEMBERS_PER_LIST:20}
   rate-limit:
     enabled: ${APP_RATE_LIMIT_ENABLED:true}
     capacity: ${APP_RATE_LIMIT_CAPACITY:120}

--- a/backend/src/test/java/com/atoook/otsukailist/config/AppMemberPropertiesValidationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/config/AppMemberPropertiesValidationTest.java
@@ -1,0 +1,43 @@
+package com.atoook.otsukailist.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AppMemberPropertiesValidationTest {
+
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void shouldAcceptDefaultProperties() {
+    AppMemberProperties properties = new AppMemberProperties();
+
+    Set<ConstraintViolation<AppMemberProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNonPositiveMaxMembersPerList() {
+    AppMemberProperties properties = new AppMemberProperties();
+    properties.setMaxMembersPerList(0);
+
+    Set<ConstraintViolation<AppMemberProperties>> violations = validator.validate(properties);
+
+    assertThat(violations)
+        .extracting(violation -> violation.getPropertyPath().toString())
+        .contains("maxMembersPerList");
+  }
+}

--- a/backend/src/test/java/com/atoook/otsukailist/config/AppMemberPropertiesValidationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/config/AppMemberPropertiesValidationTest.java
@@ -40,4 +40,16 @@ class AppMemberPropertiesValidationTest {
         .extracting(violation -> violation.getPropertyPath().toString())
         .contains("maxMembersPerList");
   }
+
+  @Test
+  void shouldRejectMaxMembersPerListAboveAbsoluteLimit() {
+    AppMemberProperties properties = new AppMemberProperties();
+    properties.setMaxMembersPerList(AppMemberProperties.ABSOLUTE_MAX_MEMBERS_PER_LIST + 1);
+
+    Set<ConstraintViolation<AppMemberProperties>> violations = validator.validate(properties);
+
+    assertThat(violations)
+        .extracting(violation -> violation.getPropertyPath().toString())
+        .contains("maxMembersPerList");
+  }
 }

--- a/backend/src/test/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequestValidationTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/dto/CreateItemListWithMembersRequestValidationTest.java
@@ -1,0 +1,42 @@
+package com.atoook.otsukailist.dto;
+
+import static com.atoook.otsukailist.config.AppMemberProperties.ABSOLUTE_MAX_MEMBERS_PER_LIST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CreateItemListWithMembersRequestValidationTest {
+
+  private Validator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  void shouldRejectMemberNamesAboveAbsoluteLimit() {
+    CreateItemListWithMembersRequest request =
+        CreateItemListWithMembersRequest.builder()
+            .name("買い物")
+            .memberNames(
+                IntStream.rangeClosed(0, ABSOLUTE_MAX_MEMBERS_PER_LIST)
+                    .mapToObj(index -> "member-" + index)
+                    .toList())
+            .build();
+
+    var violations = validator.validate(request);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getPropertyPath)
+        .map(Object::toString)
+        .contains("memberNames");
+  }
+}

--- a/backend/src/test/java/com/atoook/otsukailist/service/ListCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ListCommandServiceTest.java
@@ -1,0 +1,54 @@
+package com.atoook.otsukailist.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import com.atoook.otsukailist.config.AppMemberProperties;
+import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ListCommandServiceTest {
+
+  @Mock private ItemListRepository itemListRepo;
+  @Mock private MemberRepository memberRepo;
+  @Mock private ListRevisionService listRevisionService;
+
+  private AppMemberProperties memberProperties;
+  private ListCommandService service;
+
+  @BeforeEach
+  void setUp() {
+    memberProperties = new AppMemberProperties();
+    ListMemberLimitService listMemberLimitService =
+        new ListMemberLimitService(memberRepo, memberProperties);
+    service =
+        new ListCommandService(
+            itemListRepo, memberRepo, listRevisionService, listMemberLimitService);
+  }
+
+  @Test
+  @DisplayName("初期メンバー数が上限を超える場合はリスト作成を拒否すること")
+  void createListRejectsWhenInitialMembersExceedLimit() {
+    memberProperties.setMaxMembersPerList(2);
+    CreateItemListWithMembersRequest request =
+        CreateItemListWithMembersRequest.builder()
+            .name("買い物")
+            .memberNames(List.of("太郎", "花子", "次郎"))
+            .build();
+
+    assertThatThrownBy(() -> service.createListWithMembers(request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessage("リストに追加できるメンバーは2人までです");
+  }
+}

--- a/backend/src/test/java/com/atoook/otsukailist/service/MemberCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/MemberCommandServiceTest.java
@@ -1,0 +1,62 @@
+package com.atoook.otsukailist.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.atoook.otsukailist.config.AppMemberProperties;
+import com.atoook.otsukailist.dto.CreateMemberRequest;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MemberCommandServiceTest {
+
+  @Mock private ItemListRepository itemListRepo;
+  @Mock private MemberRepository memberRepo;
+
+  private AppMemberProperties memberProperties;
+  private MemberCommandService service;
+
+  @BeforeEach
+  void setUp() {
+    memberProperties = new AppMemberProperties();
+    ListMemberLimitService listMemberLimitService =
+        new ListMemberLimitService(memberRepo, memberProperties);
+    service = new MemberCommandService(itemListRepo, memberRepo, listMemberLimitService);
+  }
+
+  @Test
+  @DisplayName("メンバー数が上限に達している場合は新規追加を拒否すること")
+  void addMemberRejectsWhenListAlreadyReachedMemberLimit() {
+    UUID listId = UUID.randomUUID();
+    memberProperties.setMaxMembersPerList(20);
+
+    when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(itemList(listId)));
+    when(memberRepo.countByItemListId(listId)).thenReturn(20L);
+
+    CreateMemberRequest request = CreateMemberRequest.builder().displayName("追加メンバー").build();
+
+    assertThatThrownBy(() -> service.addMember(listId, request))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessage("リストに追加できるメンバーは20人までです");
+  }
+
+  private static ItemList itemList(UUID listId) {
+    ItemList list = new ItemList();
+    list.setId(listId);
+    list.setName("買い物");
+    return list;
+  }
+}

--- a/docs/backend-deploy-operations.md
+++ b/docs/backend-deploy-operations.md
@@ -66,6 +66,7 @@ curl -i http://localhost:10000/actuator/health/liveness
 - `DB_POOL_MINIMUM_IDLE` (default: `0`)
 - `DB_POOL_IDLE_TIMEOUT_MS` (default: `60000`)
 - `APP_ITEM_MAX_ITEMS_PER_LIST` (default: `100`)
+- `APP_MEMBER_MAX_MEMBERS_PER_LIST` (default: `20`)
 - `APP_RATE_LIMIT_ENABLED` (default: `true`)
 - `APP_RATE_LIMIT_CAPACITY` (default: `120`)
 - `APP_RATE_LIMIT_REFILL_TOKENS` (default: `120`)

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -194,6 +194,7 @@ http.interceptors.response.use(
 
 ```
 VITE_API_BASE_URL=http://localhost:8080
+VITE_MAX_MEMBERS_PER_LIST=20
 ```
 
 ---

--- a/frontend/src/lib/appConstants.ts
+++ b/frontend/src/lib/appConstants.ts
@@ -1,1 +1,9 @@
 export const CONTACT_FORM_URL = import.meta.env.VITE_CONTACT_FORM_URL;
+
+const DEFAULT_MAX_MEMBERS_PER_LIST = 20;
+const parsedMaxMembersPerList = Number.parseInt(import.meta.env.VITE_MAX_MEMBERS_PER_LIST ?? '', 10);
+
+export const MAX_MEMBERS_PER_LIST =
+  Number.isFinite(parsedMaxMembersPerList) && parsedMaxMembersPerList > 0
+    ? parsedMaxMembersPerList
+    : DEFAULT_MAX_MEMBERS_PER_LIST;

--- a/frontend/src/pages/CreateListPage.vue
+++ b/frontend/src/pages/CreateListPage.vue
@@ -16,6 +16,7 @@ import { normalizeText, normalizeInput } from '../utils/text-normalization';
 import { createItemList } from '@/api/list';
 import { useListStore } from '@/stores/list';
 import { getErrorMessage } from '@/lib/http';
+import { MAX_MEMBERS_PER_LIST } from '@/lib/appConstants';
 
 export default defineComponent({
   name: 'CreateListPage',
@@ -93,6 +94,10 @@ export default defineComponent({
     },
     addMember(): void {
       const normalizedName = normalizeText(this.newMemberName);
+      if (this.isMemberLimitReached) {
+        this.errorMessage = `メンバーは${MAX_MEMBERS_PER_LIST}人まで追加できます。`;
+        return;
+      }
       if (normalizedName) {
         this.members.push({
           id: Date.now().toString(), // this to be replaced with proper unique ID generation from backend
@@ -118,6 +123,9 @@ export default defineComponent({
     },
     hasValidMemberName(): boolean {
       return !!normalizeText(this.newMemberName);
+    },
+    isMemberLimitReached(): boolean {
+      return this.members.length >= MAX_MEMBERS_PER_LIST;
     }
   }
 });
@@ -159,9 +167,12 @@ export default defineComponent({
           input-name="newMember"
           placeholder="メンバーを追加..."
           variant="inline"
+          :disabled="isMemberLimitReached"
         />
 
-        <MainButton @click="addMember" :disabled="!hasValidMemberName" size="small"> 追加 </MainButton>
+        <MainButton @click="addMember" :disabled="!hasValidMemberName || isMemberLimitReached" size="small">
+          追加
+        </MainButton>
       </div>
 
       <!-- メンバーバッジ表示 -->

--- a/frontend/src/pages/ListEditPage.vue
+++ b/frontend/src/pages/ListEditPage.vue
@@ -17,6 +17,7 @@ import { createMember, deleteMember } from '@/api/member';
 import { fetchSnapshot, renameList } from '@/api/list';
 import { getErrorMessage } from '@/lib/http';
 import { updateListHistoryName, getSelectedMemberId } from '@/lib/userCache';
+import { MAX_MEMBERS_PER_LIST } from '@/lib/appConstants';
 
 export default defineComponent({
   name: 'ListEditPage',
@@ -123,6 +124,11 @@ export default defineComponent({
 
       if (!this.currentListId) {
         this.errorMessage = 'リストIDが無効です';
+        return;
+      }
+
+      if (this.isMemberLimitReached) {
+        this.errorMessage = `メンバーは${MAX_MEMBERS_PER_LIST}人まで追加できます。`;
         return;
       }
 
@@ -238,6 +244,9 @@ export default defineComponent({
     hasValidMemberName(): boolean {
       return !!normalizeText(this.newMemberName);
     },
+    isMemberLimitReached(): boolean {
+      return this.members.length >= MAX_MEMBERS_PER_LIST;
+    },
     isLoading(): boolean {
       return this.mutationLoading || this.snapshotLoading;
     }
@@ -279,9 +288,12 @@ export default defineComponent({
           input-name="newMember"
           placeholder="メンバーを追加..."
           variant="inline"
+          :disabled="isMemberLimitReached || isLoading"
         />
 
-        <MainButton @click="addMember" :disabled="!hasValidMemberName || isLoading" size="small"> 追加 </MainButton>
+        <MainButton @click="addMember" :disabled="!hasValidMemberName || isMemberLimitReached || isLoading" size="small">
+          追加
+        </MainButton>
       </div>
 
       <!-- メンバーバッジ表示 -->

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_BASE_URL?: string;
   readonly VITE_CONTACT_FORM_URL?: string;
+  readonly VITE_MAX_MEMBERS_PER_LIST?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This pull request introduces a configurable maximum number of members allowed per list, enforcing this limit consistently across both the backend and frontend. The main changes include adding validation and configuration for the member limit, updating API and service logic to enforce the limit, and ensuring the frontend UI prevents users from exceeding it. Tests and documentation are also updated to reflect the new behavior.

**Backend: Member limit enforcement and configuration**

* Added `AppMemberProperties` configuration class with a `maxMembersPerList` property, loaded from environment/config and validated to be at least 1.
* Introduced `ListMemberLimitService` to enforce the member limit when creating lists or adding members, throwing a `BadRequestException` if exceeded. All relevant service methods now use this validation. [[1]](diffhunk://#diff-e759843a635eb88690e7b6ea24c0c66023792c3dbc9c2d188b50aa13e67366f0R1-R46) [[2]](diffhunk://#diff-10462c0544b48b6962be5ceb8dc9474e21216132dadae3b168a75efad5027e32R37) [[3]](diffhunk://#diff-10462c0544b48b6962be5ceb8dc9474e21216132dadae3b168a75efad5027e32L49-R67) [[4]](diffhunk://#diff-c2fac2e6c4942b85fce6608401968b24df72591537eebac4ab9b67c4e22c7a58R28) [[5]](diffhunk://#diff-c2fac2e6c4942b85fce6608401968b24df72591537eebac4ab9b67c4e22c7a58L40-R46)
* Updated `MemberRepository` with a `countByItemListId` method to support limit checks.
* Changed validation in `CreateItemListWithMembersRequest` to remove the hardcoded upper limit, delegating enforcement to the new service.

**Frontend: UI enforcement of member limit**

* Added `MAX_MEMBERS_PER_LIST` constant, reading from environment or defaulting to 20, and used it in `CreateListPage.vue` and `ListEditPage.vue` to disable member addition and provide user feedback when the limit is reached. [[1]](diffhunk://#diff-6850f5c67567ce6a89520b67c5f012f7e5480eca2a5daefae3a743cedd768ba6R2-R9) [[2]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fR19) [[3]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fR97-R100) [[4]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fR126-R128) [[5]](diffhunk://#diff-98ab94a3b041c724b08ca1e5a493bfa17e36302c31f1e72042e4f30bdc092c2fR170-R175) [[6]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7R20) [[7]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7R130-R134) [[8]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7R247-R249) [[9]](diffhunk://#diff-8836ab821076c9275543dd7ac13ffe3666821d4ce8b185c567e6fd53527918b7R291-R296)

**Configuration and documentation**

* Added `app.member.max-members-per-list` to YAML config files and metadata, and documented the new environment variable for both backend and frontend. [[1]](diffhunk://#diff-d501b8901facc9c98d1d932ee4982cbe9fdf94c4d0e836020a21f5066b6e9a2aR44-R45) [[2]](diffhunk://#diff-003379e6dfc6ec7964bcaf0341945374ff0e593e17f5eba1e500e2ce602011d9R29-R30) [[3]](diffhunk://#diff-d3a8538712db085d50013cbc5b16e10c30e7eaba41ccac1c1915f8b4aa0628daR13-R17) [[4]](diffhunk://#diff-895bab468cdd9567f6779865337b2b141db159f226d4bde5b7cef2cc691393f1R69) [[5]](diffhunk://#diff-a04329f4153d22a3f9691ab4e1312718585663a678eb8c033986beeba97df5d1R197)

**Testing**

* Added/updated tests to verify the member limit is enforced and that invalid configurations are rejected. [[1]](diffhunk://#diff-7a0ca9ccd9e9256059ca42170ea48e24451c92029f228ba366eb57cdd4e2cbdbR1-R43) [[2]](diffhunk://#diff-50ef210b53864665c5a3348fb1eac564dd0ce539c9232513f8c4482b1bd10c46R1-R54) [[3]](diffhunk://#diff-8c5cb522c592b0c81defacb8a23a9e7644c0c9600da60a690cf65f8a122e0b66R1-R62)