### PR TITLE
feat: apply optimistic concurrency to item operations

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemCommandController.java
@@ -5,19 +5,23 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.atoook.otsukailist.api.HttpPreconditions;
 import com.atoook.otsukailist.dto.CreateItemRequest;
 import com.atoook.otsukailist.dto.DeleteItemResponse;
 import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MarkItemCompletedRequest;
 import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.UpdateItemRequest;
 import com.atoook.otsukailist.service.ItemCommandService;
@@ -62,8 +66,47 @@ public class ItemCommandController {
   public ResponseEntity<MutationResponse<ItemResponse>> update(
       @PathVariable("listId") UUID listId,
       @PathVariable("itemId") UUID itemId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch,
       @Valid @RequestBody UpdateItemRequest req) {
-    return ResponseEntity.ok(itemCommandService.updateItem(listId, itemId, req));
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(itemCommandService.updateItem(listId, itemId, req, expectedVersion));
+  }
+
+  /**
+   * Marks an item as completed.
+   *
+   * @param listId parent list identifier
+   * @param itemId item identifier
+   * @param ifMatch expected item version
+   * @param req completion request payload
+   * @return 200 updated item response
+   */
+  @PatchMapping("/{itemId}/mark-completed")
+  public ResponseEntity<MutationResponse<ItemResponse>> markCompleted(
+      @PathVariable("listId") UUID listId,
+      @PathVariable("itemId") UUID itemId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch,
+      @Valid @RequestBody MarkItemCompletedRequest req) {
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(
+        itemCommandService.markCompleted(listId, itemId, req, expectedVersion));
+  }
+
+  /**
+   * Marks an item as incomplete.
+   *
+   * @param listId parent list identifier
+   * @param itemId item identifier
+   * @param ifMatch expected item version
+   * @return 200 updated item response
+   */
+  @PatchMapping("/{itemId}/mark-incomplete")
+  public ResponseEntity<MutationResponse<ItemResponse>> markIncomplete(
+      @PathVariable("listId") UUID listId,
+      @PathVariable("itemId") UUID itemId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch) {
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(itemCommandService.markIncomplete(listId, itemId, expectedVersion));
   }
 
   /**
@@ -75,7 +118,10 @@ public class ItemCommandController {
    */
   @DeleteMapping("/{itemId}")
   public ResponseEntity<MutationResponse<DeleteItemResponse>> delete(
-      @PathVariable("listId") UUID listId, @PathVariable("itemId") UUID itemId) {
-    return ResponseEntity.ok(itemCommandService.deleteItem(listId, itemId));
+      @PathVariable("listId") UUID listId,
+      @PathVariable("itemId") UUID itemId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch) {
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(itemCommandService.deleteItem(listId, itemId, expectedVersion));
   }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/dto/MarkItemCompletedRequest.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/MarkItemCompletedRequest.java
@@ -1,0 +1,22 @@
+package com.atoook.otsukailist.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MarkItemCompletedRequest {
+
+  @NotNull(message = "完了者は必須です")
+  private UUID completedByMemberId;
+}

--- a/backend/src/main/java/com/atoook/otsukailist/dto/MutationResponse.java
+++ b/backend/src/main/java/com/atoook/otsukailist/dto/MutationResponse.java
@@ -1,5 +1,6 @@
 package com.atoook.otsukailist.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,7 +8,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MutationResponse<T> {
   private long revision;
+  private Boolean changed;
   private T data;
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/GeneratedItemSyncCommandService.java
@@ -8,6 +8,9 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +44,7 @@ public class GeneratedItemSyncCommandService {
   private final MemberRepository memberRepo;
   private final ListRevisionService listRevisionService;
   private final ListItemLimitService listItemLimitService;
+  private final EntityManager entityManager;
 
   private static final String MSG_ASSIGNED_MEMBER_NOT_IN_LIST = "指定された担当者はリストのメンバーではありません";
   private static final String MSG_GENERATED_ITEM_DUPLICATED = "生成アイテムが重複しています";
@@ -108,8 +112,9 @@ public class GeneratedItemSyncCommandService {
             .count();
     listItemLimitService.validateItemCountAfterChange(listId, newItemCount, deletedItems.size());
 
-    List<Item> savedItems = itemRepo.saveAll(changedItems);
+    List<Item> savedItems = itemRepo.saveAllAndFlush(changedItems);
     itemRepo.deleteAll(deletedItems);
+    itemRepo.flush();
     long revision = listRevisionService.incrementAndGet(listId);
 
     SyncGeneratedItemsResponse data =
@@ -133,6 +138,7 @@ public class GeneratedItemSyncCommandService {
         return null;
       }
       updateExistingGeneratedAutoItem(existingItem, command);
+      entityManager.lock(existingItem, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
       return existingItem;
     }
 

--- a/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ItemCommandService.java
@@ -4,12 +4,16 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.atoook.otsukailist.dto.CreateItemRequest;
 import com.atoook.otsukailist.dto.DeleteItemResponse;
 import com.atoook.otsukailist.dto.ItemResponse;
+import com.atoook.otsukailist.dto.MarkItemCompletedRequest;
 import com.atoook.otsukailist.dto.MutationResponse;
 import com.atoook.otsukailist.dto.QuantifiedItemRequest;
 import com.atoook.otsukailist.dto.UpdateItemRequest;
@@ -29,6 +33,7 @@ import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.ItemRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
+import com.atoook.otsukailist.service.validation.ResourceVersionValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,6 +47,7 @@ public class ItemCommandService {
 
   private final ListRevisionService listRevisionService;
   private final ListItemLimitService listItemLimitService;
+  private final EntityManager entityManager;
 
   private static final String MSG_MEMBER_NOT_IN_LIST = "指定された完了者はリストのメンバーではありません";
   private static final String MSG_ASSIGNED_MEMBER_NOT_IN_LIST = "指定された担当者はリストのメンバーではありません";
@@ -109,19 +115,17 @@ public class ItemCommandService {
   /** Item更新（rename / setCompleted） */
   @Transactional
   public MutationResponse<ItemResponse> updateItem(
-      UUID listId, UUID itemId, UpdateItemRequest req) {
-    Item item =
-        itemRepo
-            .findByIdAndItemListId(itemId, listId)
-            .orElseThrow(
-                () ->
-                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
+      UUID listId, UUID itemId, UpdateItemRequest req, long expectedVersion) {
+    Item item = findItemInList(listId, itemId);
+    ResourceVersionValidator.requireCurrentVersion(
+        "item", item.getId(), expectedVersion, item.getVersion());
 
     updateNameCategoryAndQuantified(item, req);
     updateAssignedMember(listId, item, req);
     updateCompletion(listId, item, req);
 
-    Item saved = itemRepo.save(item);
+    forceItemVersionIncrement(item);
+    Item saved = itemRepo.saveAndFlush(item);
 
     long revision = listRevisionService.incrementAndGet(listId);
 
@@ -133,16 +137,14 @@ public class ItemCommandService {
 
   /** Item削除（listIdスコープ） */
   @Transactional
-  public MutationResponse<DeleteItemResponse> deleteItem(UUID listId, UUID itemId) {
-    // listIdスコープで存在確認
-    Item item =
-        itemRepo
-            .findByIdAndItemListId(itemId, listId)
-            .orElseThrow(
-                () ->
-                    new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
+  public MutationResponse<DeleteItemResponse> deleteItem(
+      UUID listId, UUID itemId, long expectedVersion) {
+    Item item = findItemInList(listId, itemId);
+    ResourceVersionValidator.requireCurrentVersion(
+        "item", item.getId(), expectedVersion, item.getVersion());
 
     itemRepo.delete(item);
+    itemRepo.flush();
 
     long revision = listRevisionService.incrementAndGet(listId);
 
@@ -150,6 +152,75 @@ public class ItemCommandService {
         .revision(revision)
         .data(DeleteItemResponse.builder().deletedItemId(itemId).build())
         .build();
+  }
+
+  /** Mark an item as completed with an explicit user intent. */
+  @Transactional
+  public MutationResponse<ItemResponse> markCompleted(
+      UUID listId, UUID itemId, MarkItemCompletedRequest req, long expectedVersion) {
+    Item item = findItemInList(listId, itemId);
+    ResourceVersionValidator.requireCurrentVersion(
+        "item", item.getId(), expectedVersion, item.getVersion());
+
+    if (item.isCompleted()) {
+      return unchangedItemResponse(listId, item);
+    }
+
+    completeItem(listId, item, req.getCompletedByMemberId());
+    forceItemVersionIncrement(item);
+    Item saved = itemRepo.saveAndFlush(item);
+    long revision = listRevisionService.incrementAndGet(listId);
+
+    return MutationResponse.<ItemResponse>builder()
+        .revision(revision)
+        .changed(true)
+        .data(ItemMapper.toResponse(saved))
+        .build();
+  }
+
+  /** Mark an item as incomplete with an explicit user intent. */
+  @Transactional
+  public MutationResponse<ItemResponse> markIncomplete(
+      UUID listId, UUID itemId, long expectedVersion) {
+    Item item = findItemInList(listId, itemId);
+    ResourceVersionValidator.requireCurrentVersion(
+        "item", item.getId(), expectedVersion, item.getVersion());
+
+    if (!item.isCompleted()) {
+      return unchangedItemResponse(listId, item);
+    }
+
+    item.setCompleted(false);
+    item.setCompletedByMemberId(null);
+    item.setCompletedAt(null);
+    forceItemVersionIncrement(item);
+    Item saved = itemRepo.saveAndFlush(item);
+    long revision = listRevisionService.incrementAndGet(listId);
+
+    return MutationResponse.<ItemResponse>builder()
+        .revision(revision)
+        .changed(true)
+        .data(ItemMapper.toResponse(saved))
+        .build();
+  }
+
+  private MutationResponse<ItemResponse> unchangedItemResponse(UUID listId, Item item) {
+    return MutationResponse.<ItemResponse>builder()
+        .revision(listRevisionService.current(listId))
+        .changed(false)
+        .data(ItemMapper.toResponse(item))
+        .build();
+  }
+
+  private Item findItemInList(UUID listId, UUID itemId) {
+    return itemRepo
+        .findByIdAndItemListId(itemId, listId)
+        .orElseThrow(
+            () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "アイテム")));
+  }
+
+  private void forceItemVersionIncrement(Item item) {
+    entityManager.lock(item, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
   }
 
   private static void validateQuantifiedCreateRequest(ItemType itemType, CreateItemRequest req) {
@@ -234,7 +305,7 @@ public class ItemCommandService {
       return;
     }
     if (req.getCompleted()) {
-      completeItem(listId, item, req);
+      completeItem(listId, item, req.getCompletedByMemberId());
       return;
     }
     item.setCompleted(false);
@@ -242,16 +313,16 @@ public class ItemCommandService {
     item.setCompletedAt(null);
   }
 
-  private void completeItem(UUID listId, Item item, UpdateItemRequest req) {
-    if (req.getCompletedByMemberId() == null) {
+  private void completeItem(UUID listId, Item item, UUID completedByMemberId) {
+    if (completedByMemberId == null) {
       throw new BadRequestException(MSG_COMPLETED_BY_NOT_SPECIFIED);
     }
-    boolean exists = memberRepo.existsByIdAndItemListId(req.getCompletedByMemberId(), listId);
+    boolean exists = memberRepo.existsByIdAndItemListId(completedByMemberId, listId);
     if (!exists) {
       throw new BadRequestException(MSG_MEMBER_NOT_IN_LIST);
     }
     item.setCompleted(true);
-    item.setCompletedByMemberId(req.getCompletedByMemberId());
+    item.setCompletedByMemberId(completedByMemberId);
     item.setCompletedAt(Instant.now());
   }
 

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListRevisionService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListRevisionService.java
@@ -25,6 +25,17 @@ public class ListRevisionService {
     if (updated != 1) {
       throw new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト"));
     }
+    return current(listId);
+  }
+
+  /**
+   * Return the current list revision inside an existing transaction.
+   *
+   * @param listId target list ID
+   * @return current revision
+   */
+  @Transactional(propagation = Propagation.MANDATORY, readOnly = true)
+  public long current(UUID listId) {
     return itemListRepo
         .findRevision(listId)
         .orElseThrow(

--- a/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/GeneratedItemCommandServiceTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import jakarta.persistence.EntityManager;
+
 import com.atoook.otsukailist.config.AppItemProperties;
 import com.atoook.otsukailist.dto.CreateItemRequest;
 import com.atoook.otsukailist.dto.QuantifiedItemRequest;
@@ -40,6 +42,7 @@ class GeneratedItemCommandServiceTest {
   @Mock private ItemListRepository itemListRepo;
   @Mock private MemberRepository memberRepo;
   @Mock private ListRevisionService listRevisionService;
+  @Mock private EntityManager entityManager;
 
   private AppItemProperties itemProperties;
   private GeneratedItemCommandService service;
@@ -50,7 +53,12 @@ class GeneratedItemCommandServiceTest {
     ListItemLimitService listItemLimitService = new ListItemLimitService(itemRepo, itemProperties);
     GeneratedItemSyncCommandService generatedItemSyncCommandService =
         new GeneratedItemSyncCommandService(
-            itemRepo, itemListRepo, memberRepo, listRevisionService, listItemLimitService);
+            itemRepo,
+            itemListRepo,
+            memberRepo,
+            listRevisionService,
+            listItemLimitService,
+            entityManager);
     service = new GeneratedItemCommandService(generatedItemSyncCommandService);
   }
 
@@ -69,7 +77,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
         .thenReturn(List.of(existingItem));
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -98,7 +106,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("yakisoba")))
         .thenReturn(List.of());
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -153,7 +161,7 @@ class GeneratedItemCommandServiceTest {
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
         .thenReturn(List.of(seafood));
     when(itemRepo.countByItemListId(listId)).thenReturn(100L);
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(3L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -177,7 +185,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
         .thenReturn(List.of(existingItem));
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -204,7 +212,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef")))
         .thenReturn(List.of(existingItem));
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -235,7 +243,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
         .thenReturn(List.of(seafood));
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(3L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -263,7 +271,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
         .thenReturn(List.of(seafood));
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(4L);
 
     var result = service.syncGeneratedItems(listId, request);
@@ -290,7 +298,7 @@ class GeneratedItemCommandServiceTest {
     when(itemListRepo.findByIdForUpdate(listId)).thenReturn(Optional.of(list));
     when(itemRepo.findGeneratedItemsByGeneratorKeys(listId, List.of("beef", "seafood_shrimp")))
         .thenReturn(List.of(seafood));
-    when(itemRepo.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(itemRepo.saveAllAndFlush(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(listRevisionService.incrementAndGet(listId)).thenReturn(4L);
 
     var result = service.syncGeneratedItems(listId, request);

--- a/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ItemCommandServiceTest.java
@@ -8,11 +8,15 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import java.util.UUID;
 
+import jakarta.persistence.EntityManager;
+
 import com.atoook.otsukailist.config.AppItemProperties;
 import com.atoook.otsukailist.dto.CreateItemRequest;
+import com.atoook.otsukailist.dto.MarkItemCompletedRequest;
 import com.atoook.otsukailist.dto.QuantifiedItemRequest;
 import com.atoook.otsukailist.dto.UpdateItemRequest;
 import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.PreconditionFailedException;
 import com.atoook.otsukailist.model.BaseUnit;
 import com.atoook.otsukailist.model.Item;
 import com.atoook.otsukailist.model.ItemCategory;
@@ -40,6 +44,7 @@ class ItemCommandServiceTest {
   @Mock private ItemListRepository itemListRepo;
   @Mock private MemberRepository memberRepo;
   @Mock private ListRevisionService listRevisionService;
+  @Mock private EntityManager entityManager;
 
   private AppItemProperties itemProperties;
   private ItemCommandService service;
@@ -50,7 +55,12 @@ class ItemCommandServiceTest {
     ListItemLimitService listItemLimitService = new ListItemLimitService(itemRepo, itemProperties);
     service =
         new ItemCommandService(
-            itemRepo, itemListRepo, memberRepo, listRevisionService, listItemLimitService);
+            itemRepo,
+            itemListRepo,
+            memberRepo,
+            listRevisionService,
+            listItemLimitService,
+            entityManager);
   }
 
   @Test
@@ -198,6 +208,92 @@ class ItemCommandServiceTest {
   }
 
   @Test
+  @DisplayName("更新時にversionが一致しない場合は拒否すること")
+  void updateItemRejectsStaleVersion() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    Item item = plainItem("牛乳");
+    item.setId(itemId);
+    item.setVersion(3L);
+    UpdateItemRequest request = UpdateItemRequest.builder().name("低脂肪牛乳").build();
+
+    when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
+
+    assertThatThrownBy(() -> service.updateItem(listId, itemId, request, 2L))
+        .isInstanceOf(PreconditionFailedException.class)
+        .extracting("expectedVersion", "currentVersion")
+        .containsExactly(2L, 3L);
+  }
+
+  @Test
+  @DisplayName("意図別完了APIは未完了itemを完了に更新すること")
+  void markCompletedCompletesIncompleteItem() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Item item = plainItem("牛乳");
+    item.setId(itemId);
+    MarkItemCompletedRequest request =
+        MarkItemCompletedRequest.builder().completedByMemberId(memberId).build();
+
+    when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
+    when(memberRepo.existsByIdAndItemListId(memberId, listId)).thenReturn(true);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(2L);
+
+    var result = service.markCompleted(listId, itemId, request, 0L);
+
+    assertThat(result.getChanged()).isTrue();
+    assertThat(item.isCompleted()).isTrue();
+    assertThat(item.getCompletedByMemberId()).isEqualTo(memberId);
+    assertThat(item.getCompletedAt()).isNotNull();
+    assertThat(result.getRevision()).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("意図別完了APIはversionが一致しない場合は拒否すること")
+  void markCompletedRejectsStaleVersion() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Item item = plainItem("牛乳");
+    item.setId(itemId);
+    item.setVersion(4L);
+    MarkItemCompletedRequest request =
+        MarkItemCompletedRequest.builder().completedByMemberId(memberId).build();
+
+    when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
+
+    assertThatThrownBy(() -> service.markCompleted(listId, itemId, request, 3L))
+        .isInstanceOf(PreconditionFailedException.class);
+  }
+
+  @Test
+  @DisplayName("意図別未完了APIは完了済みitemを未完了に戻すこと")
+  void markIncompleteClearsCompletedFields() {
+    UUID listId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Item item = plainItem("牛乳");
+    item.setId(itemId);
+    item.setCompleted(true);
+    item.setCompletedByMemberId(memberId);
+    item.setCompletedAt(java.time.Instant.parse("2024-01-01T00:00:00Z"));
+
+    when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
+    when(listRevisionService.incrementAndGet(listId)).thenReturn(3L);
+
+    var result = service.markIncomplete(listId, itemId, 0L);
+
+    assertThat(result.getChanged()).isTrue();
+    assertThat(item.isCompleted()).isFalse();
+    assertThat(item.getCompletedByMemberId()).isNull();
+    assertThat(item.getCompletedAt()).isNull();
+    assertThat(result.getRevision()).isEqualTo(3L);
+  }
+
+  @Test
   @DisplayName("更新時に空白のみの名前を送った場合は拒否すること")
   void updateItemRejectsBlankNameAfterTrim() {
     UUID listId = UUID.randomUUID();
@@ -206,7 +302,7 @@ class ItemCommandServiceTest {
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(plainItem("牛乳")));
 
-    assertThatThrownBy(() -> service.updateItem(listId, itemId, request))
+    assertThatThrownBy(() -> service.updateItem(listId, itemId, request, 0L))
         .isInstanceOf(BadRequestException.class)
         .hasMessage("アイテム名は必須です");
   }
@@ -229,7 +325,7 @@ class ItemCommandServiceTest {
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(plainItem("牛肉")));
 
-    assertThatThrownBy(() -> service.updateItem(listId, itemId, request))
+    assertThatThrownBy(() -> service.updateItem(listId, itemId, request, 0L))
         .isInstanceOf(BadRequestException.class)
         .hasMessage("数量付きアイテムの生成状態が不正です");
   }
@@ -246,7 +342,7 @@ class ItemCommandServiceTest {
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(plainItem("牛肉")));
 
-    assertThatThrownBy(() -> service.updateItem(listId, itemId, request))
+    assertThatThrownBy(() -> service.updateItem(listId, itemId, request, 0L))
         .isInstanceOf(BadRequestException.class)
         .hasMessage("未知の生成ルールIDです");
   }
@@ -272,10 +368,10 @@ class ItemCommandServiceTest {
             .build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    var result = service.updateItem(listId, itemId, request);
+    var result = service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getName()).isEqualTo("直接編集された名前");
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.LOCKED);
@@ -291,10 +387,10 @@ class ItemCommandServiceTest {
     UpdateItemRequest request = UpdateItemRequest.builder().name("直接編集された名前").build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    var result = service.updateItem(listId, itemId, request);
+    var result = service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getName()).isEqualTo("直接編集された名前");
     assertThat(item.getQuantified().getQuantity()).isEqualTo(1000L);
@@ -314,10 +410,10 @@ class ItemCommandServiceTest {
         UpdateItemRequest.builder().preparationType(ItemPreparationType.BRING).build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    var result = service.updateItem(listId, itemId, request);
+    var result = service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getPreparationType()).isEqualTo(ItemPreparationType.BRING);
     assertThat(result.getData().getPreparationType()).isEqualTo(ItemPreparationType.BRING);
@@ -341,10 +437,10 @@ class ItemCommandServiceTest {
             .build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    var result = service.updateItem(listId, itemId, request);
+    var result = service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getItemType()).isEqualTo(ItemType.QUANTIFIED);
     assertThat(item.getName()).isEqualTo("牛肉");
@@ -369,10 +465,10 @@ class ItemCommandServiceTest {
             .build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    service.updateItem(listId, itemId, request);
+    service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getCategory()).isEqualTo(ItemCategory.MEAT);
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.AUTO);
@@ -393,10 +489,10 @@ class ItemCommandServiceTest {
             .build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    service.updateItem(listId, itemId, request);
+    service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getCategory()).isEqualTo(ItemCategory.MEAT);
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.AUTO);
@@ -418,10 +514,10 @@ class ItemCommandServiceTest {
             .build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    service.updateItem(listId, itemId, request);
+    service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getCategory()).isEqualTo(ItemCategory.MEAT);
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.LOCKED);
@@ -442,10 +538,10 @@ class ItemCommandServiceTest {
             .build();
 
     when(itemRepo.findByIdAndItemListId(itemId, listId)).thenReturn(Optional.of(item));
-    when(itemRepo.save(item)).thenReturn(item);
+    when(itemRepo.saveAndFlush(item)).thenReturn(item);
     when(listRevisionService.incrementAndGet(listId)).thenReturn(1L);
 
-    service.updateItem(listId, itemId, request);
+    service.updateItem(listId, itemId, request, 0L);
 
     assertThat(item.getCategory()).isEqualTo(ItemCategory.MEAT);
     assertThat(item.getQuantified().getRegenerationPolicy()).isEqualTo(RegenerationPolicy.AUTO);

--- a/frontend/src/api/item.ts
+++ b/frontend/src/api/item.ts
@@ -1,4 +1,5 @@
 import { http } from '@/lib/http';
+import { ifMatchHeaders } from '@/api/preconditions';
 import type { DeleteResponse, Item, MutationResponse, UUID } from '@/types/api';
 import type { ItemCategory } from '@/types/item-category';
 import type { ItemPreparationType } from '@/types/item-preparation-type';
@@ -44,18 +45,52 @@ export type SyncGeneratedItemsResponse = {
   deletedItemIds: UUID[];
 };
 
+export type MarkItemCompletedPayload = {
+  completedByMemberId: UUID;
+};
+
 export async function createItem(listId: UUID, payload: CreateItemPayload) {
   const res = await http.post<MutationResponse<Item>>(`/lists/${listId}/items`, payload);
   return res.data;
 }
 
-export async function updateItem(listId: UUID, itemId: UUID, payload: UpdateItemPayload) {
-  const res = await http.patch<MutationResponse<Item>>(`/lists/${listId}/items/${itemId}`, payload);
+export async function updateItem(listId: UUID, itemId: UUID, payload: UpdateItemPayload, version: number) {
+  const res = await http.patch<MutationResponse<Item>>(
+    `/lists/${listId}/items/${itemId}`,
+    payload,
+    ifMatchHeaders(version)
+  );
   return res.data;
 }
 
-export async function deleteItem(listId: UUID, itemId: UUID) {
-  const res = await http.delete<MutationResponse<DeleteResponse>>(`/lists/${listId}/items/${itemId}`);
+export async function markItemCompleted(
+  listId: UUID,
+  itemId: UUID,
+  payload: MarkItemCompletedPayload,
+  version: number
+) {
+  const res = await http.patch<MutationResponse<Item>>(
+    `/lists/${listId}/items/${itemId}/mark-completed`,
+    payload,
+    ifMatchHeaders(version)
+  );
+  return res.data;
+}
+
+export async function markItemIncomplete(listId: UUID, itemId: UUID, version: number) {
+  const res = await http.patch<MutationResponse<Item>>(
+    `/lists/${listId}/items/${itemId}/mark-incomplete`,
+    undefined,
+    ifMatchHeaders(version)
+  );
+  return res.data;
+}
+
+export async function deleteItem(listId: UUID, itemId: UUID, version: number) {
+  const res = await http.delete<MutationResponse<DeleteResponse>>(
+    `/lists/${listId}/items/${itemId}`,
+    ifMatchHeaders(version)
+  );
   return res.data;
 }
 

--- a/frontend/src/api/preconditions.ts
+++ b/frontend/src/api/preconditions.ts
@@ -1,0 +1,7 @@
+export function ifMatchHeaders(version: number) {
+  return {
+    headers: {
+      'If-Match': `"${version}"`
+    }
+  };
+}

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -156,9 +156,14 @@ export default defineComponent({
         return false;
       }
 
-      const snapshot = await fetchSnapshot(listId);
-      this.listStore.applySnapshot(snapshot);
-      this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+      try {
+        const snapshot = await fetchSnapshot(listId);
+        this.listStore.applySnapshot(snapshot);
+        this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+      } catch (refreshErr: unknown) {
+        console.error('Failed to refresh snapshot after stale item state', refreshErr);
+        this.errorMessage = getErrorMessage(refreshErr) ?? '最新の状態を取得できませんでした。';
+      }
       this.showErrorFeedback();
       return true;
     },

--- a/frontend/src/components/ItemGroupList.vue
+++ b/frontend/src/components/ItemGroupList.vue
@@ -9,12 +9,13 @@ import type { ItemCategory } from '../types/item-category';
 import type { ItemPreparationType } from '../types/item-preparation-type';
 import type { MemberId } from '../types/member';
 import { normalizeText } from '../utils/text-normalization';
-import { deleteItem as deleteItemApi, updateItem } from '@/api/item';
+import { deleteItem as deleteItemApi, markItemCompleted, markItemIncomplete, updateItem } from '@/api/item';
+import { fetchSnapshot } from '@/api/list';
 import { useListStore } from '@/stores/list';
 import { useMutation } from '@/composables/useMutation';
 import { groupItems } from '@/utils/item-grouping';
 import type { GroupDefinition, ItemGroup } from '@/utils/item-grouping';
-import { getErrorMessage } from '@/lib/http';
+import { getErrorMessage, hasApiErrorCode } from '@/lib/http';
 import { buildGeneratedItemExclusionConfigMutation } from '@/lib/listTemplateExclusions';
 
 const ITEM_GROUP_DEFINITIONS: GroupDefinition<Item>[] = [
@@ -150,6 +151,17 @@ export default defineComponent({
         }, 3000);
       }
     },
+    async refreshSnapshotAfterStaleState(listId: string, err: unknown): Promise<boolean> {
+      if (!hasApiErrorCode(err, 'precondition_failed')) {
+        return false;
+      }
+
+      const snapshot = await fetchSnapshot(listId);
+      this.listStore.applySnapshot(snapshot);
+      this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+      this.showErrorFeedback();
+      return true;
+    },
     async toggleItem(item: Item) {
       if (this.toggleLoading[item.id]) {
         return;
@@ -162,18 +174,26 @@ export default defineComponent({
         return;
       }
       const wasCompleted = item.completed;
-      const updatedItem: Partial<Item> = {
-        completed: !wasCompleted,
-        completedByMemberId: wasCompleted ? null : (this.selectedMemberId ?? null)
-      };
+      if (!wasCompleted && !this.selectedMemberId) {
+        this.errorMessage = '買った人を選択してください。';
+        this.showErrorFeedback();
+        return;
+      }
       try {
         this.toggleLoading = { ...this.toggleLoading, [item.id]: true };
-        const result = await this.mutationRun(() => updateItem(listId, item.id, updatedItem));
+        const result = await this.mutationRun(() =>
+          wasCompleted
+            ? markItemIncomplete(listId, item.id, item.version)
+            : markItemCompleted(listId, item.id, { completedByMemberId: this.selectedMemberId! }, item.version)
+        );
         if (result.applied) {
           this.listStore.upsertItem(result.data);
         }
       } catch (err: unknown) {
         console.error('Failed to update item', err);
+        if (await this.refreshSnapshotAfterStaleState(listId, err)) {
+          return;
+        }
         this.errorMessage = getErrorMessage(err) ?? 'アイテムの更新に失敗しました。';
         this.showErrorFeedback();
       } finally {
@@ -194,8 +214,13 @@ export default defineComponent({
       }
       try {
         const item = this.listStore.items.find((candidate) => candidate.id === itemId) ?? null;
+        if (!item) {
+          this.errorMessage = 'アイテムが見つかりませんでした。';
+          this.showErrorFeedback();
+          return;
+        }
         this.deleteLoading = { ...this.deleteLoading, [itemId]: true };
-        const result = await this.mutationRun(() => deleteItemApi(listId, itemId));
+        const result = await this.mutationRun(() => deleteItemApi(listId, itemId, item.version));
         if (result.applied) {
           this.listStore.removeItem(itemId);
         }
@@ -214,6 +239,9 @@ export default defineComponent({
         }
       } catch (err: unknown) {
         console.error('Failed to delete item', err);
+        if (await this.refreshSnapshotAfterStaleState(listId, err)) {
+          return;
+        }
         this.errorMessage = getErrorMessage(err) ?? 'アイテムの削除に失敗しました。';
         this.showErrorFeedback();
       } finally {
@@ -236,12 +264,17 @@ export default defineComponent({
         return;
       }
       try {
-        const result = await this.mutationRun(() => updateItem(listId, updatedItem.id, { name: normalizedItemName }));
+        const result = await this.mutationRun(() =>
+          updateItem(listId, updatedItem.id, { name: normalizedItemName }, updatedItem.version)
+        );
         if (result.applied) {
           this.listStore.upsertItem(result.data);
         }
       } catch (err: unknown) {
         console.error('Failed to rename item', err);
+        if (await this.refreshSnapshotAfterStaleState(listId, err)) {
+          return;
+        }
         this.errorMessage = getErrorMessage(err) ?? 'アイテムの更新に失敗しました。';
         this.showErrorFeedback();
       }

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -57,6 +57,10 @@ export function getErrorMessage(err: unknown): string | null {
   return null;
 }
 
+export function hasApiErrorCode(err: unknown, code: string): boolean {
+  return isApiError(err) && err.error === code;
+}
+
 export const http = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
   headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/pages/ItemEditPage.vue
+++ b/frontend/src/pages/ItemEditPage.vue
@@ -18,7 +18,7 @@ import { useListStore } from '@/stores/list';
 import { useMutation } from '@/composables/useMutation';
 import { updateItem, type UpdateItemPayload } from '@/api/item';
 import { fetchSnapshot } from '@/api/list';
-import { getErrorMessage } from '@/lib/http';
+import { getErrorMessage, hasApiErrorCode } from '@/lib/http';
 import { GENERATION_RULES } from '@/lib/listGenerationConstants';
 import { resolveUnitLabel } from '@/lib/quantityDisplay';
 
@@ -243,9 +243,14 @@ export default defineComponent({
         this.errorMessage = '数量付きアイテムの各項目を正しく入力してください。';
         return;
       }
+      const currentItem = this.findCurrentItem();
+      if (!currentItem) {
+        this.errorMessage = 'アイテムが見つかりませんでした。';
+        return;
+      }
       try {
         const result = await this.mutationRun(() =>
-          updateItem(this.currentListId!, this.currentItemId!, this.buildUpdatePayload(normalizedName))
+          updateItem(this.currentListId!, this.currentItemId!, this.buildUpdatePayload(normalizedName), currentItem.version)
         );
         if (result.applied) {
           this.listStore.upsertItem(result.data);
@@ -256,6 +261,12 @@ export default defineComponent({
         }
       } catch (err: unknown) {
         console.error('Failed to update item', err);
+        if (hasApiErrorCode(err, 'precondition_failed')) {
+          await this.loadSnapshot(this.currentListId);
+          this.applyCurrentItem();
+          this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+          return;
+        }
         this.errorMessage = getErrorMessage(err) ?? 'アイテムの更新に失敗しました。';
       }
     },

--- a/frontend/src/pages/ItemEditPage.vue
+++ b/frontend/src/pages/ItemEditPage.vue
@@ -148,16 +148,18 @@ export default defineComponent({
       }
       return 'manual_none';
     },
-    async loadSnapshot(listId: string): Promise<void> {
+    async loadSnapshot(listId: string): Promise<boolean> {
       this.snapshotLoading = true;
       this.errorMessage = '';
 
       try {
         const snapshot = await fetchSnapshot(listId);
         this.listStore.applySnapshot(snapshot);
+        return true;
       } catch (err: unknown) {
         console.error('Failed to load snapshot', err);
         this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';
+        return false;
       } finally {
         this.snapshotLoading = false;
       }
@@ -262,9 +264,10 @@ export default defineComponent({
       } catch (err: unknown) {
         console.error('Failed to update item', err);
         if (hasApiErrorCode(err, 'precondition_failed')) {
-          await this.loadSnapshot(this.currentListId);
-          this.applyCurrentItem();
-          this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+          if (await this.loadSnapshot(this.currentListId)) {
+            this.applyCurrentItem();
+            this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+          }
           return;
         }
         this.errorMessage = getErrorMessage(err) ?? 'アイテムの更新に失敗しました。';


### PR DESCRIPTION
## Summary

- Require If-Match for item update, mark-completed, mark-incomplete, and delete operations.
- Add intent-specific item completion APIs.
- Refresh the client snapshot when an item mutation is rejected as stale.
- Preserve pessimistic locking for add/count-limit behavior outside this PR's scope.

## Scope

This PR is stacked on #96 and applies the foundation only to item mutations.

## Validation

- `./gradlew check`
- `npm run build`
- `npm run test:run`
- `git diff --check`