### PR TITLE
Implement completion APIs and enhance feedback mechanisms

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -18,9 +18,11 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import com.atoook.otsukailist.dto.CreateItemRequest;
 import com.atoook.otsukailist.dto.DeleteItemResponse;
 import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MarkItemCompletedRequest;
 import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.UpdateItemRequest;
 import com.atoook.otsukailist.service.ItemCommandService;
+import com.atoook.otsukailist.service.ItemCompletionService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class ItemCommandController {
 
   private final ItemCommandService itemCommandService;
+  private final ItemCompletionService itemCompletionService;
 
   /**
    * Creates a new item under the given list.
@@ -64,6 +67,37 @@ public class ItemCommandController {
       @PathVariable("itemId") UUID itemId,
       @Valid @RequestBody UpdateItemRequest req) {
     return ResponseEntity.ok(itemCommandService.updateItem(listId, itemId, req));
+  }
+
+  /**
+   * Marks an item as completed. This endpoint is idempotent: already-completed items are returned
+   * without changing the completion actor or revision.
+   *
+   * @param listId parent list identifier
+   * @param itemId item identifier
+   * @param req completion actor payload
+   * @return 200 current item response
+   */
+  @PatchMapping("/{itemId}/mark-completed")
+  public ResponseEntity<MutationResponse<ItemResponse>> markCompleted(
+      @PathVariable("listId") UUID listId,
+      @PathVariable("itemId") UUID itemId,
+      @Valid @RequestBody MarkItemCompletedRequest req) {
+    return ResponseEntity.ok(itemCompletionService.markCompleted(listId, itemId, req));
+  }
+
+  /**
+   * Marks an item as incomplete. This endpoint is idempotent: already-incomplete items are returned
+   * without changing the revision.
+   *
+   * @param listId parent list identifier
+   * @param itemId item identifier
+   * @return 200 current item response
+   */
+  @PatchMapping("/{itemId}/mark-incomplete")
+  public ResponseEntity<MutationResponse<ItemResponse>> markIncomplete(
+      @PathVariable("listId") UUID listId, @PathVariable("itemId") UUID itemId) {
+    return ResponseEntity.ok(itemCompletionService.markIncomplete(listId, itemId));
   }
 
   /**

--- a/backend/src/main/java/com/atoook/otsukailist/dto/MarkItemCompletedRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/MarkItemCompletedRequest.java
@@ -1,0 +1,20 @@
+package com.atoook.otsukailist.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** Request body for marking an item as completed. */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MarkItemCompletedRequest {
+
+  private UUID completedByMemberId;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/dto/MutationResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/MutationResponse.java
@@ -1,5 +1,6 @@
 package com.atoook.otsukailist.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,4 +11,7 @@ import lombok.Getter;
 public class MutationResponse<T> {
   private long revision;
   private T data;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Boolean changed;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
+++ b/backend/src/main/java/com/atoook/otsukailist/repository/ItemRepository.java
@@ -5,8 +5,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import jakarta.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -44,6 +47,12 @@ public interface ItemRepository extends JpaRepository<Item, UUID> {
   // 特定のアイテムを取得
   @EntityGraph(attributePaths = "quantified")
   Optional<Item> findByIdAndItemListId(UUID itemId, UUID itemListId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @EntityGraph(attributePaths = "quantified")
+  @Query("select i from Item i where i.id = :itemId and i.itemList.id = :itemListId")
+  Optional<Item> findByIdAndItemListIdForUpdate(
+      @Param("itemId") UUID itemId, @Param("itemListId") UUID itemListId);
 
   // リスト内のアイテム存在チェック
   boolean existsByIdAndItemListId(UUID itemId, UUID itemListId);

--- a/backend/src/main/java/com/atoook/otsukailist/service/ItemCompletionService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ItemCompletionService.java
@@ -1,0 +1,105 @@
+package com.atoook.otsukailist.service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MarkItemCompletedRequest;
+import com.atoook.otsukailist.dto.MutationResponse;
+import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.ResourceNotFoundException;
+import com.atoook.otsukailist.mapper.ItemMapper;
+import com.atoook.otsukailist.model.Item;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ItemRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
+import com.atoook.otsukailist.service.message.ErrorMessages;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ItemCompletionService {
+
+  private final ItemRepository itemRepo;
+  private final ItemListRepository itemListRepo;
+  private final MemberRepository memberRepo;
+  private final ListRevisionService listRevisionService;
+
+  private static final String MSG_MEMBER_NOT_IN_LIST = "指定された完了者はリストのメンバーではありません";
+  private static final String MSG_COMPLETED_BY_NOT_SPECIFIED = "完了者が未指定です";
+
+  /** Marks an item as completed without deriving the target state from the client cache. */
+  @Transactional
+  public MutationResponse<ItemResponse> markCompleted(
+      UUID listId, UUID itemId, MarkItemCompletedRequest req) {
+    Item item = findItemInList(listId, itemId);
+    if (item.isCompleted()) {
+      return currentMutationResponse(listId, item);
+    }
+
+    UUID completedByMemberId = req == null ? null : req.getCompletedByMemberId();
+    validateCompletedByMember(listId, completedByMemberId);
+    item.setCompleted(true);
+    item.setCompletedByMemberId(completedByMemberId);
+    item.setCompletedAt(Instant.now());
+    return saveAndIncrementRevision(listId, item);
+  }
+
+  /** Marks an item as incomplete without deriving the target state from the client cache. */
+  @Transactional
+  public MutationResponse<ItemResponse> markIncomplete(UUID listId, UUID itemId) {
+    Item item = findItemInList(listId, itemId);
+    if (!item.isCompleted()) {
+      return currentMutationResponse(listId, item);
+    }
+
+    item.setCompleted(false);
+    item.setCompletedByMemberId(null);
+    item.setCompletedAt(null);
+    return saveAndIncrementRevision(listId, item);
+  }
+
+  private Item findItemInList(UUID listId, UUID itemId) {
+    return itemRepo
+        .findByIdAndItemListIdForUpdate(itemId, listId)
+        .orElseThrow(
+            () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
+  }
+
+  private void validateCompletedByMember(UUID listId, UUID completedByMemberId) {
+    if (completedByMemberId == null) {
+      throw new BadRequestException(MSG_COMPLETED_BY_NOT_SPECIFIED);
+    }
+    boolean exists = memberRepo.existsByIdAndItemListId(completedByMemberId, listId);
+    if (!exists) {
+      throw new BadRequestException(MSG_MEMBER_NOT_IN_LIST);
+    }
+  }
+
+  private MutationResponse<ItemResponse> saveAndIncrementRevision(UUID listId, Item item) {
+    Item saved = itemRepo.save(item);
+    long revision = listRevisionService.incrementAndGet(listId);
+    return MutationResponse.<ItemResponse>builder()
+        .revision(revision)
+        .data(ItemMapper.toResponse(saved))
+        .changed(true)
+        .build();
+  }
+
+  private MutationResponse<ItemResponse> currentMutationResponse(UUID listId, Item item) {
+    long revision =
+        itemListRepo
+            .findRevision(listId)
+            .orElseThrow(
+                () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+    return MutationResponse.<ItemResponse>builder()
+        .revision(revision)
+        .data(ItemMapper.toResponse(item))
+        .changed(false)
+        .build();
+  }
+}

--- a/backend/src/test/java/com/atoook/otsukailist/service/ItemCompletionServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ItemCompletionServiceTest.java
@@ -1,0 +1,152 @@
+package com.atoook.otsukailist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.atoook.otsukailist.dto.MarkItemCompletedRequest;
+import com.atoook.otsukailist.model.Item;
+import com.atoook.otsukailist.model.ItemType;
+import com.atoook.otsukailist.repository.ItemListRepository;
+import com.atoook.otsukailist.repository.ItemRepository;
+import com.atoook.otsukailist.repository.MemberRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ItemCompletionServiceTest {
+
+  @Mock private ItemRepository itemRepo;
+  @Mock private ItemListRepository itemListRepo;
+  @Mock private MemberRepository memberRepo;
+  @Mock private ListRevisionService listRevisionService;
+
+  private ItemCompletionService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ItemCompletionService(itemRepo, itemListRepo, memberRepo, listRevisionService);
+  }
+
+  @Test
+  @DisplayName("markCompletedは未完了アイテムを完了にしrevisionを進めること")
+  void markCompletedCompletesIncompleteItemAndIncrementsRevision() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Item item = plainItem("牛乳");
+    MarkItemCompletedRequest request =
+        MarkItemCompletedRequest.builder().completedByMemberId(memberId).build();
+
+    when(itemRepo.findByIdAndItemListIdForUpdate(itemId, listId)).thenReturn(Optional.of(item));
+    when(memberRepo.existsByIdAndItemListId(memberId, listId)).thenReturn(true);
+    when(itemRepo.save(item)).thenReturn(item);
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
+
+    var result = service.markCompleted(listId, itemId, request);
+
+    assertThat(item.isCompleted()).isTrue();
+    assertThat(item.getCompletedByMemberId()).isEqualTo(memberId);
+    assertThat(item.getCompletedAt()).isNotNull();
+    assertThat(result.getRevision()).isEqualTo(2L);
+    assertThat(result.getChanged()).isTrue();
+    assertThat(result.getData().isCompleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("markCompletedは既に完了済みなら完了者を上書きせずno-opにすること")
+  void markCompletedNoopsWhenAlreadyCompleted() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    UUID originalMemberId = UUID.randomUUID();
+    UUID requestedMemberId = UUID.randomUUID();
+    Instant completedAt = Instant.parse("2024-01-01T00:00:00Z");
+    Item item = completedItem("牛乳", originalMemberId, completedAt);
+    MarkItemCompletedRequest request =
+        MarkItemCompletedRequest.builder().completedByMemberId(requestedMemberId).build();
+
+    when(itemRepo.findByIdAndItemListIdForUpdate(itemId, listId)).thenReturn(Optional.of(item));
+    when(itemListRepo.findRevision(listId)).thenReturn(Optional.of(7L));
+
+    var result = service.markCompleted(listId, itemId, request);
+
+    assertThat(result.getRevision()).isEqualTo(7L);
+    assertThat(result.getChanged()).isFalse();
+    assertThat(result.getData().isCompleted()).isTrue();
+    assertThat(result.getData().getCompletedByMemberId()).isEqualTo(originalMemberId);
+    assertThat(result.getData().getCompletedAt()).isEqualTo(completedAt);
+    verify(itemRepo, never()).save(any(Item.class));
+    verify(listRevisionService, never()).incrementAndGet(listId);
+  }
+
+  @Test
+  @DisplayName("markIncompleteは完了済みアイテムを未完了にしrevisionを進めること")
+  void markIncompleteClearsCompletedItemAndIncrementsRevision() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Item item = completedItem("牛乳", memberId, Instant.parse("2024-01-01T00:00:00Z"));
+
+    when(itemRepo.findByIdAndItemListIdForUpdate(itemId, listId)).thenReturn(Optional.of(item));
+    when(itemRepo.save(item)).thenReturn(item);
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(8L);
+
+    var result = service.markIncomplete(listId, itemId);
+
+    assertThat(item.isCompleted()).isFalse();
+    assertThat(item.getCompletedByMemberId()).isNull();
+    assertThat(item.getCompletedAt()).isNull();
+    assertThat(result.getRevision()).isEqualTo(8L);
+    assertThat(result.getChanged()).isTrue();
+    assertThat(result.getData().isCompleted()).isFalse();
+  }
+
+  @Test
+  @DisplayName("markIncompleteは他ユーザーが先に未完了へ戻していた場合も逆反転せずno-opにすること")
+  void markIncompleteNoopsWhenAlreadyIncompleteAfterAnotherUserUpdate() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    Item item = plainItem("牛乳");
+
+    when(itemRepo.findByIdAndItemListIdForUpdate(itemId, listId)).thenReturn(Optional.of(item));
+    when(itemListRepo.findRevision(listId)).thenReturn(Optional.of(9L));
+
+    var result = service.markIncomplete(listId, itemId);
+
+    assertThat(result.getRevision()).isEqualTo(9L);
+    assertThat(result.getChanged()).isFalse();
+    assertThat(result.getData().isCompleted()).isFalse();
+    assertThat(result.getData().getCompletedByMemberId()).isNull();
+    verify(itemRepo, never()).save(any(Item.class));
+    verify(listRevisionService, never()).incrementAndGet(listId);
+  }
+
+  private static Item plainItem(String itemName) {
+    Item item = new Item();
+    item.setName(itemName);
+    item.setItemType(ItemType.PLAIN);
+
+    return item;
+  }
+
+  private static Item completedItem(
+      String itemName, UUID completedByMemberId, Instant completedAt) {
+    Item item = plainItem(itemName);
+    item.setCompleted(true);
+    item.setCompletedByMemberId(completedByMemberId);
+    item.setCompletedAt(completedAt);
+
+    return item;
+  }
+}

--- a/docs/item-completion-intent-api.md
+++ b/docs/item-completion-intent-api.md
@@ -31,6 +31,7 @@ Response:
 ```json
 {
   "revision": 12,
+  "changed": true,
   "data": {
     "id": "item-uuid",
     "completed": true,
@@ -44,8 +45,8 @@ Response:
 
 | 現在状態 | 結果 | revision |
 | --- | --- | --- |
-| `completed=false` | `completed=true` に更新し、`completedByMemberId` と `completedAt` を設定 | 進める |
-| `completed=true` | no-op。既存の `completedByMemberId` と `completedAt` を保持 | 進めない |
+| `completed=false` | `completed=true` に更新し、`completedByMemberId` と `completedAt` を設定。`changed=true` | 進める |
+| `completed=true` | no-op。既存の `completedByMemberId` と `completedAt` を保持。`changed=false` | 進めない |
 
 ### markIncomplete
 
@@ -58,6 +59,7 @@ Response:
 ```json
 {
   "revision": 13,
+  "changed": true,
   "data": {
     "id": "item-uuid",
     "completed": false,
@@ -71,8 +73,8 @@ Response:
 
 | 現在状態 | 結果 | revision |
 | --- | --- | --- |
-| `completed=true` | `completed=false` に更新し、完了者と完了日時をクリア | 進める |
-| `completed=false` | no-op | 進めない |
+| `completed=true` | `completed=false` に更新し、完了者と完了日時をクリア。`changed=true` | 進める |
+| `completed=false` | no-op。`changed=false` | 進めない |
 
 ## エラー方針
 
@@ -97,6 +99,8 @@ Response:
 | 完了済み | 未完了に戻す | `markItemIncomplete(listId, itemId)` |
 
 `PATCH /items/{itemId}` の `completed` 更新は既存互換として残すが、一覧のチェック操作では使わない。レスポンスrevisionにギャップがある場合は既存の `useMutation` が snapshot を取り直す。
+
+`changed=false` の場合は、ユーザーの操作で状態が変わったわけではない。フロントは「この操作では変更されず、既に更新済みだった状態を表示した」ことを通知し、自分の操作として誤認されないようにする。
 
 ## 競合テスト観点
 

--- a/docs/item-completion-intent-api.md
+++ b/docs/item-completion-intent-api.md
@@ -1,0 +1,110 @@
+# Item completed intent API
+
+## 背景
+
+一覧画面のチェック操作で `completed: !wasCompleted` を送ると、クライアントが古い状態を持っている場合に意図しない逆反転が起きる。
+
+例:
+
+1. 端末Aは `completed=true` の表示を保持している。
+2. 端末Bが先に未完了へ戻し、サーバ状態は `completed=false` になる。
+3. 端末Aが古い表示を元にチェック解除すると、旧実装では `completed=false` のつもりがトグル値として `true` を送る可能性がある。
+
+この問題を避けるため、一覧操作は現在値トグルではなくユーザー意図別APIを呼び分ける。
+
+## API契約
+
+### markCompleted
+
+`PATCH /api/lists/{listId}/items/{itemId}/mark-completed`
+
+Request:
+
+```json
+{
+  "completedByMemberId": "member-uuid"
+}
+```
+
+Response:
+
+```json
+{
+  "revision": 12,
+  "data": {
+    "id": "item-uuid",
+    "completed": true,
+    "completedByMemberId": "member-uuid",
+    "completedAt": "2024-01-01T00:00:00Z"
+  }
+}
+```
+
+状態遷移:
+
+| 現在状態 | 結果 | revision |
+| --- | --- | --- |
+| `completed=false` | `completed=true` に更新し、`completedByMemberId` と `completedAt` を設定 | 進める |
+| `completed=true` | no-op。既存の `completedByMemberId` と `completedAt` を保持 | 進めない |
+
+### markIncomplete
+
+`PATCH /api/lists/{listId}/items/{itemId}/mark-incomplete`
+
+Request body: なし
+
+Response:
+
+```json
+{
+  "revision": 13,
+  "data": {
+    "id": "item-uuid",
+    "completed": false,
+    "completedByMemberId": null,
+    "completedAt": null
+  }
+}
+```
+
+状態遷移:
+
+| 現在状態 | 結果 | revision |
+| --- | --- | --- |
+| `completed=true` | `completed=false` に更新し、完了者と完了日時をクリア | 進める |
+| `completed=false` | no-op | 進めない |
+
+## エラー方針
+
+| ケース | HTTP | `error` | 備考 |
+| --- | --- | --- | --- |
+| アイテムまたはリストが存在しない | 404 | `not_found` | 既存のAPIエラー形式に合わせる |
+| `completedByMemberId` 未指定 | 400 | `bad_request` | `markCompleted` で `completed=false -> true` に遷移する場合 |
+| `completedByMemberId` がリスト外メンバー | 400 | `bad_request` | `markCompleted` で `completed=false -> true` に遷移する場合 |
+| DB制約違反 | 409 | `conflict` | 既存ハンドラに合わせる |
+
+この対応では、誤反転防止は意図別APIの冪等性で担保する。明示的なリビジョン前提条件を導入する場合は、`If-Match` または request body の `expectedRevision` を使い、不一致時は `412 precondition_failed` として `details.expectedRevision` / `details.currentRevision` を返す方針にする。
+
+実装上は完了状態の判定前に対象アイテム行を更新ロックで取得し、同時に届いた2つ目の意図別リクエストが先行コミット後の状態を見て no-op 判定できるようにする。
+
+## フロント修正方針
+
+一覧のチェック操作は、押下時に見えている状態からユーザー意図を決め、以下を呼び分ける。
+
+| 表示上の状態 | ユーザー操作の意図 | 呼ぶAPI |
+| --- | --- | --- |
+| 未完了 | 完了にする | `markItemCompleted(listId, itemId, { completedByMemberId })` |
+| 完了済み | 未完了に戻す | `markItemIncomplete(listId, itemId)` |
+
+`PATCH /items/{itemId}` の `completed` 更新は既存互換として残すが、一覧のチェック操作では使わない。レスポンスrevisionにギャップがある場合は既存の `useMutation` が snapshot を取り直す。
+
+## 競合テスト観点
+
+1. 他ユーザーが先に `true -> false` へ戻した後、古い `true` 表示の端末がチェック解除する。
+   - 期待: `markIncomplete` が no-op になり、`false -> true` へ戻らない。
+2. 他ユーザーが先に `false -> true` へ完了した後、古い `false` 表示の端末がチェックする。
+   - 期待: `markCompleted` が no-op になり、既存の完了者と完了日時を上書きしない。
+3. 2端末がほぼ同時に `markCompleted` と `markIncomplete` を送る。
+   - 期待: 最後にコミットされた意図が最終状態になる。どちらのリクエストもトグル値を送らないため、古い状態由来の逆反転は起きない。
+4. `markCompleted` にリスト外メンバーを指定する。
+   - 期待: 400 `bad_request`。

--- a/frontend/src/api/item.ts
+++ b/frontend/src/api/item.ts
@@ -15,6 +15,10 @@ export type UpdateItemPayload = {
   quantified?: QuantifiedItem | null;
 };
 
+export type MarkItemCompletedPayload = {
+  completedByMemberId: UUID;
+};
+
 type CreateItemPayloadBase = {
   name: string;
   category?: ItemCategory | null;
@@ -51,6 +55,16 @@ export async function createItem(listId: UUID, payload: CreateItemPayload) {
 
 export async function updateItem(listId: UUID, itemId: UUID, payload: UpdateItemPayload) {
   const res = await http.patch<MutationResponse<Item>>(`/lists/${listId}/items/${itemId}`, payload);
+  return res.data;
+}
+
+export async function markItemCompleted(listId: UUID, itemId: UUID, payload: MarkItemCompletedPayload) {
+  const res = await http.patch<MutationResponse<Item>>(`/lists/${listId}/items/${itemId}/mark-completed`, payload);
+  return res.data;
+}
+
+export async function markItemIncomplete(listId: UUID, itemId: UUID) {
+  const res = await http.patch<MutationResponse<Item>>(`/lists/${listId}/items/${itemId}/mark-incomplete`);
   return res.data;
 }
 

--- a/frontend/src/components/ItemGroupList.test.ts
+++ b/frontend/src/components/ItemGroupList.test.ts
@@ -37,6 +37,10 @@ function createItem(overrides: Partial<Item> = {}): Item {
 function createVm(overrides: Record<string, unknown> = {}) {
   const component = ItemGroupList as unknown as ItemGroupListOptions;
   const upsertItem = vi.fn();
+  const memberMap = new Map([
+    ['member-1', { id: 'member-1', displayName: '自分' }],
+    ['member-2', { id: 'member-2', displayName: '田中' }]
+  ]);
   const mutationRun = vi.fn(async (fn: () => Promise<unknown>) => {
     await fn();
     return {
@@ -48,10 +52,11 @@ function createVm(overrides: Record<string, unknown> = {}) {
   const vm: Record<string, unknown> = {
     ...component.data(),
     selectedMemberId: 'member-1',
+    memberMap,
     listStore: {
       listId: 'list-1',
       items: [],
-      memberMap: new Map(),
+      memberMap,
       upsertItem
     },
     mutationRun,
@@ -131,8 +136,6 @@ describe('ItemGroupList', () => {
     expect(markItemCompleted).toHaveBeenCalledWith('list-1', 'item-1', {
       completedByMemberId: 'member-1'
     });
-    expect(alert).toHaveBeenCalledWith(
-      'この操作では変更されませんでした。既に完了済みだったため、最新の完了者を表示しました。'
-    );
+    expect(alert).toHaveBeenCalledWith('このアイテムは「田中」が既に完了しています。');
   });
 });

--- a/frontend/src/components/ItemGroupList.test.ts
+++ b/frontend/src/components/ItemGroupList.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Item } from '@/types/item';
+
+vi.mock('@/api/item', () => ({
+  deleteItem: vi.fn(),
+  markItemCompleted: vi.fn(),
+  markItemIncomplete: vi.fn(),
+  updateItem: vi.fn()
+}));
+
+import { markItemCompleted, markItemIncomplete, updateItem } from '@/api/item';
+import ItemGroupList from './ItemGroupList.vue';
+
+type ItemGroupListOptions = {
+  data: () => Record<string, unknown>;
+  methods: Record<string, (this: Record<string, unknown>, ...args: unknown[]) => unknown>;
+};
+
+function createItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'item-1',
+    name: '牛乳',
+    itemType: 'plain',
+    category: null,
+    preparationType: null,
+    quantified: null,
+    completed: false,
+    assignedMemberId: null,
+    completedByMemberId: null,
+    completedAt: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides
+  };
+}
+
+function createVm(overrides: Record<string, unknown> = {}) {
+  const component = ItemGroupList as unknown as ItemGroupListOptions;
+  const upsertItem = vi.fn();
+  const mutationRun = vi.fn(async (fn: () => Promise<unknown>) => {
+    await fn();
+    return {
+      applied: true,
+      data: createItem({ completed: true, completedByMemberId: 'member-1' }),
+      revision: 2
+    };
+  });
+  const vm: Record<string, unknown> = {
+    ...component.data(),
+    selectedMemberId: 'member-1',
+    listStore: {
+      listId: 'list-1',
+      items: [],
+      memberMap: new Map(),
+      upsertItem
+    },
+    mutationRun,
+    ...overrides
+  };
+
+  Object.entries(component.methods).forEach(([name, method]) => {
+    vm[name] = method.bind(vm);
+  });
+
+  return vm;
+}
+
+describe('ItemGroupList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(markItemCompleted).mockResolvedValue({
+      revision: 2,
+      data: createItem({ completed: true, completedByMemberId: 'member-1' })
+    });
+    vi.mocked(markItemIncomplete).mockResolvedValue({
+      revision: 2,
+      data: createItem({ completed: false })
+    });
+  });
+
+  it('未完了アイテムのチェックはmarkItemCompletedを呼ぶ', async () => {
+    const item = createItem({ completed: false });
+    const vm = createVm();
+
+    await (vm.toggleItem as (item: Item) => Promise<void>)(item);
+
+    expect(markItemCompleted).toHaveBeenCalledWith('list-1', 'item-1', {
+      completedByMemberId: 'member-1'
+    });
+    expect(markItemIncomplete).not.toHaveBeenCalled();
+    expect(updateItem).not.toHaveBeenCalled();
+  });
+
+  it('完了済みアイテムのチェック解除はmarkItemIncompleteを呼ぶ', async () => {
+    const item = createItem({
+      completed: true,
+      completedByMemberId: 'member-2',
+      completedAt: '2024-01-01T00:10:00Z'
+    });
+    const vm = createVm({
+      mutationRun: vi.fn(async (fn: () => Promise<unknown>) => {
+        await fn();
+        return { applied: true, data: createItem({ completed: false }), revision: 3 };
+      })
+    });
+
+    await (vm.toggleItem as (item: Item) => Promise<void>)(item);
+
+    expect(markItemIncomplete).toHaveBeenCalledWith('list-1', 'item-1');
+    expect(markItemCompleted).not.toHaveBeenCalled();
+    expect(updateItem).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ItemGroupList.test.ts
+++ b/frontend/src/components/ItemGroupList.test.ts
@@ -68,6 +68,7 @@ function createVm(overrides: Record<string, unknown> = {}) {
 describe('ItemGroupList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('alert', vi.fn());
     vi.mocked(markItemCompleted).mockResolvedValue({
       revision: 2,
       data: createItem({ completed: true, completedByMemberId: 'member-1' })
@@ -109,5 +110,29 @@ describe('ItemGroupList', () => {
     expect(markItemIncomplete).toHaveBeenCalledWith('list-1', 'item-1');
     expect(markItemCompleted).not.toHaveBeenCalled();
     expect(updateItem).not.toHaveBeenCalled();
+  });
+
+  it('既に他の更新が反映済みだった場合はno-opとして通知する', async () => {
+    const item = createItem({ completed: false });
+    const vm = createVm({
+      mutationRun: vi.fn(async (fn: () => Promise<unknown>) => {
+        await fn();
+        return {
+          applied: true,
+          changed: false,
+          data: createItem({ completed: true, completedByMemberId: 'member-2' }),
+          revision: 3
+        };
+      })
+    });
+
+    await (vm.toggleItem as (item: Item) => Promise<void>)(item);
+
+    expect(markItemCompleted).toHaveBeenCalledWith('list-1', 'item-1', {
+      completedByMemberId: 'member-1'
+    });
+    expect(alert).toHaveBeenCalledWith(
+      'この操作では変更されませんでした。既に完了済みだったため、最新の完了者を表示しました。'
+    );
   });
 });

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -9,7 +9,7 @@ import type { ItemCategory } from '../types/item-category';
 import type { ItemPreparationType } from '../types/item-preparation-type';
 import type { MemberId } from '../types/member';
 import { normalizeText } from '../utils/text-normalization';
-import { deleteItem as deleteItemApi, updateItem } from '@/api/item';
+import { deleteItem as deleteItemApi, markItemCompleted, markItemIncomplete, updateItem } from '@/api/item';
 import { useListStore } from '@/stores/list';
 import { useMutation } from '@/composables/useMutation';
 import { groupItems } from '@/utils/item-grouping';
@@ -162,13 +162,24 @@ export default defineComponent({
         return;
       }
       const wasCompleted = item.completed;
-      const updatedItem: Partial<Item> = {
-        completed: !wasCompleted,
-        completedByMemberId: wasCompleted ? null : (this.selectedMemberId ?? null)
-      };
+      const completedByMemberId = this.selectedMemberId;
+      const completionMutation = (() => {
+        if (wasCompleted) {
+          return () => markItemIncomplete(listId, item.id);
+        }
+        if (!completedByMemberId) {
+          this.errorMessage = '買った人を選択してください。';
+          this.showErrorFeedback();
+          return null;
+        }
+        return () => markItemCompleted(listId, item.id, { completedByMemberId });
+      })();
+      if (!completionMutation) {
+        return;
+      }
       try {
         this.toggleLoading = { ...this.toggleLoading, [item.id]: true };
-        const result = await this.mutationRun(() => updateItem(listId, item.id, updatedItem));
+        const result = await this.mutationRun(completionMutation);
         if (result.applied) {
           this.listStore.upsertItem(result.data);
         }

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -150,12 +150,16 @@ export default defineComponent({
         }, 3000);
       }
     },
-    showCompletionNoopFeedback(wasCompleted: boolean): void {
-      if (wasCompleted) {
-        alert('この操作では変更されませんでした。既に未完了になっていたため、最新の状態を表示しました。');
+    showCompletionNoopFeedback(item: Item): void {
+      if (item.completed) {
+        const memberName =
+          item.completedByMemberId == null
+            ? '他のメンバー'
+            : (this.memberMap.get(item.completedByMemberId)?.displayName ?? '他のメンバー');
+        alert(`このアイテムは「${memberName}」が既に完了しています。`);
         return;
       }
-      alert('この操作では変更されませんでした。既に完了済みだったため、最新の完了者を表示しました。');
+      alert('このアイテムは既に未完了です。');
     },
     async toggleItem(item: Item) {
       if (this.toggleLoading[item.id]) {
@@ -191,7 +195,7 @@ export default defineComponent({
           this.listStore.upsertItem(result.data);
         }
         if (result.changed === false) {
-          this.showCompletionNoopFeedback(wasCompleted);
+          this.showCompletionNoopFeedback(result.data);
         }
       } catch (err: unknown) {
         console.error('Failed to update item', err);

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -150,6 +150,13 @@ export default defineComponent({
         }, 3000);
       }
     },
+    showCompletionNoopFeedback(wasCompleted: boolean): void {
+      if (wasCompleted) {
+        alert('この操作では変更されませんでした。既に未完了になっていたため、最新の状態を表示しました。');
+        return;
+      }
+      alert('この操作では変更されませんでした。既に完了済みだったため、最新の完了者を表示しました。');
+    },
     async toggleItem(item: Item) {
       if (this.toggleLoading[item.id]) {
         return;
@@ -182,6 +189,9 @@ export default defineComponent({
         const result = await this.mutationRun(completionMutation);
         if (result.applied) {
           this.listStore.upsertItem(result.data);
+        }
+        if (result.changed === false) {
+          this.showCompletionNoopFeedback(wasCompleted);
         }
       } catch (err: unknown) {
         console.error('Failed to update item', err);

--- a/frontend/src/composables/useMutation.ts
+++ b/frontend/src/composables/useMutation.ts
@@ -7,6 +7,7 @@ export type MutationRunResult<T> = {
   data: T;
   applied: boolean;
   revision: number;
+  changed?: boolean;
 };
 
 export function useMutation() {
@@ -27,19 +28,19 @@ export function useMutation() {
       const gap = nextRevision - currentRevision;
 
       if (nextRevision <= currentRevision) {
-        return { data: res.data, applied: false, revision: nextRevision };
+        return { data: res.data, applied: false, revision: nextRevision, changed: res.changed };
       }
 
       if (gap > 1 && listStore.listId) {
         const snapshot = await fetchSnapshot(listStore.listId);
         listStore.applySnapshot(snapshot);
         listStore.setRevision(Math.max(listStore.revision, nextRevision));
-        return { data: res.data, applied: false, revision: nextRevision };
+        return { data: res.data, applied: false, revision: nextRevision, changed: res.changed };
       }
 
       listStore.setRevision(nextRevision);
 
-      return { data: res.data, applied: true, revision: nextRevision };
+      return { data: res.data, applied: true, revision: nextRevision, changed: res.changed };
     } catch (err) {
       error.value = err as ApiError;
       throw err;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -7,6 +7,7 @@ export type UUID = string;
 export type MutationResponse<T> = {
   revision: number;
   data: T;
+  changed?: boolean;
 };
 
 export type ApiError = {


### PR DESCRIPTION
This pull request introduces intent-based APIs for marking items as completed or incomplete to prevent accidental state toggling due to stale client data. It adds new endpoints, backend service logic, and supporting DTOs, along with corresponding frontend API functions. The implementation ensures idempotency, proper revision handling, and clear error responses.

**API Changes:**

* Added two new endpoints to `ItemCommandController`: `markCompleted` and `markIncomplete`, each with idempotent behavior to prevent unintended state changes from stale client views.
* Documented the new intent-based API contract and usage in `docs/item-completion-intent-api.md`.

**Backend Implementation:**

* Introduced `ItemCompletionService` with methods to mark items as completed or incomplete, handling member validation, revision incrementing, and idempotency.
* Added `MarkItemCompletedRequest` DTO for specifying the member completing the item.
* Updated `MutationResponse` to include an optional `changed` field indicating whether the operation resulted in an actual state change.
* Enhanced `ItemRepository` with a pessimistic write lock method to safely fetch items for update during completion/incompletion.

**Frontend Support:**

* Added `markItemCompleted` and `markItemIncomplete` functions to the frontend API (`item.ts`) for calling the new endpoints. [[1]](diffhunk://#diff-747c2227edab9bef7e1aaa1f56f036d79210be82fe942e08fae109b76fa528a7R18-R21) [[2]](diffhunk://#diff-747c2227edab9bef7e1aaa1f56f036d79210be82fe942e08fae109b76fa528a7R61-R70)

**Testing:**

* Added `ItemCompletionServiceTest` to verify correct and idempotent behavior of the new service methods, including revision handling and no-op cases.