### PR TITLE
feat: apply optimistic concurrency to member and list metadata

### DIFF
--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/ItemListCommandController.java
@@ -5,15 +5,18 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.atoook.otsukailist.api.HttpPreconditions;
 import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
 import com.atoook.otsukailist.dto.CreateItemListWithMembersResponse;
 import com.atoook.otsukailist.dto.ItemListResponse;
@@ -57,7 +60,10 @@ public class ItemListCommandController {
    */
   @PatchMapping("/{listId}")
   public ResponseEntity<MutationResponse<ItemListResponse>> rename(
-      @PathVariable("listId") UUID listId, @Valid @RequestBody UpdateItemListRequest req) {
-    return ResponseEntity.ok(listCommandService.renameList(listId, req));
+      @PathVariable("listId") UUID listId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch,
+      @Valid @RequestBody UpdateItemListRequest req) {
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(listCommandService.renameList(listId, req, expectedVersion));
   }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
+++ b/backend/src/main/java/com/atoook/otsukailist/api/controller/MemberCommandController.java
@@ -5,16 +5,19 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.atoook.otsukailist.api.HttpPreconditions;
 import com.atoook.otsukailist.dto.CreateMemberRequest;
 import com.atoook.otsukailist.dto.DeleteMemberResponse;
 import com.atoook.otsukailist.dto.MemberResponse;
@@ -61,8 +64,11 @@ public class MemberCommandController {
   public ResponseEntity<MutationResponse<MemberResponse>> rename(
       @PathVariable("listId") UUID listId,
       @PathVariable("memberId") UUID memberId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch,
       @Valid @RequestBody CreateMemberRequest req) {
-    return ResponseEntity.ok(memberCommandService.renameMember(listId, memberId, req));
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(
+        memberCommandService.renameMember(listId, memberId, req, expectedVersion));
   }
 
   /**
@@ -74,7 +80,10 @@ public class MemberCommandController {
    */
   @DeleteMapping("/{memberId}")
   public ResponseEntity<MutationResponse<DeleteMemberResponse>> delete(
-      @PathVariable("listId") UUID listId, @PathVariable("memberId") UUID memberId) {
-    return ResponseEntity.ok(memberCommandService.deleteMember(listId, memberId));
+      @PathVariable("listId") UUID listId,
+      @PathVariable("memberId") UUID memberId,
+      @RequestHeader(value = HttpHeaders.IF_MATCH, required = false) String ifMatch) {
+    long expectedVersion = HttpPreconditions.requireIfMatchVersion(ifMatch);
+    return ResponseEntity.ok(memberCommandService.deleteMember(listId, memberId, expectedVersion));
   }
 }

--- a/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/ListCommandService.java
@@ -23,6 +23,7 @@ import com.atoook.otsukailist.model.Member;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
+import com.atoook.otsukailist.service.validation.ResourceVersionValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -97,12 +98,15 @@ public class ListCommandService {
    * @return renamed list payload with the incremented revision
    */
   @Transactional
-  public MutationResponse<ItemListResponse> renameList(UUID listId, UpdateItemListRequest req) {
+  public MutationResponse<ItemListResponse> renameList(
+      UUID listId, UpdateItemListRequest req, long expectedVersion) {
     ItemList list =
         itemListRepo
             .findById(listId)
             .orElseThrow(
                 () -> new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "リスト")));
+    ResourceVersionValidator.requireCurrentVersion(
+        "list", list.getId(), expectedVersion, list.getVersion());
 
     list.setName(req.getName().trim());
 

--- a/backend/src/main/java/com/atoook/otsukailist/service/MemberCommandService.java
+++ b/backend/src/main/java/com/atoook/otsukailist/service/MemberCommandService.java
@@ -16,6 +16,7 @@ import com.atoook.otsukailist.model.Member;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
 import com.atoook.otsukailist.service.message.ErrorMessages;
+import com.atoook.otsukailist.service.validation.ResourceVersionValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -68,18 +69,20 @@ public class MemberCommandService {
    */
   @Transactional
   public MutationResponse<MemberResponse> renameMember(
-      UUID listId, UUID memberId, CreateMemberRequest req) {
+      UUID listId, UUID memberId, CreateMemberRequest req, long expectedVersion) {
     Member member =
         memberRepo
             .findByIdAndItemListId(memberId, listId)
             .orElseThrow(
                 () ->
                     new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "メンバー")));
+    ResourceVersionValidator.requireCurrentVersion(
+        "member", member.getId(), expectedVersion, member.getVersion());
 
     // Mapperでtrim含めて更新する想定
     MemberMapper.updateEntity(member, req);
 
-    Member saved = memberRepo.save(member);
+    Member saved = memberRepo.saveAndFlush(member);
 
     long revision = incrementAndGetRevision(listId);
 
@@ -97,15 +100,19 @@ public class MemberCommandService {
    * @return deletion response with the new revision number
    */
   @Transactional
-  public MutationResponse<DeleteMemberResponse> deleteMember(UUID listId, UUID memberId) {
+  public MutationResponse<DeleteMemberResponse> deleteMember(
+      UUID listId, UUID memberId, long expectedVersion) {
     Member member =
         memberRepo
             .findByIdAndItemListId(memberId, listId)
             .orElseThrow(
                 () ->
                     new ResourceNotFoundException(String.format(ErrorMessages.NOT_FOUND, "メンバー")));
+    ResourceVersionValidator.requireCurrentVersion(
+        "member", member.getId(), expectedVersion, member.getVersion());
 
     memberRepo.delete(member);
+    memberRepo.flush();
     // DB側 FK: item.assigned_member_id / completed_by_member_id ON DELETE SET NULL が効く
 
     long revision = incrementAndGetRevision(listId);

--- a/backend/src/test/java/com/atoook/otsukailist/service/ListCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/ListCommandServiceTest.java
@@ -1,12 +1,22 @@
 package com.atoook.otsukailist.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import com.atoook.otsukailist.config.AppMemberProperties;
 import com.atoook.otsukailist.dto.CreateItemListWithMembersRequest;
+import com.atoook.otsukailist.dto.UpdateItemListRequest;
 import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.PreconditionFailedException;
+import com.atoook.otsukailist.model.ItemList;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
 
@@ -50,5 +60,29 @@ class ListCommandServiceTest {
     assertThatThrownBy(() -> service.createListWithMembers(request))
         .isInstanceOf(BadRequestException.class)
         .hasMessage("リストに追加できるメンバーは2人までです");
+  }
+
+  @Test
+  @DisplayName("リスト名変更時にversionが一致しない場合は拒否すること")
+  void renameListRejectsWhenVersionDoesNotMatch() {
+    UUID listId = UUID.randomUUID();
+    ItemList list = itemList(listId, 4L);
+    UpdateItemListRequest request = UpdateItemListRequest.builder().name("週末の買い物").build();
+
+    when(itemListRepo.findById(listId)).thenReturn(Optional.of(list));
+
+    assertThatThrownBy(() -> service.renameList(listId, request, 3L))
+        .isInstanceOf(PreconditionFailedException.class);
+
+    verify(itemListRepo, never()).saveAndFlush(any(ItemList.class));
+    verifyNoInteractions(listRevisionService);
+  }
+
+  private static ItemList itemList(UUID listId, long version) {
+    ItemList list = new ItemList();
+    list.setId(listId);
+    list.setName("買い物");
+    list.setVersion(version);
+    return list;
   }
 }

--- a/backend/src/test/java/com/atoook/otsukailist/service/MemberCommandServiceTest.java
+++ b/backend/src/test/java/com/atoook/otsukailist/service/MemberCommandServiceTest.java
@@ -1,6 +1,9 @@
 package com.atoook.otsukailist.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -9,7 +12,9 @@ import java.util.UUID;
 import com.atoook.otsukailist.config.AppMemberProperties;
 import com.atoook.otsukailist.dto.CreateMemberRequest;
 import com.atoook.otsukailist.exception.BadRequestException;
+import com.atoook.otsukailist.exception.PreconditionFailedException;
 import com.atoook.otsukailist.model.ItemList;
+import com.atoook.otsukailist.model.Member;
 import com.atoook.otsukailist.repository.ItemListRepository;
 import com.atoook.otsukailist.repository.MemberRepository;
 
@@ -53,10 +58,54 @@ class MemberCommandServiceTest {
         .hasMessage("リストに追加できるメンバーは20人までです");
   }
 
+  @Test
+  @DisplayName("メンバー名変更時にversionが一致しない場合は拒否すること")
+  void renameMemberRejectsWhenVersionDoesNotMatch() {
+    UUID listId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Member member = member(listId, memberId, 3L);
+    CreateMemberRequest request = CreateMemberRequest.builder().displayName("変更後").build();
+
+    when(memberRepo.findByIdAndItemListId(memberId, listId)).thenReturn(Optional.of(member));
+
+    assertThatThrownBy(() -> service.renameMember(listId, memberId, request, 2L))
+        .isInstanceOf(PreconditionFailedException.class);
+
+    verify(memberRepo, never()).saveAndFlush(any(Member.class));
+    verify(itemListRepo, never()).incrementRevision(listId);
+  }
+
+  @Test
+  @DisplayName("メンバー削除時にversionが一致しない場合は拒否すること")
+  void deleteMemberRejectsWhenVersionDoesNotMatch() {
+    UUID listId = UUID.randomUUID();
+    UUID memberId = UUID.randomUUID();
+    Member member = member(listId, memberId, 3L);
+
+    when(memberRepo.findByIdAndItemListId(memberId, listId)).thenReturn(Optional.of(member));
+
+    assertThatThrownBy(() -> service.deleteMember(listId, memberId, 2L))
+        .isInstanceOf(PreconditionFailedException.class);
+
+    verify(memberRepo, never()).delete(any(Member.class));
+    verify(memberRepo, never()).flush();
+    verify(itemListRepo, never()).incrementRevision(listId);
+  }
+
   private static ItemList itemList(UUID listId) {
     ItemList list = new ItemList();
     list.setId(listId);
     list.setName("買い物");
     return list;
+  }
+
+  private static Member member(UUID listId, UUID memberId, long version) {
+    ItemList list = itemList(listId);
+    Member member = new Member();
+    member.setId(memberId);
+    member.setDisplayName("太郎");
+    member.setVersion(version);
+    member.setItemList(list);
+    return member;
   }
 }

--- a/frontend/src/api/list.ts
+++ b/frontend/src/api/list.ts
@@ -1,4 +1,5 @@
 import { http } from '@/lib/http';
+import { ifMatchHeaders } from '@/api/preconditions';
 import type {
   CreateItemListWithMembersResponse,
   ItemListResponse,
@@ -18,8 +19,12 @@ export async function fetchSnapshot(listId: UUID) {
   return res.data;
 }
 
-export async function renameList(listId: UUID, payload: { name: string }) {
-  const res = await http.patch<MutationResponse<ItemListResponse>>(`/lists/${listId}`, payload);
+export async function renameList(listId: UUID, payload: { name: string }, version: number) {
+  const res = await http.patch<MutationResponse<ItemListResponse>>(
+    `/lists/${listId}`,
+    payload,
+    ifMatchHeaders(version)
+  );
   return res.data;
 }
 

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,4 +1,5 @@
 import { http } from '@/lib/http';
+import { ifMatchHeaders } from '@/api/preconditions';
 import type { DeleteResponse, Member, MutationResponse, UUID } from '@/types/api';
 
 export async function createMember(listId: UUID, payload: { displayName: string }) {
@@ -6,12 +7,19 @@ export async function createMember(listId: UUID, payload: { displayName: string 
   return res.data;
 }
 
-export async function updateMember(listId: UUID, memberId: UUID, payload: { displayName: string }) {
-  const res = await http.patch<MutationResponse<Member>>(`/lists/${listId}/members/${memberId}`, payload);
+export async function updateMember(listId: UUID, memberId: UUID, payload: { displayName: string }, version: number) {
+  const res = await http.patch<MutationResponse<Member>>(
+    `/lists/${listId}/members/${memberId}`,
+    payload,
+    ifMatchHeaders(version)
+  );
   return res.data;
 }
 
-export async function deleteMember(listId: UUID, memberId: UUID) {
-  const res = await http.delete<MutationResponse<DeleteResponse>>(`/lists/${listId}/members/${memberId}`);
+export async function deleteMember(listId: UUID, memberId: UUID, version: number) {
+  const res = await http.delete<MutationResponse<DeleteResponse>>(
+    `/lists/${listId}/members/${memberId}`,
+    ifMatchHeaders(version)
+  );
   return res.data;
 }

--- a/frontend/src/pages/ListEditPage.vue
+++ b/frontend/src/pages/ListEditPage.vue
@@ -96,16 +96,18 @@ export default defineComponent({
       this.refreshMembersFromStore();
       this.refreshSelectedMember();
     },
-    async loadSnapshot(listId: string): Promise<void> {
+    async loadSnapshot(listId: string): Promise<boolean> {
       this.snapshotLoading = true;
       this.errorMessage = '';
 
       try {
         const snapshot = await fetchSnapshot(listId);
         this.listStore.applySnapshot(snapshot);
+        return true;
       } catch (err: unknown) {
         console.error('Failed to load snapshot', err);
         this.errorMessage = getErrorMessage(err) ?? 'リストの取得に失敗しました。';
+        return false;
       } finally {
         this.snapshotLoading = false;
       }
@@ -150,6 +152,7 @@ export default defineComponent({
         this.errorMessage = 'リストIDが無効です';
         return;
       }
+      const listId = this.currentListId;
 
       try {
         const member = this.listStore.members.find((candidate) => candidate.id === memberId) ?? null;
@@ -158,7 +161,7 @@ export default defineComponent({
           return;
         }
 
-        const result = await this.mutationRun(() => deleteMember(this.currentListId!, memberId, member.version));
+        const result = await this.mutationRun(() => deleteMember(listId, memberId, member.version));
         if (result.applied && result.data.deletedMemberId) {
           this.listStore.removeMember(result.data.deletedMemberId);
           this.refreshMembersFromStore();
@@ -170,9 +173,10 @@ export default defineComponent({
       } catch (err: unknown) {
         console.error('Failed to remove member', err);
         if (hasApiErrorCode(err, 'precondition_failed')) {
-          await this.loadSnapshot(this.currentListId);
-          this.applyListFromStore();
-          this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+          if (await this.loadSnapshot(listId)) {
+            this.applyListFromStore();
+            this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+          }
           return;
         }
         this.errorMessage = getErrorMessage(err) ?? 'メンバーの削除に失敗しました。';
@@ -183,6 +187,7 @@ export default defineComponent({
         this.errorMessage = 'リストIDが無効です';
         return;
       }
+      const listId = this.currentListId;
 
       const normalizedListName = normalizeText(this.listName);
       if (!normalizedListName || this.members.length === 0) {
@@ -192,25 +197,26 @@ export default defineComponent({
 
       this.listName = normalizedListName;
 
-      const shouldRename = this.listStore.listId === this.currentListId && this.listStore.name !== normalizedListName;
+      const shouldRename = this.listStore.listId === listId && this.listStore.name !== normalizedListName;
 
       if (shouldRename) {
         try {
           const result = await this.mutationRun(() =>
-            renameList(this.currentListId!, { name: normalizedListName }, this.listStore.version)
+            renameList(listId, { name: normalizedListName }, this.listStore.version)
           );
           if (!result.applied) {
             this.errorMessage = 'リスト名の更新が反映されませんでした。時間をおいて再試行してください。';
             return;
           }
           this.listStore.version = result.data.version;
-          updateListHistoryName(this.currentListId!, normalizedListName);
+          updateListHistoryName(listId, normalizedListName);
         } catch (err: unknown) {
           console.error('Failed to rename list', err);
           if (hasApiErrorCode(err, 'precondition_failed')) {
-            await this.loadSnapshot(this.currentListId);
-            this.applyListFromStore();
-            this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+            if (await this.loadSnapshot(listId)) {
+              this.applyListFromStore();
+              this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+            }
             return;
           }
           this.errorMessage = getErrorMessage(err) ?? 'リスト名の更新に失敗しました。';

--- a/frontend/src/pages/ListEditPage.vue
+++ b/frontend/src/pages/ListEditPage.vue
@@ -15,7 +15,7 @@ import { useListStore } from '@/stores/list';
 import { useMutation } from '@/composables/useMutation';
 import { createMember, deleteMember } from '@/api/member';
 import { fetchSnapshot, renameList } from '@/api/list';
-import { getErrorMessage } from '@/lib/http';
+import { getErrorMessage, hasApiErrorCode } from '@/lib/http';
 import { updateListHistoryName, getSelectedMemberId } from '@/lib/userCache';
 import { MAX_MEMBERS_PER_LIST } from '@/lib/appConstants';
 
@@ -152,7 +152,13 @@ export default defineComponent({
       }
 
       try {
-        const result = await this.mutationRun(() => deleteMember(this.currentListId!, memberId));
+        const member = this.listStore.members.find((candidate) => candidate.id === memberId) ?? null;
+        if (!member) {
+          this.errorMessage = 'メンバーが見つかりませんでした。';
+          return;
+        }
+
+        const result = await this.mutationRun(() => deleteMember(this.currentListId!, memberId, member.version));
         if (result.applied && result.data.deletedMemberId) {
           this.listStore.removeMember(result.data.deletedMemberId);
           this.refreshMembersFromStore();
@@ -163,6 +169,12 @@ export default defineComponent({
         this.errorMessage = '';
       } catch (err: unknown) {
         console.error('Failed to remove member', err);
+        if (hasApiErrorCode(err, 'precondition_failed')) {
+          await this.loadSnapshot(this.currentListId);
+          this.applyListFromStore();
+          this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+          return;
+        }
         this.errorMessage = getErrorMessage(err) ?? 'メンバーの削除に失敗しました。';
       }
     },
@@ -184,14 +196,23 @@ export default defineComponent({
 
       if (shouldRename) {
         try {
-          const result = await this.mutationRun(() => renameList(this.currentListId!, { name: normalizedListName }));
+          const result = await this.mutationRun(() =>
+            renameList(this.currentListId!, { name: normalizedListName }, this.listStore.version)
+          );
           if (!result.applied) {
             this.errorMessage = 'リスト名の更新が反映されませんでした。時間をおいて再試行してください。';
             return;
           }
+          this.listStore.version = result.data.version;
           updateListHistoryName(this.currentListId!, normalizedListName);
         } catch (err: unknown) {
           console.error('Failed to rename list', err);
+          if (hasApiErrorCode(err, 'precondition_failed')) {
+            await this.loadSnapshot(this.currentListId);
+            this.applyListFromStore();
+            this.errorMessage = '既に他のメンバーが更新しています。最新の状態を表示しました。';
+            return;
+          }
           this.errorMessage = getErrorMessage(err) ?? 'リスト名の更新に失敗しました。';
           return;
         }
@@ -199,7 +220,8 @@ export default defineComponent({
 
       this.listStore.updateListDetails({
         name: this.listName,
-        members: [...this.members]
+        members: [...this.members],
+        version: this.listStore.version
       });
       this.errorMessage = '';
       this.$router.push({

--- a/frontend/src/stores/list.ts
+++ b/frontend/src/stores/list.ts
@@ -78,7 +78,13 @@ export const useListStore = defineStore('list', {
     removeMember(memberId: UUID) {
       this.members = this.members.filter((member) => member.id !== memberId);
       this.items = this.items.map((item) =>
-        item.completedByMemberId === memberId ? { ...item, completedByMemberId: null } : item
+        item.completedByMemberId === memberId || item.assignedMemberId === memberId
+          ? {
+              ...item,
+              assignedMemberId: item.assignedMemberId === memberId ? null : item.assignedMemberId,
+              completedByMemberId: item.completedByMemberId === memberId ? null : item.completedByMemberId
+            }
+          : item
       );
     },
 


### PR DESCRIPTION
## Summary

- Require If-Match for member rename/delete and list rename.
- Validate member/list resource versions before applying metadata changes.
- Refresh the client snapshot when metadata mutations are rejected as stale.
- Keep member add count-limit serialization on the item_list row lock.

## Scope

This PR is stacked on #97 and extends optimistic concurrency from item operations to member/list metadata mutations.

## Validation

- `./gradlew check`
- `npm run build`
- `npm run test:run`
- `git diff --check`